### PR TITLE
Minor improvements to fitness model configuration

### DIFF
--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -16,6 +16,35 @@ pc=1e-2
 regularization = 1e-3
 default_predictors = ['lb', 'ep', 'ne_star']
 
+
+def process_predictor_args(predictors, params=None, sds=None):
+    """Returns a predictor data structure for the given lists of predictors, params,
+    and standard deviations.
+
+    When no parameters or deviations are provided, the predictors are a simple
+    list. When parameters and deviations are provided, the predictor are a
+    dictionary indexed by predictor name with values corresponding to each
+    predictor's param and global standard deviation.
+
+    >>> process_predictor_args(None, None, None)
+    >>> process_predictor_args(['ep'])
+    ['ep']
+    >>> process_predictor_args(['ep'], None, None)
+    ['ep']
+    >>> process_predictor_args(['ep'], [1], [5])
+    {'ep': [1, 5]}
+    """
+    if predictors is None:
+        processed_predictors = None
+    elif params is None or sds is None:
+        processed_predictors = predictors
+    else:
+        merged_params = map(list, zip(params, sds))
+        processed_predictors = dict(zip(predictors, merged_params))
+
+    return processed_predictors
+
+
 def make_pivots(start, stop, pivots_per_year=12, precision=2):
     """Makes an array of pivots (i.e., timepoints) between the given start and stop
     by the given pivots per year. The generated pivots are floating point values

--- a/base/process.py
+++ b/base/process.py
@@ -606,12 +606,11 @@ class process(object):
         if "predictors" in self.config:
             kwargs["predictor_input"] = self.config["predictors"]
 
-        if "titers" in self.config:
-            if "epitope_mask" in self.config["titers"]:
-                kwargs["epitope_masks_fname"] = self.config["titers"]["epitope_mask"]
+        if "epitope_mask" in self.config:
+            kwargs["epitope_masks_fname"] = self.config["epitope_mask"]
 
-            if "epitope_mask_version" in self.config["titers"]:
-                kwargs["epitope_mask_version"] = self.config["titers"]["epitope_mask_version"]
+        if "epitope_mask_version" in self.config:
+            kwargs["epitope_mask_version"] = self.config["epitope_mask_version"]
 
         if self.config["subprocess_verbosity_level"] > 0:
             kwargs["verbose"] = 1

--- a/docs/process.md
+++ b/docs/process.md
@@ -44,7 +44,7 @@ While _process_ can be computationally expensive, as long as the underlying _pre
 * `timetree_options` {dict} See [Phylogenies](./phylogenies.md)
 * `epitope_mask` {string} a tab-delimited file containing epitope mask names in the first column and a bitmask of sites in the protein coding sequence of a virus segment associated with epitopes
 * `epitope_mask_version` {string} the name of an epitope mask defined in the `epitope_mask` file to use for analyses
-* `predictors` {array of strings} a list of attributes annotated to each tree node to use for the fitness model (e.g., `"['ep']"` or `"['cTiter', 'ep']"`)
+* `predictors` {array of strings or dict} a list of attributes annotated to each tree node to use for the fitness model (e.g., `"['ep']"` or `"['cTiter', 'ep']"`) or a dictionary of predictors and their corresponding precalculated model parameters and global standard deviations (e.g., `{'ep': [0.33, 1.31]}`)
 
 ##### Auspice output settings
 * `auspice`

--- a/docs/process.md
+++ b/docs/process.md
@@ -42,6 +42,9 @@ While _process_ can be computationally expensive, as long as the underlying _pre
 * `newick_tree_options` {dict} (default: `{}`) See [Phylogenies](./phylogenies.md)
 * `clock_filter` {`False` | dict} See [Phylogenies](./phylogenies.md)
 * `timetree_options` {dict} See [Phylogenies](./phylogenies.md)
+* `epitope_mask` {string} a tab-delimited file containing epitope mask names in the first column and a bitmask of sites in the protein coding sequence of a virus segment associated with epitopes
+* `epitope_mask_version` {string} the name of an epitope mask defined in the `epitope_mask` file to use for analyses
+* `predictors` {array of strings} a list of attributes annotated to each tree node to use for the fitness model (e.g., `"['ep']"` or `"['cTiter', 'ep']"`)
 
 ##### Auspice output settings
 * `auspice`

--- a/flu/flu.process.py
+++ b/flu/flu.process.py
@@ -185,7 +185,11 @@ if __name__=="__main__":
 
         # Predict fitness.
         if runner.config["annotate_fitness"]:
-            runner.fitness_model = runner.annotate_fitness()
+            fitness_model = runner.annotate_fitness()
+            print("Fitness model parameters: %s" % str(zip(fitness_model.predictors, fitness_model.model_params)))
+            print("Fitness model deviations: %s" % str(zip(fitness_model.predictors, fitness_model.global_sds)))
+            print("Abs clade error: %s" % fitness_model.clade_fit(fitness_model.model_params))
+            runner.fitness_model = fitness_model
 
         if not os.path.exists("processed/recurring_mutations/"):
             os.makedirs("processed/recurring_mutations/")

--- a/flu/flu.process.py
+++ b/flu/flu.process.py
@@ -48,8 +48,6 @@ def make_config (prepared_json, args):
         },
         "titers": {
             "criterium": lambda x: len(x.aa_mutations['HA1']+x.aa_mutations['HA2'])>0,
-            "epitope_mask": "metadata/h3n2_epitope_masks.tsv",
-            "epitope_mask_version": args.epitope_mask_version,
             "lam_avi":2.0,
             "lam_pot":0.3,
             "lam_drop":2.0
@@ -57,6 +55,8 @@ def make_config (prepared_json, args):
         "build_tree": not args.no_tree,
         "estimate_mutation_frequencies": not args.no_mut_freqs,
         "estimate_tree_frequencies": not args.no_tree_freqs,
+        "epitope_mask": "metadata/h3n2_epitope_masks.tsv",
+        "epitope_mask_version": args.epitope_mask_version,
         "annotate_fitness": args.annotate_fitness,
         "predictors": args.predictors,
         "clean": args.clean,
@@ -167,7 +167,7 @@ if __name__=="__main__":
         if hasattr(runner, "titers"):
             HI_model(runner)
             if runner.info["lineage"] == "h3n2":
-                H3N2_scores(runner, runner.tree.tree, runner.config["titers"]["epitope_mask"])
+                H3N2_scores(runner, runner.tree.tree, runner.config["epitope_mask"])
             if runner.config["auspice"]["titers_export"]:
                 HI_export(runner)
 

--- a/flu/flu.process.py
+++ b/flu/flu.process.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import os, sys, glob
 sys.path.append('..') # we assume (and assert) that this script is running from the virus directory, i.e. inside H7N9 or zika
 import base.process
+from base.fitness_model import process_predictor_args
 from base.process import process
 from base.utils import fix_names
 from flu_titers import HI_model, HI_export, H3N2_scores
@@ -24,6 +25,8 @@ def parse_args():
     parser.add_argument('--titers_export', default=False, action='store_true', help="export titers.json file")
     parser.add_argument('--annotate_fitness', default=False, action='store_true', help="run fitness prediction model and annotate fitnesses on tree nodes")
     parser.add_argument('--predictors', default=['cTiter'], nargs='+', help="attributes to use as fitness model predictors")
+    parser.add_argument('--predictors_params', type=float, nargs='+', help="precalculated fitness model parameters for each of the given predictors")
+    parser.add_argument('--predictors_sds', type=float, nargs='+', help="precalculated global standard deviations for each of the given predictors")
     parser.add_argument('--epitope_mask_version', default="wolf", help="name of the epitope mask that defines epitope mutations")
 
     parser.set_defaults(
@@ -33,6 +36,13 @@ def parse_args():
     return parser.parse_args()
 
 def make_config (prepared_json, args):
+    # Create a fitness model parameters data structure for the given arguments.
+    predictors = process_predictor_args(
+        args.predictors,
+        args.predictors_params,
+        args.predictors_sds
+    )
+
     return {
         "dir": "flu",
         "in": prepared_json,
@@ -58,7 +68,7 @@ def make_config (prepared_json, args):
         "epitope_mask": "metadata/h3n2_epitope_masks.tsv",
         "epitope_mask_version": args.epitope_mask_version,
         "annotate_fitness": args.annotate_fitness,
-        "predictors": args.predictors,
+        "predictors": predictors,
         "clean": args.clean,
         "pivot_spacing": args.pivot_spacing/12.0,
         "timetree_options": {


### PR DESCRIPTION
 * Reorganize process config options for epitope masks
 * Report calculated fitness model parameters from flu.process.py to standard out
 * Add support for defining existing fitness model parameters (skipping parameter learning)
