### PR TITLE
Do not attempt to collapse colinear mutations when there are no relevant mutations

### DIFF
--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -889,7 +889,7 @@ class SubstitutionModel(TiterModel):
         self.weights = np.sqrt(weights)
         self.titer_dist =  np.array(titer_dist)*self.weights
         self.design_matrix = (np.array(seq_graph).T*self.weights).T
-        if colin_thres is not None:
+        if colin_thres is not None and self.genetic_params > 0:
             self.collapse_colinear_mutations(colin_thres)
         self.TgT = np.dot(self.design_matrix.T, self.design_matrix)
         print ("Found", self.design_matrix.shape, "measurements x parameters")


### PR DESCRIPTION
Resolves an edge case in the sequence titer model when there are too few titer measurements available to identify relevant mutations associated with titer drops.

The issue manifests when a 2y H3N2 data set with the following error during the substitution model run.

```
Made training data as fraction 1.0 of all measurements
 - remaining data set
 --- 2  reference virues
 --- 2  sera
 --- 3  test_viruses
 --- 6  non-redundant test virus/serum pairs
 --- 6  measurements in training set
dimensions of old design matrix (6, 5)
Traceback (most recent call last):
  File "flu.process.py", line 577, in <module>
    HI_model(runner)
  File "/fh/fast/bedford_t/users/jhuddles/janus/augur/builds/flu/flu_titers.py", line 31, in HI_model
    process.HI_subs.prepare(**kwargs)
  File "../../base/titer_model.py", line 799, in prepare
    self.make_seqgraph()
  File "../../base/titer_model.py", line 893, in make_seqgraph
    self.collapse_colinear_mutations(colin_thres)
  File "../../base/titer_model.py", line 919, in collapse_colinear_mutations
    self.design_matrix[:,self.genetic_params:]))
  File "/home/jhuddles/miniconda3/envs/janus_python2/lib/python2.7/site-packages/numpy/core/shape_base.py", line 286, in hstack
    return _nx.concatenate(arrs, 0)
ValueError: all the input arrays must have same number of dimensions
```