### PR TITLE
Added script to extract FASTA sequences from prepared JSON

### DIFF
--- a/scripts/prepared_json_to_fasta.py
+++ b/scripts/prepared_json_to_fasta.py
@@ -13,9 +13,8 @@ from base.sequences_process import sequence_set
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Convert a prepared JSON file from augur into a FASTA file.")
     parser.add_argument("json", help="prepared JSON from augur")
-    parser.add_argument("fasta", help="FASTA output for sequences in JSON file")
 
     args = parser.parse_args()
 
@@ -39,5 +38,5 @@ if __name__ == "__main__":
     if not sequences.reference_in_dataset:
         output_sequences.append(sequences.reference_seq)
 
-    # Write sequences to disk.
-    Bio.SeqIO.write(output_sequences, args.fasta, "fasta")
+    # Write sequences to standard out.
+    Bio.SeqIO.write(output_sequences, sys.stdout, "fasta")

--- a/scripts/prepared_json_to_fasta.py
+++ b/scripts/prepared_json_to_fasta.py
@@ -1,0 +1,43 @@
+"""
+Convert a prepared JSON file from augur into a FASTA file.
+"""
+import argparse
+import Bio
+import json
+import logging
+import sys
+
+sys.path.append('..')
+
+from base.sequences_process import sequence_set
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("json", help="prepared JSON from augur")
+    parser.add_argument("fasta", help="FASTA output for sequences in JSON file")
+
+    args = parser.parse_args()
+
+    # Setup the logger.
+    logger = logging.getLogger(__name__)
+
+    # Load the JSON data.
+    with open(args.json, "r") as fh:
+        data = json.load(fh)
+
+    # Prepare a sequence set.
+    sequences = sequence_set(
+        logger,
+        data["sequences"],
+        data["reference"],
+        data["info"]["date_format"]
+    )
+
+    # Add the reference to output sequences if it isn't already included.
+    output_sequences = sequences.seqs.values()
+    if not sequences.reference_in_dataset:
+        output_sequences.append(sequences.reference_seq)
+
+    # Write sequences to disk.
+    Bio.SeqIO.write(output_sequences, args.fasta, "fasta")


### PR DESCRIPTION
This might be more useful in sacra, but for now this provides an easy way to get from prepared JSON to FASTA for debugging or additional analyses that require the original sequence set (e.g., running your own multiple sequence alignment).