### PR TITLE
Move LBI into flu scores

### DIFF
--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -128,15 +128,6 @@ def export_metadata_json(process, prefix, indent):
     if "vaccine_choices" in process.info:
         meta_json["vaccine_choices"] = process.info["vaccine_choices"]
 
-    if "LBI_params" in process.info:
-        meta_json["color_options"]["lbi"] = {
-            "key": "LBI",
-            "legendTitle": "local branching index",
-            "menuItem": "local branching index",
-            "tau": process.info["LBI_params"]["tau"],
-            "timeWindow": process.info["LBI_params"]["time_window"]
-        }
-
     ## ignore frequency params for now until they are implemented in nextstrain/auspice
 
     if "defaults" in process.config["auspice"]:

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -7,6 +7,7 @@ import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.stats import linregress
 
+from builds.flu.scores import select_nodes_in_season
 from frequencies import logit_transform, tree_frequencies
 from fitness_predictors import fitness_predictors
 
@@ -308,7 +309,7 @@ class fitness_model(object):
             node.predictors = {}
         for time in self.timepoints:
             if self.verbose: print "calculating predictors for time", time
-            self.select_nodes_in_season(time, self.time_window)
+            select_nodes_in_season(self.tree, time, self.time_window)
             self.calc_predictors(time)
             for node in self.nodes:
                 if 'dfreq' in [x for x in self.predictors]: node.dfreq = node.freq_slope[time]

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -313,7 +313,8 @@ class fitness_model(object):
             self.calc_predictors(time)
             for node in self.nodes:
                 if 'dfreq' in [x for x in self.predictors]: node.dfreq = node.freq_slope[time]
-                node.predictors[time] = np.array([node.__getattribute__(pred) for pred in self.predictors])
+                node.predictors[time] = np.array([hasattr(node, pred) and getattr(node, pred) or node.attr[pred]
+                                                  for pred in self.predictors])
             tmp_preds = []
             for tip in self.tips:
                 tmp_preds.append(tip.predictors[time])

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -243,21 +243,6 @@ class fitness_model(object):
             if pred != 'dfreq':
                 self.fp.setup_predictor(self.tree, pred, timepoint, **self.predictor_kwargs)
 
-    def select_nodes_in_season(self, timepoint, time_window):
-        """Annotate a boolean to each node in the tree if it is alive at the given
-        timepoint or prior to the timepoint by the given time window preceding.
-
-        This annotation is used by the LBI and epitope cross-immunity predictors.
-        """
-        for node in self.tree.find_clades(order="postorder"):
-            if node.is_terminal():
-                if node.attr['num_date'] <= timepoint and node.attr['num_date'] > timepoint - time_window:
-                    node.alive=True
-                else:
-                    node.alive=False
-            else:
-                node.alive = any(ch.alive for ch in node.clades)
-
     def calc_time_censored_tree_frequencies(self):
         print("fitting time censored tree frequencies")
         # this doesn't interfere with the previous freq estimates via difference in region: global_censored vs global

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -408,7 +408,7 @@ class fitness_model(object):
         return af
 
     def af_fit(self, params):
-        # TODO: fix me for continuos prediction
+        # TODO: fix me for continuous prediction
         seasonal_errors = []
         self.pred_vs_true = []
         for s,t in self.fit_test_season_pairs:

--- a/base/fitness_predictors.py
+++ b/base/fitness_predictors.py
@@ -6,6 +6,8 @@ from itertools import izip
 from scipy.stats import linregress
 import sys
 
+from builds.flu.scores import calculate_LBI
+
 # all fitness predictors should be designed to give a positive sign, ie.
 # number of epitope mutations
 # -1 * number of non-epitope mutations
@@ -29,8 +31,8 @@ class fitness_predictors(object):
         return "".join(node.translations.values())
 
     def setup_predictor(self, tree, pred, timepoint, **kwargs):
-        #if pred == 'lb':
-        #    self.calc_LBI(tree, **kwargs)
+        if pred == 'lb':
+           calculate_LBI(tree, **kwargs)
         # if pred == 'ep':
         #     self.calc_epitope_distance(tree)
         if pred == 'ep_x':

