### PR TITLE
export tip frequencies

### DIFF
--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -48,7 +48,10 @@ def export_tip_frequency_json(process, prefix, indent):
     freq_json = {'pivots':process_freqs(process.pivots, num_dp)}
 
     for n in process.tree.tree.get_terminals():
-        freq_json["global_clade:"+str(n.clade)] = process_freqs(process.tree_frequencies["global"][n.clade], num_dp)
+        freq_json[n.name] = {
+            "frequencies" : process_freqs(process.tree_frequencies["global"][n.clade], num_dp),
+            "weight": 1.0
+        }
 
     write_json(freq_json, prefix+'_tip-frequencies.json', indent=indent)
 

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -39,6 +39,23 @@ def export_frequency_json(process, prefix, indent):
     else:
         process.log.notify("Cannot export frequencies - pivots do not exist")
 
+def export_tip_frequency_json(process, prefix, indent):
+    def process_freqs(freq): # 6dp here, 4 above
+        return [round(x,6) for x in freq]
+
+    if not (hasattr(process, 'pivots') and hasattr(process, 'tree_frequencies')):
+        process.log.notify("Cannot export tip frequencies - pivots and/or tree_frequencies do not exist")
+        return;
+
+    freq_json = {'pivots':process_freqs(process.pivots)}
+
+    clade_tip_map = {n.clade: n.name for n in process.tree.tree.get_terminals()}
+
+    for clade, freq in process.tree_frequencies["global"].iteritems():
+        if clade in clade_tip_map:
+            freq_json[clade_tip_map[clade]] = process_freqs(freq)
+
+    write_json(freq_json, prefix+'_tipfrequencies.json', indent=indent)
 
 def summarise_publications_from_tree(tree):
     info = defaultdict(lambda: {"n": 0, "title": "?"})

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -55,7 +55,7 @@ def export_tip_frequency_json(process, prefix, indent):
         if clade in clade_tip_map:
             freq_json[clade_tip_map[clade]] = process_freqs(freq)
 
-    write_json(freq_json, prefix+'_tipfrequencies.json', indent=indent)
+    write_json(freq_json, prefix+'_tip-frequencies.json', indent=indent)
 
 def summarise_publications_from_tree(tree):
     info = defaultdict(lambda: {"n": 0, "title": "?"})

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -47,11 +47,8 @@ def export_tip_frequency_json(process, prefix, indent):
     num_dp = 6;
     freq_json = {'pivots':process_freqs(process.pivots, num_dp)}
 
-    clade_tip_map = {n.clade: n.name for n in process.tree.tree.get_terminals()}
-
-    for clade, freq in process.tree_frequencies["global"].iteritems():
-        if clade in clade_tip_map:
-            freq_json[clade_tip_map[clade]] = process_freqs(freq, num_dp)
+    for n in process.tree.tree.get_terminals():
+        freq_json["global_clade:"+str(n.clade)] = process_freqs(process.tree_frequencies["global"][n.clade], num_dp)
 
     write_json(freq_json, prefix+'_tip-frequencies.json', indent=indent)
 

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -10,28 +10,29 @@ def process_freqs(frequencies, num_dp):
     return [round(x, num_dp) for x in frequencies]
 
 def export_frequency_json(process, prefix, indent):
+    num_dp = 4;
     # construct a json file containing all frequency estimate
     # the format is region_protein:159F for mutations and region_clade:123 for clades
     if hasattr(process, 'pivots'):
-        freq_json = {'pivots':process_freqs(process.pivots, 4)}
+        freq_json = {'pivots':process_freqs(process.pivots, num_dp)}
         if hasattr(process, 'mutation_frequencies'):
             freq_json['counts'] = {x:list(counts) for x, counts in process.mutation_frequency_counts.iteritems()}
             for (region, gene), tmp_freqs in process.mutation_frequencies.iteritems():
                 for mut, freq in tmp_freqs.iteritems():
                     label_str =  region+"_"+ gene + ':' + str(mut[0]+1)+mut[1]
