### PR TITLE
Remove default file prefix for prepared flu files

### DIFF
--- a/flu/flu.prepare.py
+++ b/flu/flu.prepare.py
@@ -34,8 +34,7 @@ def collect_args():
     parser.add_argument('--titers', help="tab-delimited file of titer strains and values from fauna (e.g., h3n2_hi_titers.tsv)")
 
     parser.set_defaults(
-        viruses_per_month=0,
-        file_prefix="flu"
+        viruses_per_month=0
     )
 
     return parser


### PR DESCRIPTION
This PR corrects unexpected behavior by the flu.prepare.py script when no `file_prefix` is given by the user. Output files should include the lineage by default (e.g., `flu_h3n2_ha_3y.json`).