--- a/base/fitness_predictors.py
+++ b/base/fitness_predictors.py
@@ -59,7 +59,7 @@ class fitness_predictors(object):
         #if pred == 'cHI':
             # do nothing
 
-    def setup_epitope_mask(self, epitope_masks_fname = 'builds/flu/metadata/h3n2_epitope_masks.tsv', epitope_mask_version = 'wolf', tolerance_mask_version = 'ha1'):
+    def setup_epitope_mask(self, epitope_masks_fname = 'metadata/ha_masks.tsv', epitope_mask_version = 'wolf', tolerance_mask_version = 'ha1'):
         sys.stderr.write("setup " + str(epitope_mask_version) + " epitope mask and " + str(tolerance_mask_version) + " tolerance mask\n")
         self.epitope_mask = ""
         self.tolerance_mask = ""

--- a/base/process.py
+++ b/base/process.py
@@ -630,6 +630,10 @@ class process(object):
         """Run the fitness prediction model and annotate the tree's nodes with fitness
         values. Returns the resulting fitness model instance.
         """
+        if not hasattr(self, "tree_frequencies"):
+            self.log.warn("Could not find tree frequencies.")
+            return
+
         kwargs = {
             "tree": self.tree.tree,
             "frequencies": self.tree_frequencies,

--- a/base/process.py
+++ b/base/process.py
@@ -638,7 +638,7 @@ class process(object):
             "tree": self.tree.tree,
             "frequencies": self.tree_frequencies,
             "time_interval": self.info["time_interval"],
-            "pivot_spacing": self.config["pivot_spacing"]
+            "pivots": np.around(self.pivots, 2)
         }
 
         if "predictors" in self.config:

