### PR TITLE
cleaner syntax for methods in Process class

### DIFF
--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -5,6 +5,11 @@ import json
 from pdb import set_trace
 from collections import defaultdict
 
+"""
+These functions are used as methods on the Process class
+They are defined here simply for readability.
+"""
+
 def export_frequency_json(self, prefix, indent):
 
     # local function or round frequency estimates to useful precision (reduces file size)
@@ -40,25 +45,26 @@ def export_frequency_json(self, prefix, indent):
         self.log.notify("Cannot export frequencies - pivots do not exist")
 
 
-def summarise_publications_from_tree(tree):
-    info = defaultdict(lambda: {"n": 0, "title": "?"})
-    mapping = {}
-    for clade in tree.find_clades():
-        if not clade.is_terminal():
-            continue
-        if "authors" not in clade.attr:
-            mapping[clade.name] = None
-            print("Error - {} had no authors".format(clade.name))
-            continue
-        authors = clade.attr["authors"]
-        mapping[clade.name] = authors
-        info[authors]["n"] += 1
-        for attr in ["title", "journal", "paper_url"]:
-            if attr in clade.attr:
-                info[authors][attr] = clade.attr[attr]
-    return (info, mapping)
-
 def export_metadata_json(self, prefix, indent):
+
+    def summarise_publications_from_tree(tree):
+        info = defaultdict(lambda: {"n": 0, "title": "?"})
+        mapping = {}
+        for clade in tree.find_clades():
+            if not clade.is_terminal():
+                continue
+            if "authors" not in clade.attr:
+                mapping[clade.name] = None
+                print("Error - {} had no authors".format(clade.name))
+                continue
+            authors = clade.attr["authors"]
+            mapping[clade.name] = authors
+            info[authors]["n"] += 1
+            for attr in ["title", "journal", "paper_url"]:
+                if attr in clade.attr:
+                    info[authors][attr] = clade.attr[attr]
+        return (info, mapping)
+
     self.log.notify("Writing out metadata")
     meta_json = {}
 

--- a/base/process.py
+++ b/base/process.py
@@ -118,9 +118,11 @@ class process(object):
         ## usefull flag to set (from pathogen run file) to disable restoring
         self.try_to_restore = True
 
-        ## load in additional methods defined in helper files
-        self.export_frequency_json = export_frequency_json
-        self.export_metadata_json = export_metadata_json
+    '''
+    load in additional methods defined in helper files
+    '''
+    export_frequency_json = export_frequency_json
+    export_metadata_json = export_metadata_json
 
     def dump(self):
         '''
@@ -565,10 +567,10 @@ class process(object):
                          + ["muts", "aa_muts","attr", "clade"], indent = indent)
 
         ## FREQUENCIES ##
-        self.export_frequency_json(self, prefix=prefix, indent=indent)
+        self.export_frequency_json(prefix=prefix, indent=indent)
 
         ## METADATA ##
-        self.export_metadata_json(self, prefix=prefix, indent=indent)
+        self.export_metadata_json(prefix=prefix, indent=indent)
 
     def run_geo_inference(self):
         if self.config["geo_inference"] == False:


### PR DESCRIPTION
This PR improves the way in which methods on the `Process` class are defined and called when the methods themselves live in a separate file. They are now called in the same way as methods defined the traditional way. 