### PR TITLE
Fix restore for multiple sequence alignment

### DIFF
--- a/base/process.py
+++ b/base/process.py
@@ -190,12 +190,12 @@ class process(object):
             if fill_gaps:
                 self.seqs.make_gaps_ambiguous()
 
+            AlignIO.write(self.seqs.aln, fnameStripped, 'fasta')
+
             if not self.seqs.reference_in_dataset:
                 self.seqs.remove_reference_from_alignment()
             # if outgroup is not None:
             #     self.seqs.clock_filter(n_iqd=3, plot=False, max_gaps=0.05, root_seq=outgroup)
-
-            AlignIO.write(self.seqs.aln, fnameStripped, 'fasta')
 
         self.seqs.translate() # creates self.seqs.translations
         # save additional translations - disabled for now


### PR DESCRIPTION
Fix the restore of the multiple sequence alignment by removing the reference from the MSA after writing the alignment to disk.

Based on [the docstring for the align method](https://github.com/nextstrain/augur/blob/951aa67da9286484612a4ad8f947a490442d49b5/base/sequences_process.py#L84), the reference is always expected to be included in the MSA. If that's not still the case, we could just remove the reference requirement from the restore method.