-                    freq_json[label_str] = process_freqs(freq, 4)
+                    freq_json[label_str] = process_freqs(freq, num_dp)
         # repeat for clade frequencies in trees
         if hasattr(process, 'tree_frequencies'):
             for region in process.tree_frequencies:
                 for clade, freq in process.tree_frequencies[region].iteritems():
                     label_str = region+'_clade:'+str(clade)
-                    freq_json[label_str] = process_freqs(freq, 4)
+                    freq_json[label_str] = process_freqs(freq, num_dp)
         # repeat for named clades
         if hasattr(process, 'clades_to_nodes') and hasattr(process, 'tree_frequencies'):
             for region in process.tree_frequencies:
                 for clade, node in process.clades_to_nodes.iteritems():
                     label_str = region+'_'+str(clade)
-                    freq_json[label_str] = process_freqs(process.tree_frequencies[region][node.clade], 4)
+                    freq_json[label_str] = process_freqs(process.tree_frequencies[region][node.clade], num_dp)
         # write to one frequency json
         if hasattr(process, 'tree_frequencies') or hasattr(process, 'mutation_frequencies'):
             write_json(freq_json, prefix+'_frequencies.json', indent=indent)
@@ -43,13 +44,14 @@ def export_tip_frequency_json(process, prefix, indent):
         process.log.notify("Cannot export tip frequencies - pivots and/or tree_frequencies do not exist")
         return;
 
-    freq_json = {'pivots':process_freqs(process.pivots, 6)}
+    num_dp = 6;
+    freq_json = {'pivots':process_freqs(process.pivots, num_dp)}
 
     clade_tip_map = {n.clade: n.name for n in process.tree.tree.get_terminals()}
 
     for clade, freq in process.tree_frequencies["global"].iteritems():
         if clade in clade_tip_map:
-            freq_json[clade_tip_map[clade]] = process_freqs(freq, 6)
+            freq_json[clade_tip_map[clade]] = process_freqs(freq, num_dp)
 
     write_json(freq_json, prefix+'_tip-frequencies.json', indent=indent)
 

--- a/base/process.py
+++ b/base/process.py
@@ -9,7 +9,7 @@ from base.utils import num_date, save_as_nexus, parse_date
 from base.tree import tree
 from base.fitness_model import fitness_model
 from base.frequencies import alignment_frequencies, tree_frequencies, make_pivots
-from base.auspice_export import export_metadata_json, export_frequency_json
+from base.auspice_export import export_metadata_json, export_frequency_json, export_tip_frequency_json
 import numpy as np
 from datetime import datetime
 import json
@@ -689,6 +689,7 @@ class process(object):
         ## FREQUENCIES ##
         if "frequencies" in self.config["auspice"]["extra_jsons"]:
             export_frequency_json(self, prefix=prefix, indent=indent)
+            export_tip_frequency_json(self, prefix=prefix, indent=indent)
 
         ## METADATA ##
         export_metadata_json(self, prefix=prefix, indent=indent)

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -50,7 +50,7 @@ def make_config (prepared_json, args):
         "in": prepared_json,
         "geo_inference": ['region'],
         "auspice": { ## settings for auspice JSON export
-            "panels": ['tree', 'entropy'],
+            "panels": ['tree', 'entropy', 'frequencies'],
             "extra_attr": ['serum'],
             "color_options": {
                 "region":{"key":"region", "legendTitle":"Region", "menuItem":"region", "type":"discrete"},


### PR DESCRIPTION
### what
A `tipfrequencies.JSON` is exported at the same time as `frequencies.JSON`. This is a dictionary with keys `pivots` (same as frequencies) as well as each strain name -> frequencies at pivots. The frequencies are 6dp as opposed to 4dp to reduce error.

### why
Auspice frequencies uses this information. This is a subset of the larger frequencies JSON to improve auspice fetch time.