### PR TITLE
Add wrapper function to titer model to re-run training/test set sampling N times

### DIFF
--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -449,26 +449,26 @@ class TiterModel(object):
         model_performance['values'] = validation.values()
 
         self.validation = model_performance
-        # if plot:
-        #     import matplotlib.pyplot as plt
-        #     import seaborn as sns
-        #     fs=16
-        #     sns.set_style('darkgrid')
-        #     plt.figure()
-        #     ax = plt.subplot(111)
-        #     plt.plot([-1,6], [-1,6], 'k')
-        #     plt.scatter(actual, predicted)
-        #     plt.ylabel(r"predicted $\log_2$ distance", fontsize = fs)
-        #     plt.xlabel(r"measured $\log_2$ distance" , fontsize = fs)
-        #     ax.tick_params(axis='both', labelsize=fs)
-        #     plt.text(-2.5,6,'regularization:\nprediction error:\nR^2:', fontsize = fs-2)
-        #     plt.text(1.2,6, str(self.lam_drop)+'/'+str(self.lam_pot)+'/'+str(self.lam_avi)+' (HI/pot/avi)'
-        #              +'\n'+str(round(model_performance['abs_error'], 2))+'/'+str(round(model_performance['rms_error'], 2))+' (abs/rms)'
-        #              + '\n' + str(model_performance['r_squared']), fontsize = fs-2)
-        #     plt.tight_layout()
-        #
-        #     if fname:
-        #         plt.savefig(fname)
+        if plot:
+            import matplotlib.pyplot as plt
+            import seaborn as sns
+            fs=16
+            sns.set_style('darkgrid')
+            plt.figure()
+            ax = plt.subplot(111)
+            plt.plot([-1,6], [-1,6], 'k')
+            plt.scatter(actual, predicted)
+            plt.ylabel(r"predicted $\log_2$ distance", fontsize = fs)
+            plt.xlabel(r"measured $\log_2$ distance" , fontsize = fs)
+            ax.tick_params(axis='both', labelsize=fs)
+            plt.text(-2.5,6,'regularization:\nprediction error:\nR^2:', fontsize = fs-2)
+            plt.text(1.2,6, str(self.lam_drop)+'/'+str(self.lam_pot)+'/'+str(self.lam_avi)+' (HI/pot/avi)'
+                     +'\n'+str(round(model_performance['abs_error'], 2))+'/'+str(round(model_performance['rms_error'], 2))+' (abs/rms)'
+                     + '\n' + str(model_performance['r_squared']), fontsize = fs-2)
+            plt.tight_layout()
+
+            if fname:
+                plt.savefig(fname)
 
         return model_performance
 

--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from base.io_util import myopen
 from itertools import izip
 import pandas as pd
+from pprint import pprint
 
 TITER_ROUND=4
 logger = logging.getLogger(__name__)
@@ -420,45 +421,56 @@ class TiterModel(object):
         predict titers of the validation set (separate set of test_titers aside previously)
         and compare against known values. If requested by plot=True,
         a figure comparing predicted and measured titers is produced
+
+        Compute basic error metrics for actual vs. predicted titer values.
+        Return a dictionary of {'metric': computed_metric, 'values': [(actual, predicted), ...]}, save a copy in self.validation
         '''
         from scipy.stats import linregress, pearsonr
         if validation_set is None:
             validation_set=self.test_titers
-        self.validation = {}
+        validation = {}
         for key, val in validation_set.iteritems():
             pred_titer = self.predict_titer(key[0], key[1], cutoff=cutoff)
-            self.validation[key] = (val, pred_titer)
+            validation[key] = (val, pred_titer)
 
-        a = np.array(self.validation.values())
-        print ("number of prediction-measurement pairs",a.shape)
-        self.abs_error = np.mean(np.abs(a[:,0]-a[:,1]))
-        self.rms_error = np.sqrt(np.mean((a[:,0]-a[:,1])**2))
-        self.slope, self.intercept, tmpa, tmpb, tmpc = linregress(a[:,0], a[:,1])
-        print ("error (abs/rms): ",self.abs_error, self.rms_error)
-        print ("slope, intercept:", self.slope, self.intercept)
-        self.r2 = pearsonr(a[:,0], a[:,1])[0]**2
-        print ("pearson correlation:", self.r2)
+        validation_array = np.array(validation.values())
+        actual = validation_array[:,0]
+        predicted = validation_array[:,1]
 
-        if plot:
-            import matplotlib.pyplot as plt
-            import seaborn as sns
-            fs=16
-            sns.set_style('darkgrid')
-            plt.figure()
-            ax = plt.subplot(111)
-            plt.plot([-1,6], [-1,6], 'k')
-            plt.scatter(a[:,0], a[:,1])
-            plt.ylabel(r"predicted $\log_2$ distance", fontsize = fs)
-            plt.xlabel(r"measured $\log_2$ distance" , fontsize = fs)
-            ax.tick_params(axis='both', labelsize=fs)
-            plt.text(-2.5,6,'regularization:\nprediction error:\nR^2:', fontsize = fs-2)
-            plt.text(1.2,6, str(self.lam_drop)+'/'+str(self.lam_pot)+'/'+str(self.lam_avi)+' (HI/pot/avi)'
-                     +'\n'+str(round(self.abs_error, 2))+'/'+str(round(self.rms_error, 2))+' (abs/rms)'
-                     + '\n' + str(self.r2), fontsize = fs-2)
-            plt.tight_layout()
+        regression = linregress(actual, predicted)
+        model_performance = {
+                        'slope': regression[0],
+                        'intercept': regression[1],
+                        'r_squared': pearsonr(actual, predicted)[0]**2,
+                        'abs_error':  np.mean(np.abs(actual-predicted)),
+                        'rms_error': np.sqrt(np.mean((actual-predicted)**2)),
+        }
+        pprint(model_performance)
+        model_performance['values'] = validation.values()
 
-            if fname:
-                plt.savefig(fname)
+        self.validation = model_performance
+        # if plot:
+        #     import matplotlib.pyplot as plt
+        #     import seaborn as sns
+        #     fs=16
+        #     sns.set_style('darkgrid')
+        #     plt.figure()
+        #     ax = plt.subplot(111)
+        #     plt.plot([-1,6], [-1,6], 'k')
+        #     plt.scatter(actual, predicted)
+        #     plt.ylabel(r"predicted $\log_2$ distance", fontsize = fs)
+        #     plt.xlabel(r"measured $\log_2$ distance" , fontsize = fs)
+        #     ax.tick_params(axis='both', labelsize=fs)
+        #     plt.text(-2.5,6,'regularization:\nprediction error:\nR^2:', fontsize = fs-2)
+        #     plt.text(1.2,6, str(self.lam_drop)+'/'+str(self.lam_pot)+'/'+str(self.lam_avi)+' (HI/pot/avi)'
+        #              +'\n'+str(round(model_performance['abs_error'], 2))+'/'+str(round(model_performance['rms_error'], 2))+' (abs/rms)'
+        #              + '\n' + str(model_performance['r_squared']), fontsize = fs-2)
+        #     plt.tight_layout()
+        #
+        #     if fname:
+        #         plt.savefig(fname)
+
+        return model_performance
 
     def reference_virus_statistic(self):
         '''
