### PR TITLE
Document tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,13 @@ test_input/
 test_output/
 scratch/
 
+# For Python #
+##############
+*.pyc
+.tox/
+.cache/
+augur.egg-info/
+
 # Compiled source #
 ###################
 *.com
@@ -22,7 +29,6 @@ scratch/
 *.exe
 *.o
 *.so
-*.pyc
 
 # OS generated files #
 ######################

--- a/base/sequences_process.py
+++ b/base/sequences_process.py
@@ -1,6 +1,5 @@
 from __future__ import division, print_function
 import os, re, time, csv, sys
-import warnings
 from io_util import make_dir, remove_dir, write_json
 # from io_util import myopen, make_dir, remove_dir, tree_to_json, write_json
 # from collections import defaultdict
@@ -51,11 +50,8 @@ def safe_translate(sequence):
     """
     try:
         # Attempt translation by extracting the sequence according to the
-        # BioPython SeqFeature. In frame gaps of three will translate as
-        # '-'. Ignore BioPython warnings about codon lengths.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            translated_sequence = str(Seq(sequence).translate(gap='-'))
+        # BioPhython SeqFeature in frame gaps of three will translate as '-'
+        translated_sequence = str(Seq(sequence).translate(gap='-'))
     except TranslationError:
         # Any other codon like '-AA' or 'NNT' etc will fail. Translate codons
         # one by one.

--- a/base/sequences_process.py
+++ b/base/sequences_process.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function
 import os, re, time, csv, sys
+import warnings
 from io_util import make_dir, remove_dir, write_json
 # from io_util import myopen, make_dir, remove_dir, tree_to_json, write_json
 # from collections import defaultdict
@@ -50,8 +51,11 @@ def safe_translate(sequence):
     """
     try:
         # Attempt translation by extracting the sequence according to the
-        # BioPhython SeqFeature in frame gaps of three will translate as '-'
-        translated_sequence = str(Seq(sequence).translate(gap='-'))
+        # BioPython SeqFeature. In frame gaps of three will translate as
+        # '-'. Ignore BioPython warnings about codon lengths.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            translated_sequence = str(Seq(sequence).translate(gap='-'))
     except TranslationError:
         # Any other codon like '-AA' or 'NNT' etc will fail. Translate codons
         # one by one.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,35 @@
 * [Prepare](prepare.md)
 * [Process](process.md)
 * [Format of (auspice) output JSONs](auspice_output.md)