--- a/builds/flu/clean_directory.sh
+++ b/builds/flu/clean_directory.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Removing temporary directories."
+rm -rf temp*
+echo "Clearing out auspice/, processed/, prepared/"
+rm auspice/*
+rm processed/*
+rm prepared/*
+echo "Done cleaning directories, ready for clean builds."

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -7,7 +7,7 @@ from base.fitness_model import process_predictor_args
 from base.process import process
 from base.utils import fix_names
 from flu_titers import HI_model, HI_export
-from scores import calculate_sequence_scores, calculate_metadata_scores
+from scores import calculate_sequence_scores, calculate_metadata_scores, calculate_phylogenetic_scores
 from flu_info import clade_designations
 import argparse
 import numpy as np
@@ -588,6 +588,22 @@ if __name__=="__main__":
         #     "legendTitle": "Avg host gender in clade",
         #     "key": "num_gender"
         # }
+
+        calculate_phylogenetic_scores(
+            runner.tree.tree,
+            tau=runner.info["LBI_params"]["tau"],
+            time_window=runner.info["LBI_params"]["time_window"]
+        )
+        assert "lb" in runner.tree.tree.root.attr, "LBI not annotated"
+
+        runner.config["auspice"]["color_options"]["lb"] = {
+            "menuItem": "local branching index (new)",
+            "type": "continuous",
+            "legendTitle": "local branching index",
+            "key": "lb",
+            "vmin": 0,
+            "vmax": 0.7
+        }
 
         if segment=='ha' and runner.info["lineage"] in ["h3n2", "h1n1pdm"]:
             calculate_sequence_scores(

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -566,6 +566,9 @@ if __name__=="__main__":
         calculate_metadata_scores(runner.tree.tree)
         assert "age" in runner.tree.tree.root.attr, "age not annotated"
 
+        # outputs figures and tables of age distributions
+        age_distribution(runner)
+
         # runner.config["auspice"]["color_options"]["age"] = {
         #     "menuItem": "average host age in clade",
         #     "type": "continuous",
@@ -670,8 +673,6 @@ if __name__=="__main__":
                                 fname='processed/%s_grouped_with_potency_titer_matrix.png'%runner.info["prefix"],
                                 title = runner.info["prefix"], virus_clades=virus_clades, serum_clades=serum_clades, potency=True)
 
-        # outputs figures and tables of age distributions
-        age_distribution(runner)
     if segment in ["na"]:
         import json
         ha_tree_json_fname = os.path.join(runner.config["output"]["auspice"], runner.info["prefix"]) + "_tree.json"

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -560,10 +560,11 @@ if __name__=="__main__":
             # Predict fitness.
             if runner.config["annotate_fitness"]:
                 fitness_model = runner.annotate_fitness()
-                print("Fitness model parameters: %s" % str(zip(fitness_model.predictors, fitness_model.model_params)))
-                print("Fitness model deviations: %s" % str(zip(fitness_model.predictors, fitness_model.global_sds)))
-                print("Abs clade error: %s" % fitness_model.clade_fit(fitness_model.model_params))
-                runner.fitness_model = fitness_model
+                if fitness_model is not None:
+                    print("Fitness model parameters: %s" % str(zip(fitness_model.predictors, fitness_model.model_params)))
+                    print("Fitness model deviations: %s" % str(zip(fitness_model.predictors, fitness_model.global_sds)))
+                    print("Abs clade error: %s" % fitness_model.clade_fit(fitness_model.model_params))
+                    runner.fitness_model = fitness_model
 
         if segment in ['ha', 'na']:
             if not os.path.exists("processed/recurring_mutations/"):

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -579,21 +579,22 @@ if __name__=="__main__":
         #     "key": "num_gender"
         # }
 
-        calculate_phylogenetic_scores(
-            runner.tree.tree,
-            tau=runner.info["LBI_params"]["tau"],
-            time_window=runner.info["LBI_params"]["time_window"]
-        )
-        assert "lb" in runner.tree.tree.root.attr, "LBI not annotated"
+        if "LBI_params" in runner.info:
+            calculate_phylogenetic_scores(
+                runner.tree.tree,
+                tau=runner.info["LBI_params"]["tau"],
+                time_window=runner.info["LBI_params"]["time_window"]
+            )
+            assert "lb" in runner.tree.tree.root.attr, "LBI not annotated"
 
-        runner.config["auspice"]["color_options"]["lb"] = {
-            "menuItem": "local branching index (new)",
-            "type": "continuous",
-            "legendTitle": "local branching index",
-            "key": "lb",
-            "vmin": 0,
-            "vmax": 0.7
-        }
+            runner.config["auspice"]["color_options"]["lb"] = {
+                "menuItem": "local branching index",
+                "type": "continuous",
+                "legendTitle": "local branching index",
+                "key": "lb",
+                "vmin": 0,
+                "vmax": 0.7
+            }
 
         if segment=='ha' and runner.info["lineage"] in ["h3n2", "h1n1pdm"]:
             calculate_sequence_scores(

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -532,8 +532,6 @@ if __name__=="__main__":
             for regionTuple in runner.info["regions"]:
                 runner.estimate_tree_frequencies(region=str(regionTuple[0]))
 
-
-        # ignore fitness for NA.
         if segment=='ha':
             if runner.info["lineage"]=='h3n2':
                 clades = ['3c2.A', 'A1', 'A1b/135K', 'A2', 'A3']
@@ -556,15 +554,6 @@ if __name__=="__main__":
                 virus_clades = clades
                 serum_clades = clades
             runner.matchClades(clade_designations[runner.info["lineage"]])
-
-            # Predict fitness.
-            if runner.config["annotate_fitness"]:
-                fitness_model = runner.annotate_fitness()
-                if fitness_model is not None:
-                    print("Fitness model parameters: %s" % str(zip(fitness_model.predictors, fitness_model.model_params)))
-                    print("Fitness model deviations: %s" % str(zip(fitness_model.predictors, fitness_model.global_sds)))
-                    print("Abs clade error: %s" % fitness_model.clade_fit(fitness_model.model_params))
-                    runner.fitness_model = fitness_model
 
         if segment in ['ha', 'na']:
             if not os.path.exists("processed/recurring_mutations/"):
@@ -696,5 +685,14 @@ if __name__=="__main__":
                 if n.name in ha_tree_flat:
                     if "clade_membership" in ha_tree_flat[n.name]["attr"]:
                         n.attr["clade_membership"] = ha_tree_flat[n.name]["attr"]["clade_membership"]
+
+    # Predict fitness for HA after all other scores and annotations have completed.
+    if segment == 'ha' and runner.config["annotate_fitness"]:
+        fitness_model = runner.annotate_fitness()
+        if fitness_model is not None:
+            print("Fitness model parameters: %s" % str(zip(fitness_model.predictors, fitness_model.model_params)))
+            print("Fitness model deviations: %s" % str(zip(fitness_model.predictors, fitness_model.global_sds)))
+            print("Abs clade error: %s" % fitness_model.clade_fit(fitness_model.model_params))
+            runner.fitness_model = fitness_model
 
     runner.auspice_export()

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -587,7 +587,7 @@ if __name__=="__main__":
             )
             assert "lb" in runner.tree.tree.root.attr, "LBI not annotated"
 
-            runner.config["auspice"]["color_options"]["lb"] = {
+            runner.config["auspice"]["color_options"]["lbi"] = {
                 "menuItem": "local branching index",
                 "type": "continuous",
                 "legendTitle": "local branching index",

--- a/builds/flu/flu_info.py
+++ b/builds/flu/flu_info.py
@@ -340,6 +340,17 @@ frequency_params = {
     '12y': {"dfreq_dn": 6}
 }
 
+# Map lineages to specific HA masks.
+lineage_to_epitope_mask = {
+    "h3n2": "wolf",
+    "h1n1pdm": "canton"
+}
+
+lineage_to_glyc_mask = {
+    "h3n2": "ha1_h3n2",
+    "h1n1pdm": "ha1_globular_head_h1n1pdm"
+}
+
 clade_designations = {
     "h3n2":{
         "3b":    [('HA2',158,'N'), ('HA1',198,'S'), ('HA1',312,'S'), ('HA1',223,'I'),

--- a/builds/flu/scores.py
+++ b/builds/flu/scores.py
@@ -113,7 +113,7 @@ def glycosylation_count(total_aa_seq, glyc_mask):
 
     return len(re.findall('N[^P][ST][^P]', total_aa_seq_masked))
 
-def calculate_sequence_scores(tree, mask_file, lineage, segment, epitope_mask_version='wolf', glyc_mask_version='wolf'):
+def calculate_sequence_scores(tree, mask_file, lineage, segment, epitope_mask_version, glyc_mask_version):
     """Calculate scores from the amino acid sequence of each node in the given tree.
 
     Sequence scores depend on lineage- and segment-specific amino acid site masks or named masks.

--- a/builds/flu/scores.py
+++ b/builds/flu/scores.py
@@ -173,7 +173,7 @@ def calculate_LBI(tree, attr="lb", tau=0.4, transform=lambda x:x, **kwargs):
     traverses the tree in postorder and preorder to calculate the
     up and downstream tree length exponentially weighted by distance.
     then adds them as LBI
-    tree -- dendropy tree for whose node the LBI is being computed
+    tree     -- biopython tree for whose node the LBI is being computed
     attr     -- the attribute name used to store the result
     '''
     print("Tau: %s" % tau)

--- a/builds/flu/scores.py
+++ b/builds/flu/scores.py
@@ -220,6 +220,7 @@ def calculate_LBI(tree, attr="lb", tau=0.4, transform=lambda x:x, **kwargs):
     # Normalize LBI to range [0, 1].
     for node in tree.find_clades():
         node.attr[attr] /= max_LBI
+        setattr(node, attr, node.attr[attr])
 
 def calculate_phylogenetic_scores(tree, **kwargs):
     """Calculate scores based on a given phylogenetic tree and assign scores to each node.

--- a/builds/flu/scores.py
+++ b/builds/flu/scores.py
@@ -149,3 +149,90 @@ def calculate_sequence_scores(tree, mask_file, lineage, segment, epitope_mask_ve
 
         if rbs_mask is not None:
             node.attr['rb'] = mask_distance(total_aa_seq, root_total_aa_seq, rbs_mask)
+
+def select_nodes_in_season(tree, timepoint, time_window=0.6, **kwargs):
+    """Annotate a boolean to each node in the tree if it is alive at the given
+    timepoint or prior to the timepoint by the given time window preceding.
+
+    This annotation is used by the LBI and epitope cross-immunity predictors.
+    """
+    print("Time point: %s" % timepoint)
+    print("Time window: %s" % time_window)
+
+    for node in tree.find_clades(order="postorder"):
+        if node.is_terminal():
+            if node.attr['num_date'] <= timepoint and node.attr['num_date'] > timepoint - time_window:
+                node.alive=True
+            else:
+                node.alive=False
+        else:
+            node.alive = any(ch.alive for ch in node.clades)
+
+def calculate_LBI(tree, attr="lb", tau=0.4, transform=lambda x:x, **kwargs):
+    '''
+    traverses the tree in postorder and preorder to calculate the
+    up and downstream tree length exponentially weighted by distance.
+    then adds them as LBI
+    tree -- dendropy tree for whose node the LBI is being computed
+    attr     -- the attribute name used to store the result
+    '''
+    print("Tau: %s" % tau)
+
+    # Calculate clock length.
+    tree.root.clock_length = 0.0
+    for node in tree.find_clades():
+        for child in node.clades:
+            child.clock_length = child.attr['num_date'] - node.attr['num_date']
+
+    # traverse the tree in postorder (children first) to calculate msg to parents
+    for node in tree.find_clades(order="postorder"):
+        node.down_polarizer = 0
+        node.up_polarizer = 0
+        for child in node.clades:
+            node.up_polarizer += child.up_polarizer
+        bl =  node.clock_length / tau
+        node.up_polarizer *= np.exp(-bl)
+        if node.alive: node.up_polarizer += tau*(1-np.exp(-bl))
+
+    # traverse the tree in preorder (parents first) to calculate msg to children
+    for node in tree.get_nonterminals():
+        for child1 in node.clades:
+            child1.down_polarizer = node.down_polarizer
+            for child2 in node.clades:
+                if child1!=child2:
+                    child1.down_polarizer += child2.up_polarizer
+
+            bl =  child1.clock_length / tau
+            child1.down_polarizer *= np.exp(-bl)
+            if child1.alive: child1.down_polarizer += tau*(1-np.exp(-bl))
+
+    # go over all nodes and calculate the LBI (can be done in any order)
+    max_LBI = 0.0
+    for node in tree.find_clades(order="postorder"):
+        tmp_LBI = node.down_polarizer
+        for child in node.clades:
+            tmp_LBI += child.up_polarizer
+
+        node.attr[attr] = transform(tmp_LBI)
+        if node.attr[attr] > max_LBI:
+            max_LBI = node.attr[attr]
+
+    # Normalize LBI to range [0, 1].
+    for node in tree.find_clades():
+        node.attr[attr] /= max_LBI
+
+def calculate_phylogenetic_scores(tree, **kwargs):
+    """Calculate scores based on a given phylogenetic tree and assign scores to each node.
+
+    Scores include:
+
+      - LBI
+    """
+    # Find maximum time point in the given tree.
+    timepoint = max(node.attr["num_date"] for node in tree.find_clades())
+
+    # Select nodes within time window for LBI.
+    select_nodes_in_season(tree, timepoint, **kwargs)
+
+    # Calculate LBI.
+    calculate_LBI(tree, **kwargs)


### PR DESCRIPTION
This PR moves the functions to calculate LBI from the fitness model into the flu scores module. It also adds LBI calculation to the flu process for all subtypes that have LBI parameters defined and exports color options for auspice.

The only strange change here is that I need to be able to access source code from `builds/flu` in the top-level `base/fitness_model.py`. To do this, I needed to make both `builds` and `builds/flu` proper Python modules by adding a `__init__.py` file. The other way around this is to move the `scores.py` module up to `base` and make it generally available to any pathogens that want to use those functions.