### PR TITLE
Filter tips predating first pivot from tree frequency calculations

### DIFF
--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -374,7 +374,7 @@ class tree_frequencies(object):
                     self.frequencies[clade.clade] = frac*self.frequencies[node.clade]
 
         # Assign zero frequencies to tips that did not pass the node_filter.
-        for tip in self.tree.get_nonterminals():
+        for tip in self.tree.get_terminals():
             if not self.node_filter(tip):
                 self.frequencies[tip.clade] = np.zeros(len(self.pivots))
 

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -164,7 +164,7 @@ class frequency_estimator(object):
                 self.sol = minimize(logLH, logit_transform(self.pivot_freq,self.pc), method='powell')
 
             self.pivot_freq = logit_inv(self.sol['x'], self.pc)
-        self.pivot_freq = fix_freq(self.pivot_freq, 0.0001)
+        self.pivot_freq = fix_freq(self.pivot_freq, self.pc)
 
         # instantiate an interpolation object based on the optimal frequency pivots
         self.frequency_estimate = interp1d(self.pivots, self.pivot_freq, kind=self.interpolation_type, bounds_error=False)

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -333,7 +333,10 @@ class tree_frequencies(object):
                 if len(c.leafs)>self.min_clades:
                     obs_to_estimate[c.clade] = np.in1d(node.leafs, c.leafs)
                 else:
-                    small_clades.append(c)
+                    # Only include internal nodes or tips that pass the node
+                    # filter as small clades.
+                    if not c.is_terminal() or self.node_filter(c):
+                        small_clades.append(c)
             if len(obs_to_estimate):
                 if len(small_clades):
                     remainder = {}
@@ -369,6 +372,11 @@ class tree_frequencies(object):
                     else:
                         frac = 0.0
                     self.frequencies[clade.clade] = frac*self.frequencies[node.clade]
+
+        # Assign zero frequencies to tips that did not pass the node_filter.
+        for tip in self.tree.get_nonterminals():
+            if not self.node_filter(tip):
+                self.frequencies[tip.clade] = np.zeros(len(self.pivots))
 
 
     def calc_confidence(self):

--- a/base/process.py
+++ b/base/process.py
@@ -450,11 +450,6 @@ class process(object):
         '''
         estimate frequencies of clades in the tree, possibly region specific
         '''
-        if region=='global':
-            node_filter_func = None
-        else:
-            node_filter_func = lambda x:x.attr['region']==region
-
         if not hasattr(self, 'tree_frequencies'):
             self.restore_tree_frequencies()
 
@@ -467,6 +462,12 @@ class process(object):
             self.pivots=make_pivots(pivots, tps)
 
         self.log.notify('Estimate tree frequencies for %s: using self.pivots' % (region))
+
+        # Omit strains sampled prior to the first pivot from frequency calculations.
+        if region=='global':
+            node_filter_func = lambda node: node.attr["num_date"] >= self.pivots[0]
+        else:
+            node_filter_func = lambda node: (node.attr['region'] == region) and (node.attr["num_date"] >= self.pivots[0])
 
         tree_freqs = tree_frequencies(self.tree.tree, self.pivots, method='SLSQP',
                                       node_filter = node_filter_func,


### PR DESCRIPTION
This PR uses the `node_filter` functionality of the tree frequencies calculations to omit tips that predate the first pivot of an analysis from the frequency estimations.

The included code  ensures that tips filtered by the `node_filter` function do not get included in frequency calculations and makes the filtering of old tips the default for tree frequency estimation.