+
+## Tests
+
+Install [pytest](https://docs.pytest.org/en/latest/).
+
+```bash
+# Install with pip.
+pip install pytest
+
+# Or install with conda.
+conda install pytest
+```
+
+Checkout augur and temporarily install it as a package.
+
+```bash
+git clone --recursive https://github.com/nextstrain/augur
+cd augur
+pip install -e .
+```
+
+Run tests.
+
+```bash
+pytest
+```
+
+Uninstall the augur package.
+
+```bash
+pip uninstall augur
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,32 +9,34 @@
 
 ## Tests
 
-Install [pytest](https://docs.pytest.org/en/latest/).
+Tests run using [tox](http://tox.readthedocs.io/en/latest/)
+and [pytest](https://docs.pytest.org/en/latest/). If you didn't install augur
+with the pip `requirements.txt` or with
+the
+[janus conda environment](https://github.com/nextstrain/janus/#installation),
+install them as follows.
 
 ```bash
 # Install with pip.
-pip install pytest
+pip install pytest tox
 
-# Or install with conda.
-conda install pytest
+# Or install inside a conda environment.
+conda install pytest virtualenv
+pip install tox
 ```
 
-Checkout augur and temporarily install it as a package.
+Run tests from the augur root directory.
 
 ```bash
-git clone --recursive https://github.com/nextstrain/augur
-cd augur
-pip install -e .
+tox
 ```
 
-Run tests.
+Tox builds an empty virtual environment, installs augur's requirements and a
+package of augur built from the local directory, and runs tests with pytest. The
+`tox.ini` file defines the test environment and the `pytest.ini` file defines
+which tests to run. Tox reuses the virtual environment with subsequent runs. Use
+the `-r` flag to force it to rebuild its environment.
 
 ```bash
-pytest
-```
-
-Uninstall the augur package.
-
-```bash
-pip uninstall augur
+tox -r
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,3 +41,18 @@ the `-r` flag to force it to rebuild its environment.
 ```bash
 tox -r
 ```
+
+Note that on OS X, matplotlib may throw errors during testing stating
+
+```bash
+from matplotlib.backends import _macosx
+E   RuntimeError: Python is not installed as a framework.
+```
+
+This can be resolved by switching matplotlib backends. Create a file in the home directory `~/.matplotlib/matplotlibrc` and include the following:
+
+```python
+backend: TkAgg
+```
+
+This should fix the error.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,16 +11,17 @@
 
 Tests run using [tox](http://tox.readthedocs.io/en/latest/)
 and [pytest](https://docs.pytest.org/en/latest/). If you didn't install augur
-with the pip `requirements.txt` or with
+with `pip -r requirements.txt` or with
 the
 [janus conda environment](https://github.com/nextstrain/janus/#installation),
 install them as follows.
 
 ```bash
 # Install with pip.
-pip install pytest tox
+pip install --user pytest tox
 
 # Or install inside a conda environment.
+source activate janus_python2
 conda install pytest virtualenv
 pip install tox
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs = treetime_augur
-addopts = --doctest-modules tests/ base/io_util.py base/sequences_prepare.py base/sequences_process.py base/fitness_model.py base/titer_model.py
+addopts = --doctest-modules tests/ base/

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ schedule==0.3.0
 seaborn==0.6.0
 ipdb==0.10.1
 gitpython==2.1.3
+pytest==3.2.1
+tox==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,18 @@ import os
 from setuptools import setup, find_packages
 
 setup(
-        name = "augur",
-        version = "1.0.0",
-        author = "Richard Neher and Trevor Bedford",
-        author_email = "trevor@bedford.io",
-        description = ("Pipeline components for real-time virus analysis"),
-        license = "GNU Affero General Public License v3.0",
-        keywords = "",
-        url = "https://github.com/nextstrain/augur",
-        packages=find_packages(exclude=['docs', 'tests']),
-        classifiers=[
-            "Development Status :: 5 - Production/Stable",
-            "Topic :: Science",
-            "License :: GNU Affero General Public License v3.0",
-            ],
-        )
+    name = "augur",
+    version = "1.0.0",
+    author = "Richard Neher and Trevor Bedford",
+    author_email = "trevor@bedford.io",
+    description = ("Pipeline components for real-time virus analysis"),
+    license = "GNU Affero General Public License v3.0",
+    keywords = "",
+    url = "https://github.com/nextstrain/augur",
+    packages=find_packages(exclude=['docs', 'tests']),
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Topic :: Science",
+        "License :: GNU Affero General Public License v3.0",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+"""
+Pipeline components for real-time virus analysis
+Author: Richard Neher and Trevor Bedford
+"""
+import os
+from setuptools import setup, find_packages
+
+setup(
+        name = "augur",
+        version = "1.0.0",
+        author = "Richard Neher and Trevor Bedford",
+        author_email = "trevor@bedford.io",
+        description = ("Pipeline components for real-time virus analysis"),
+        license = "GNU Affero General Public License v3.0",
+        keywords = "",
+        url = "https://github.com/nextstrain/augur",
+        packages=find_packages(exclude=['docs', 'tests']),
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Topic :: Science",
+            "License :: GNU Affero General Public License v3.0",
+            ],
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps = -rrequirements.txt
+commands = pytest


### PR DESCRIPTION
Adds [documentation about how to run unit tests and doctests](https://github.com/nextstrain/augur/tree/document-tests/docs#tests)

Part of getting doctests to work within the [pytest](https://docs.pytest.org/en/latest/) environment requires temporarily installing augur as a package. I've added a minimal `setup.py` file to the top level for this purpose, but installing augur as a proper module is part of a bigger discussion and PR that involves reorganizing the repository (e.g., to organize code into a module like [treetime](https://github.com/neherlab/treetime) is).