### PR TITLE
Fix small clade frequencies

### DIFF
--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -349,13 +349,15 @@ class tree_frequencies(object):
                 for clade, tmp_freq in freq_est.iteritems():
                     if clade!="other":
                         self.frequencies[clade] = self.frequencies[node.clade]*tmp_freq
-                if len(small_clades)>1:
+
+                if len(small_clades) > 1:
+                    total_leaves_in_small_clades = 0
                     for clade in small_clades:
-                        if len(node.leafs):
-                            frac = 1.0*len(clade.leafs)/len(node.leafs)
-                        else:
-                            frac = 0.0
-                        self.frequencies[clade.clade] = frac*freq_est["other"]
+                        total_leaves_in_small_clades += len(clade.leafs)
+
+                    for clade in small_clades:
+                        frac = len(clade.leafs) / total_leaves_in_small_clades
+                        self.frequencies[clade.clade] = frac * freq_est["other"] * self.frequencies[node.clade]
             else:
                 for clade in small_clades:
                     if len(node.leafs):

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -356,7 +356,11 @@ class tree_frequencies(object):
                         total_leaves_in_small_clades += len(clade.leafs)
 
                     for clade in small_clades:
-                        frac = len(clade.leafs) / total_leaves_in_small_clades
+                        if total_leaves_in_small_clades > 0:
+                            frac = len(clade.leafs) / total_leaves_in_small_clades
+                        else:
+                            frac = 0.0
+
                         self.frequencies[clade.clade] = frac * freq_est["other"] * self.frequencies[node.clade]
             else:
                 for clade in small_clades:


### PR DESCRIPTION
While debugging the fitness model's performance, I noticed that the frequencies of all tips at any given time point (or pivot) never summed to 1 but to values ranging from 3-5.

To debug the issue, I identified a larger clade whose predicted frequency at any given time was always less than the sum of the tip frequencies. The plot below shows the frequency of the original clade, the individual tip frequencies for all 243 tips, and the sum of the tip frequencies.

![image](https://user-images.githubusercontent.com/85372/35015486-76ffc642-fac9-11e7-8000-e818b1084428.png)

After digging into `frequencies.py` for a bit, I found that after nested frequency calculations, small clade frequencies were not converted to an absolute frequency like the other nested frequencies by multiplying the current clade's frequency.

```python
# Original code scales the remaining "other" frequency in the current clade
# by the number of leaves in the current small clade divided by the number
# of leaves in the current parent clade.
self.frequencies[clade.clade] = frac * freq_est["other"]
```

Additionally, the remaining "other" frequency was divided amongst the remaining small clades based on the number of leaves in each small clade divided by the number of leaves in the parent clade. Because these fractions usually don't sum to 1 across all small clades, the "other" frequency was not being completely accounted for.

This PR introduces two changes to the `estimate_clade_frequencies` method that fix the frequencies for small clades. After making these changes, the frequencies of all tips sum to one and the frequencies of all tips in any given clade sum to that clade's frequency as shown below.

![image](https://user-images.githubusercontent.com/85372/35015560-c0644c68-fac9-11e7-8f60-d466d0193bed.png)