@@ -630,6 +642,25 @@ class TreeModel(TiterModel):
     """
     def __init__(self,*args, **kwargs):
         super(TreeModel, self).__init__(*args, **kwargs)
+
+
+    def cross_validate(self, n, **kwargs):
+        '''
+        For each of n iterations, randomly re-allocate titers to training and test set.
+        Fit the model using training titers, assess performance using test titers (see TiterModel.validate)
+        Append dictionaries of {'abs_error': , 'rms_error': , 'values': [(actual, predicted), ...], etc.} for each iteration to the model_performance list.
+        Return model_performance, and save a copy in self.cross_validation
+        '''
+
+        model_performance = []
+        for iteration in range(n):
+            self.prepare(**kwargs) # randomly reassign titers to training and test sets
+            self.train(**kwargs) # train the model
+            performance = self.validate() # assess performance on the withheld test data. Returns {'values': [(actual, predicted), ...], 'metric': metric_value, ...}
+            model_performance.append(performance)
+
+        self.cross_validation = model_performance
+        return self.cross_validation
 
     def prepare(self, **kwargs):
         self.make_training_set(**kwargs)
@@ -961,7 +992,7 @@ if __name__=="__main__":
     ttm.train(method='nnl1reg')
     ttm.validate(plot=True)
 
-    tsm = TreeModel(flu.tree.tree, flu.titers)
+    tsm = SubstitutionModel(flu.tree.tree, flu.titers)
     tsm.prepare(training_fraction=0.8)
     tsm.train(method='nnl1reg')
     tsm.validate(plot=True)

--- a/builds/dengue/dengue.process.py
+++ b/builds/dengue/dengue.process.py
@@ -121,15 +121,16 @@ if __name__=="__main__":
                 titer_model(runner,
                             lam_pot = runner.config['titers']['lam_pot'],
                             lam_avi = runner.config['titers']['lam_avi'],
-                            lam_drop = runner.config['titers']['lam_drop'],
-                            training_fraction = runner.config['titers']['training_fraction'],
-                            sanofi_strain = sanofi_vaccine_strains[runner.info['lineage']], # vaccine strain for each serotype-specific build
+                        lam_drop = runner.config['titers']['lam_drop'],
+                        training_fraction = runner.config['titers']['training_fraction'],
+                        sanofi_strain = sanofi_vaccine_strains[runner.info['lineage']], # vaccine strain for each serotype-specific build
                             plot=False,
                             criterium = lambda node: True) # calculate dTiter for all branches
-                titer_export(runner)
+                        cross_validate=3) # calculate dTiter for all branches
+            titer_export(runner)
 
-            ### Export for visualization in auspice
-            runner.auspice_export()
+        ### Export for visualization in auspice
+        runner.auspice_export()
 
         except:
             continue


### PR DESCRIPTION
This PR makes two major changes in `base/titer_model.py`:  
1 - `TiterModel.validate()` now returns a dictionary with the slope, intercept, abs error, rms error, and r^2 values. This dictionary also includes `values: [(actual, predicted), ...]` for each measurement in the test set. A copy of this dictionary is saved in `self.validation`.
  
2 - A new wrapper function, `TiterModel.cross_validate()`, independently runs through `prepare`, `train`, and `validate` N times. The output from `validate` (described above) is stored in a list of dictionaries, which is then returned and stored as an attribute in `self.cross_validate()`. 

I believe the easiest way to collate and export these values is via pandas, but other build maintainers may have other preferences. I've implemented an example of how to call and export results from `cross_validate` in the dengue build for now; if desired, I'm also happy to add the pandas parsing to the base class so that `cross_validate` returns `pd.DataFrame` objects instead of a list of dictionaries. 

Comments, suggestions and questions welcome. Otherwise, I'll plan to merge in a few days.