### PR TITLE
Define mapping of lineages to masks within augur

### DIFF
--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -8,7 +8,7 @@ from base.process import process
 from base.utils import fix_names
 from flu_titers import HI_model, HI_export
 from scores import calculate_sequence_scores, calculate_metadata_scores
-from flu_info import clade_designations
+from flu_info import clade_designations, lineage_to_epitope_mask, lineage_to_glyc_mask
 import argparse
 import numpy as np
 from pprint import pprint
@@ -29,9 +29,9 @@ def parse_args():
     parser.add_argument('--predictors', default=['cTiter'], nargs='+', help="attributes to use as fitness model predictors")
     parser.add_argument('--predictors_params', type=float, nargs='+', help="precalculated fitness model parameters for each of the given predictors")
     parser.add_argument('--predictors_sds', type=float, nargs='+', help="precalculated global standard deviations for each of the given predictors")
-    parser.add_argument('--epitope_mask_version', default="wolf", help="name of the epitope mask that defines epitope mutations")
+    parser.add_argument('--epitope_mask_version', help="name of the epitope mask that defines epitope mutations")
     parser.add_argument('--tolerance_mask_version', help="name of the tolerance mask that defines non-epitope mutations")
-    parser.add_argument('--glyc_mask_version', default='ha1_h3n2', help="name of the mask that defines putative glycosylation sites")
+    parser.add_argument('--glyc_mask_version', help="name of the mask that defines putative glycosylation sites")
 
     parser.set_defaults(
         json="prepared/flu.json"
@@ -590,13 +590,22 @@ if __name__=="__main__":
         # }
 
         if segment=='ha' and runner.info["lineage"] in ["h3n2", "h1n1pdm"]:
+            epitope_mask_version = runner.config["epitope_mask_version"]
+            if epitope_mask_version is None:
+                epitope_mask_version = lineage_to_epitope_mask[runner.info["lineage"]]
+
+            glyc_mask_version = runner.config["glyc_mask_version"]
+            if glyc_mask_version is None:
+                glyc_mask_version = lineage_to_glyc_mask[runner.info["lineage"]]
+
+            print("Calculating scores with epitope mask '%s' and glycosylation mask '%s'." % (epitope_mask_version, glyc_mask_version))
             calculate_sequence_scores(
                 runner.tree.tree,
                 runner.config["ha_masks"],
                 runner.info["lineage"],
                 runner.segment,
-                epitope_mask_version=runner.config["epitope_mask_version"],
-                glyc_mask_version=runner.config["glyc_mask_version"]
+                epitope_mask_version=epitope_mask_version,
+                glyc_mask_version=glyc_mask_version
             )
             assert "ep" in runner.tree.tree.root.attr, "epitope mutations not annotated"
             assert "ne" in runner.tree.tree.root.attr, "non-epitope mutations not annotated"

--- a/builds/flu/flu_info.py
+++ b/builds/flu/flu_info.py
@@ -340,6 +340,17 @@ frequency_params = {
     '12y': {"dfreq_dn": 6}
 }
 
+# Map lineages to specific HA masks.
+lineage_to_epitope_mask = {
+    "h3n2": "wolf",
+    "h1n1pdm": "canton"
+}
+
+lineage_to_glyc_mask = {
+    "h3n2": "ha1_h3n2",
+    "h1n1pdm": "ha1_globular_head_h1n1pdm"
+}
+
 clade_designations = {
     "h3n2":{
         "3b":    [('HA2',158,'N'), ('HA1',198,'S'), ('HA1',312,'S'), ('HA1',223,'I'),


### PR DESCRIPTION
When an epitope mask is shorter than the amino acid sequence it is trying to mask, augur can throw an error like the following:

```python
Traceback (most recent call last):
  File "flu.process.py", line 599, in <module>
    glyc_mask_version=runner.config["glyc_mask_version"]
  File "/fh/fast/bedford_t/nextflu/augur-who/builds/flu/scores.py", line 146, in calculate_sequence_scores
    node.attr['ep'] = mask_distance(total_aa_seq, root_total_aa_seq, epitope_mask)
  File "/fh/fast/bedford_t/nextflu/augur-who/builds/flu/scores.py", line 104, in mask_distance
    sites_A = mask_sites(aaA, mask)
  File "/fh/fast/bedford_t/nextflu/augur-who/builds/flu/scores.py", line 100, in mask_sites
    return aa[mask[:len(aa)]]
IndexError: boolean index did not match indexed array along dimension 0; dimension is 567 but corresponding boolean dimension is 566
```

This PR tries to avoid this type of error by defining the mapping of flu lineages to masks within augur. This way the user does not need to know which mask name to provide on the command line to match the requested lineage and there is less chance for error.