### PR TITLE
Switch from appending identifier to overwriting file_prefix

### DIFF
--- a/base/prepare.py
+++ b/base/prepare.py
@@ -215,10 +215,6 @@ class prepare(object):
     def write_to_json(self):
         for seg, obj in self.segments.iteritems():
             prefix = self.config["file_prefix"]
-            if seg != "genome" and seg not in prefix:
-                prefix = prefix + "_" + seg
-            if "identifier" in self.config and self.config['identifier']:
-                prefix = prefix + "_" + self.config["identifier"]
             fname = os.path.join(self.config["output_folder"], prefix + ".json")
             with open(fname, 'w') as fh:
                 obj.write_json(fh, self.config, prefix)

--- a/flu/run_flu.py
+++ b/flu/run_flu.py
@@ -10,11 +10,10 @@ for lineage in ['h3n2', 'h1n1pdm', 'vic', 'yam']:
 					continue
 
 				call = ['python', 'flu.prepare.py', '-r', resolution,  '-l', lineage, '--titers', '../../fauna/data/%s_cdc_%s_%s_titers.tsv'%(lineage, titer, passage),
-					'--sequences', '../../fauna/data/%s.fasta'%lineage, '--identifier', '%s_%s'%(passage, titer), '--complete_frequencies']
+					'--sequences', '../../fauna/data/%s.fasta'%lineage, '--file_prefix', 'flu_%s_ha_%s_%s_%s'%(lineage, resolution, passage, titer), '--complete_frequencies']
 
 				os.system(' '.join(call))
 				call = ['qsub', 'submit_script.sh', 'flu.process.py', '-j', 'prepared/flu_%s_ha_%s_%s_%s.json'%(lineage, resolution, passage, titer)]
 
 				os.system(' '.join(call))
 				print(' '.join(call))
-


### PR DESCRIPTION
This PR moves seasonal flu to follow other augur builds in specifying custom file names via `file_prefix` rather than appending an `identifier`. With this is place, if you call `flu.prepare.py` and don't provide `--file_prefix` you'll get one constructed from lineage + segment + resolution, ala `flu_h3n2_ha_3y`. If you do provide `--file_prefix` this overwrites rather than appending making it clear what you are going to get.