### PR TITLE
Tree verbosity

### DIFF
--- a/base/config.py
+++ b/base/config.py
@@ -57,6 +57,7 @@ process = {
     "estimate_mutation_frequencies": False,
     "estimate_tree_frequencies": False,
     "titers": False,
+    "tree_verbosity_level": 0,
     "newick_tree_options": {},
     "timetree_options": {
         "Tc": 0.02,

--- a/base/config.py
+++ b/base/config.py
@@ -57,7 +57,7 @@ process = {
     "estimate_mutation_frequencies": False,
     "estimate_tree_frequencies": False,
     "titers": False,
-    "tree_verbosity_level": 0,
+    "subprocess_verbosity_level": 0,
     "newick_tree_options": {},
     "timetree_options": {
         "Tc": 0.02,

--- a/base/process.py
+++ b/base/process.py
@@ -369,8 +369,7 @@ class process(object):
         (2) If newick file doesn't exist or isn't valid: build a newick tree (normally RAxML)
         (3) Make a TimeTree
         '''
-        # self.log.warn("self.verbose not set")
-        self.tree = tree(aln=self.seqs.aln, proteins=self.proteins, verbose=0)
+        self.tree = tree(aln=self.seqs.aln, proteins=self.proteins, verbose=self.config["tree_verbosity_level"])
         newick_file = self.output_path + ".newick"
         try:
             assert(self.try_to_restore == True)
@@ -378,6 +377,7 @@ class process(object):
             self.tree.check_newick(newick_file)
             self.log.notify("Newick file restored from \"{}\"".format(newick_file))
         except AssertionError:
+            self.log.notify("Building newick tree.")
             self.tree.build_newick(newick_file, **self.config["newick_tree_options"])
 
 

--- a/base/process.py
+++ b/base/process.py
@@ -149,7 +149,7 @@ class process(object):
         if self.try_to_restore:
             self.seqs.try_restore_align_from_disk(fname)
         if not hasattr(self.seqs, "aln"):
-            self.seqs.align(fname, debug=debug)
+            self.seqs.align(fname, self.config["subprocess_verbosity_level"], debug=debug)
             # need to redo everything
             self.try_to_restore = False
 
@@ -369,7 +369,7 @@ class process(object):
         (2) If newick file doesn't exist or isn't valid: build a newick tree (normally RAxML)
         (3) Make a TimeTree
         '''
-        self.tree = tree(aln=self.seqs.aln, proteins=self.proteins, verbose=self.config["tree_verbosity_level"])
+        self.tree = tree(aln=self.seqs.aln, proteins=self.proteins, verbose=self.config["subprocess_verbosity_level"])
         newick_file = self.output_path + ".newick"
         try:
             assert(self.try_to_restore == True)

--- a/base/sequences_process.py
+++ b/base/sequences_process.py
@@ -73,7 +73,7 @@ class sequence_set(object):
     def codon_align(self):
         self.log.fatal("Codon align not yet implemented")
 
-    def align(self, fname, debug=False):
+    def align(self, fname, verbose, debug=False):
         '''
         align sequences using mafft
 
@@ -93,7 +93,10 @@ class sequence_set(object):
 
         SeqIO.write(out_seqs, "temp_in.fasta", "fasta")
         self.log.notify("Running alignment")
-        os.system("mafft --anysymbol --thread " + str(self.nthreads) + " temp_in.fasta 1> temp_out.fasta 2>mafft_stderr")
+        if verbose == 0:
+            os.system("mafft --anysymbol --thread " + str(self.nthreads) + " temp_in.fasta 1> temp_out.fasta 2>mafft_stderr")
+        else:
+            os.system("mafft --anysymbol --thread " + str(self.nthreads) + " temp_in.fasta 1> temp_out.fasta")
         self.aln = AlignIO.read('temp_out.fasta', 'fasta')
         os.chdir("..")
         os.rename(os.path.join(self.run_dir, "temp_out.fasta"), fname)

--- a/base/tree.py
+++ b/base/tree.py
@@ -56,7 +56,7 @@ class tree(object):
             self.run_dir = kwarks['run_dir']
         if logger is None:
             def f(x,y):
-                if y>self.verbose: print(x)
+                if y<self.verbose: print(x)
             self.logger = f
         else:
             self.logger=logger

--- a/docs/phylogenies.md
+++ b/docs/phylogenies.md
@@ -2,6 +2,8 @@
 
 Building the tree is a 2 step process: A newick file is created (e.g. with RAxML) and then this is converted into a TimeTree.
 
+* `tree_verbosity_level` {int} (default `0`). Control the amount of information displayed. Higher numbers -> more output.
+
 ### step 1: initial phylogeny
 This is normally created via RAxML however FastTree may also be used. A number of options are available however for the most part the defaults are fine.
 All the keyword arguments in the `build_newick` method of the `Tree` class may be set via the `newick_tree_options` config dictionary. The most common ones are:

--- a/docs/phylogenies.md
+++ b/docs/phylogenies.md
@@ -2,8 +2,6 @@
 
 Building the tree is a 2 step process: A newick file is created (e.g. with RAxML) and then this is converted into a TimeTree.
 
-* `tree_verbosity_level` {int} (default `0`). Control the amount of information displayed. Higher numbers -> more output.
-
 ### step 1: initial phylogeny
 This is normally created via RAxML however FastTree may also be used. A number of options are available however for the most part the defaults are fine.
 All the keyword arguments in the `build_newick` method of the `Tree` class may be set via the `newick_tree_options` config dictionary. The most common ones are:

--- a/docs/process.md
+++ b/docs/process.md
@@ -28,6 +28,8 @@ While _process_ can be computationally expensive, as long as the underlying _pre
   * `auspice`: the finished JSONs for display in auspice
 * `in` {string}: The prepared JSON file. Sometimes defined by command line arguments
 * `clean` {bool} (default `False`) Run a clean build by removing any (previously created) files
+* `subprocess_verbosity_level` {int} (default `0`). Control the amount of information displayed during alignment and tree building. Higher numbers -> more output.
+
 
 ##### Analysis settings
 * `geo_inference` {`False` || array of strings} (Default: `False`) what traits to perform geographic inference (mugration model) upon


### PR DESCRIPTION
Tree verbosity (a bit of RAxML, mainly TreeTime) now set via a config parameter in `process`.
The default is `0` (very little output).

Config parameter `"tree_verbosity_level"`. Default: `0`.

Note that the logging function in the Tree class has changed from `if y>self.verbose: print(x)` to `if y<self.verbose: print(x)` to mirror TreeTime. 