### PR TITLE
Write out stripped alignment

### DIFF
--- a/base/process.py
+++ b/base/process.py
@@ -13,6 +13,7 @@ import json
 from pdb import set_trace
 from base.logger import logger
 from Bio import SeqIO
+from Bio import AlignIO
 import cPickle as pickle
 
 class process(object):
@@ -167,6 +168,7 @@ class process(object):
         self.seqs.strip_non_reference()
         if fill_gaps:
             self.seqs.make_gaps_ambiguous()
+        AlignIO.write(self.seqs.aln, self.output_path + "_aligned_stripped.mfa", 'fasta')
         # if outgroup is not None:
         #     self.seqs.clock_filter(n_iqd=3, plot=False, max_gaps=0.05, root_seq=outgroup)
         self.seqs.translate() # creates self.seqs.translations

--- a/base/process.py
+++ b/base/process.py
@@ -154,7 +154,7 @@ class process(object):
         (3) Write to multi-fasta
         CODON ALIGNMENT IS NOT IMPLEMENTED
         '''
-        fname = self.output_path + "_aligned.mfa"
+        fname = self.output_path + "_aligned_stripped.mfa"
         if self.try_to_restore:
             self.seqs.try_restore_align_from_disk(fname)
         if not hasattr(self.seqs, "aln"):
@@ -168,9 +168,14 @@ class process(object):
         self.seqs.strip_non_reference()
         if fill_gaps:
             self.seqs.make_gaps_ambiguous()
-        AlignIO.write(self.seqs.aln, self.output_path + "_aligned_stripped.mfa", 'fasta')
+
+        if not self.seqs.reference_in_dataset:
+            self.seqs.remove_reference_from_alignment()
         # if outgroup is not None:
         #     self.seqs.clock_filter(n_iqd=3, plot=False, max_gaps=0.05, root_seq=outgroup)
+
+        #overwrite direct mafft output (gappy alignment) with stripped alignment
+        AlignIO.write(self.seqs.aln, self.output_path + "_aligned_stripped.mfa", 'fasta')
         self.seqs.translate() # creates self.seqs.translations
         # save additional translations - disabled for now
         # for name, msa in self.seqs.translations.iteritems():

--- a/base/process.py
+++ b/base/process.py
@@ -154,28 +154,28 @@ class process(object):
         (3) Write to multi-fasta
         CODON ALIGNMENT IS NOT IMPLEMENTED
         '''
-        fname = self.output_path + "_aligned_stripped.mfa"
+        fnameStripped = self.output_path + "_aligned_stripped.mfa"
         if self.try_to_restore:
-            self.seqs.try_restore_align_from_disk(fname)
+            self.seqs.try_restore_align_from_disk(fnameStripped)
         if not hasattr(self.seqs, "aln"):
             if codon_align:
                 self.seqs.codon_align()
             else:
-                self.seqs.align(fname, self.config["subprocess_verbosity_level"], debug=debug)
+                self.seqs.align(self.config["subprocess_verbosity_level"], debug=debug)
             # need to redo everything
             self.try_to_restore = False
 
-        self.seqs.strip_non_reference()
-        if fill_gaps:
-            self.seqs.make_gaps_ambiguous()
+            self.seqs.strip_non_reference()
+            if fill_gaps:
+                self.seqs.make_gaps_ambiguous()
 
-        if not self.seqs.reference_in_dataset:
-            self.seqs.remove_reference_from_alignment()
-        # if outgroup is not None:
-        #     self.seqs.clock_filter(n_iqd=3, plot=False, max_gaps=0.05, root_seq=outgroup)
+            if not self.seqs.reference_in_dataset:
+                self.seqs.remove_reference_from_alignment()
+            # if outgroup is not None:
+            #     self.seqs.clock_filter(n_iqd=3, plot=False, max_gaps=0.05, root_seq=outgroup)
 
-        #overwrite direct mafft output (gappy alignment) with stripped alignment
-        AlignIO.write(self.seqs.aln, self.output_path + "_aligned_stripped.mfa", 'fasta')
+            AlignIO.write(self.seqs.aln, fnameStripped, 'fasta')
+
         self.seqs.translate() # creates self.seqs.translations
         # save additional translations - disabled for now
         # for name, msa in self.seqs.translations.iteritems():

--- a/base/sequences_process.py
+++ b/base/sequences_process.py
@@ -102,9 +102,8 @@ class sequence_set(object):
         os.rename(os.path.join(self.run_dir, "temp_out.fasta"), fname)
         if not debug: remove_dir(self.run_dir)
 
-        self.set_reference_alignment()
-        if not self.reference_in_dataset:
-            self.remove_reference_from_alignment()
+        self.set_reference_alignment() #make reference_aln object while reference still in alignment
+
         self.set_sequence_lookup()
         self.add_attributes_to_aln()
 

--- a/base/sequences_process.py
+++ b/base/sequences_process.py
@@ -73,7 +73,7 @@ class sequence_set(object):
     def codon_align(self):
         self.log.fatal("Codon align not yet implemented")
 
-    def align(self, fname, verbose, debug=False):
+    def align(self, verbose, debug=False):
         '''
         align sequences using mafft
 
@@ -99,11 +99,9 @@ class sequence_set(object):
             os.system("mafft --anysymbol --thread " + str(self.nthreads) + " temp_in.fasta 1> temp_out.fasta")
         self.aln = AlignIO.read('temp_out.fasta', 'fasta')
         os.chdir("..")
-        os.rename(os.path.join(self.run_dir, "temp_out.fasta"), fname)
         if not debug: remove_dir(self.run_dir)
 
         self.set_reference_alignment() #make reference_aln object while reference still in alignment
-
         self.set_sequence_lookup()
         self.add_attributes_to_aln()
 


### PR DESCRIPTION
Resolves #41 

This writes out an alignment FASTA after stripping to reference and names it `_aligned_stripped.mfa`.

@jameshadfield: I'm not sure I entirely agree with keeping both an `_aligned.mfa` and an `_aligned_stripped.mfa` around. Especially as `_aligned.mfa` gets immediately stripped to reference after importing. Seems like it would be cleaner to have a single exported alignment and use the one after stripping and `make_gaps_ambiguous`. _Export exactly what goes into the tree inference procedure._ What do you think?

cc @alliblk 

