### PR TITLE
LBI predictor

### DIFF
--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -79,7 +79,7 @@ def matthews_correlation_coefficient(tp, tn, fp, fn):
 
 class fitness_model(object):
 
-    def __init__(self, tree, frequencies, time_interval, predictor_input = ['ep', 'lb', 'dfreq'], pivot_spacing = 1.0 / 12, verbose = 0, enforce_positive_predictors = True, **kwargs):
+    def __init__(self, tree, frequencies, time_interval, predictor_input = ['ep', 'lb', 'dfreq'], pivots = None, pivot_spacing = 1.0 / 12, verbose = 0, enforce_positive_predictors = True, predictor_kwargs=None, **kwargs):
         '''
         parameters:
         tree -- tree of sequences for which a fitness model is to be determined
@@ -94,6 +94,13 @@ class fitness_model(object):
         self.estimate_coefficients = True
         self.min_freq = kwargs.get("min_freq", 0.1)
         self.max_freq = kwargs.get("max_freq", 0.99)
+
+        if predictor_kwargs is None:
+            self.predictor_kwargs = {}
+        else:
+            self.predictor_kwargs = predictor_kwargs
+
+        self.time_window = kwargs.get("time_window", 6.0 / 12.0)
 
         # Convert datetime date interval to floating point interval from
         # earliest to latest.
@@ -112,9 +119,9 @@ class fitness_model(object):
                 self.estimate_coefficients = True
 
         # If pivots have not been calculated yet, calculate them here.
-        if (not hasattr(self, "pivots") and
-            hasattr(self, "time_interval") and
-            hasattr(self, "pivot_spacing")):
+        if pivots is not None:
+            self.pivots = pivots
+        else:
             self.pivots = make_pivots(
                 self.time_interval[0],
                 self.time_interval[1],

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -250,13 +250,13 @@ class fitness_model(object):
         This annotation is used by the LBI and epitope cross-immunity predictors.
         """
         for node in self.tree.find_clades(order="postorder"):
-            if not node.is_terminal():
-                node.alive = any(ch.alive for ch in node.clades)
-            else:
-                if node.numdate <= timepoint and node.numdate > timepoint - time_window:
+            if node.is_terminal():
+                if node.attr['num_date'] <= timepoint and node.attr['num_date'] > timepoint - time_window:
                     node.alive=True
                 else:
                     node.alive=False
+            else:
+                node.alive = any(ch.alive for ch in node.clades)
 
     def calc_time_censored_tree_frequencies(self):
         print("fitting time censored tree frequencies")
@@ -278,7 +278,7 @@ class fitness_model(object):
                 time_interval[1],
                 1 / self.pivot_spacing
             )
-            node_filter_func = lambda node: node.numdate >= time_interval[0] and node.numdate < time_interval[1]
+            node_filter_func = lambda node: node.attr['num_date'] >= time_interval[0] and node.attr['num_date'] < time_interval[1]
 
             # Recalculate tree frequencies for the given time interval and its
             # corresponding pivots.

--- a/base/fitness_predictors.py
+++ b/base/fitness_predictors.py
@@ -368,13 +368,20 @@ class fitness_predictors(object):
         tree -- dendropy tree for whose node the LBI is being computed
         attr     -- the attribute name used to store the result
         '''
+        # Check for clock length attribute and create it if it does not exist.
+        if not hasattr(tree.root, "clock_length"):
+            tree.root.clock_length = 0.0
+            for node in tree.find_clades():
+                for child in node.clades:
+                    child.clock_length = child.tvalue - node.tvalue
+
         # traverse the tree in postorder (children first) to calculate msg to parents
         for node in tree.find_clades(order="postorder"):
             node.down_polarizer = 0
             node.up_polarizer = 0
             for child in node.clades:
                 node.up_polarizer += child.up_polarizer
-            bl =  node.branch_length/tau
+            bl =  node.clock_length / tau
             node.up_polarizer *= np.exp(-bl)
             if node.alive: node.up_polarizer += tau*(1-np.exp(-bl))
 
@@ -386,7 +393,7 @@ class fitness_predictors(object):
                     if child1!=child2:
                         child1.down_polarizer += child2.up_polarizer
 
-                bl =  child1.branch_length/tau
+                bl =  child1.clock_length / tau
                 child1.down_polarizer *= np.exp(-bl)
                 if child1.alive: child1.down_polarizer += tau*(1-np.exp(-bl))
 

--- a/base/fitness_predictors.py
+++ b/base/fitness_predictors.py
@@ -28,9 +28,9 @@ class fitness_predictors(object):
         """
         return "".join(node.translations.values())
 
-    def setup_predictor(self, tree, pred, timepoint):
+    def setup_predictor(self, tree, pred, timepoint, **kwargs):
         if pred == 'lb':
-            self.calc_LBI(tree, tau = 0.0005, transform = lambda x:x)
+            self.calc_LBI(tree, **kwargs)
         if pred == 'ep':
             self.calc_epitope_distance(tree)
         if pred == 'ep_x':

--- a/base/fitness_predictors.py
+++ b/base/fitness_predictors.py
@@ -360,7 +360,7 @@ class fitness_predictors(object):
             else:
                 node.__setattr__(attr, np.nan)
 
-    def calc_LBI(self, tree, attr = 'lb', tau=0.0005, transform = lambda x:x):
+    def calc_LBI(self, tree, attr = 'lb', tau=0.4, transform = lambda x:x):
         '''
         traverses the tree in postorder and preorder to calculate the
         up and downstream tree length exponentially weighted by distance.

--- a/base/fitness_predictors.py
+++ b/base/fitness_predictors.py
@@ -155,7 +155,7 @@ class fitness_predictors(object):
         comparison_nodes = []
         for node in tree.find_clades(order="postorder"):
             if node.is_leaf():
-                if node.num_date < timepoint and node.num_date > timepoint - window:
+                if node.attr['num_date'] < timepoint and node.attr['num_date'] > timepoint - window:
                     comparison_nodes.append(node)
             if not hasattr(node, 'np_ep'):
                 if not hasattr(node, 'aa'):
@@ -373,7 +373,7 @@ class fitness_predictors(object):
             tree.root.clock_length = 0.0
             for node in tree.find_clades():
                 for child in node.clades:
-                    child.clock_length = child.tvalue - node.tvalue
+                    child.clock_length = child.attr['num_date'] - node.attr['num_date']
 
         # traverse the tree in postorder (children first) to calculate msg to parents
         for node in tree.find_clades(order="postorder"):


### PR DESCRIPTION
This PR updates the LBI fitness predictor to work in the context of modern augur and Bio.Phylo. It also updates the interface to the fitness model and its predictors to easily use these classes as utilities in other code such as a Jupyter notebook.

 Changes include:

  - Enable use of precalculated pivots for fitness model (e.g., pivots from an auspice frequencies JSON)
  - Enable run-time configuration of fitness predictors by providing a kwargs argument to pass through
  - Generalize code to select active nodes in a "season" by providing a `time_window` argument
  - Update LBI's default tau to match production auspice parameter for LBI
  - Calculate LBI with clock length from treetime instead of branch length from sequence divergence

Using tau=0.4 and a time window of 0.6 as in production auspice, we get the following distribution of LBI values on a recent 3 year H3N2 tree:

![image](https://user-images.githubusercontent.com/85372/38107359-8d95a470-3346-11e8-9982-575419f9b54a.png)
