### PR TITLE
Streamline lineage/segment/resolution specific defaults

### DIFF
--- a/base/sequences_prepare.py
+++ b/base/sequences_prepare.py
@@ -271,6 +271,8 @@ class sequence_set(object):
             data["info"]["time_interval"] = [str(x) for x in config["time_interval"]]
         potentially_combine(config, data["info"], "regions")
         potentially_combine(config, data["info"], "lineage", False)
+        data["info"]["segment"] = self.segmentName
+        potentially_combine(config, data["info"], "resolution", False)
         data["sequences"] = {}
         for seqName, seq in self.seqs.iteritems():
             data["sequences"][seqName] = {

--- a/builds/flu/flu.prepare.py
+++ b/builds/flu/flu.prepare.py
@@ -84,6 +84,7 @@ def make_config(lineage, resolution, params):
         "segments": params.segments,
         "ensure_all_segments": params.ensure_all_segments,
         "lineage": lineage,
+        "resolution": resolution,
         "input_paths": input_paths,
         #  0                     1   2         3          4      5     6       7       8          9                             10  11
         # >A/Galicia/RR9542/2012|flu|EPI376225|2012-02-23|europe|spain|galicia|galicia|unpassaged|instituto_de_salud_carlos_iii|47y|female

--- a/builds/flu/flu_info.py
+++ b/builds/flu/flu_info.py
@@ -340,7 +340,15 @@ frequency_params = {
     '12y': {"dfreq_dn": 6}
 }
 
-# Map lineages to specific HA masks.
+# Map resolution to pivot spacing
+resolution_to_pivot_spacing = {
+    "2y": 1. / 12.,
+    "3y": 1. / 12.,
+    "6y": 2. / 12.,
+    "12y": 3. / 12.
+}
+
+# Map lineages to specific HA masks
 lineage_to_epitope_mask = {
     "h3n2": "wolf",
     "h1n1pdm": "canton"

--- a/builds/flu/run_flu.py
+++ b/builds/flu/run_flu.py
@@ -1,26 +1,5 @@
 import os
 
-resolution_to_spacing = {
-    "2y": "1.0",
-    "3y": "1.0",
-    "6y": "2.0",
-    "12y": "3.0"
-}
-
-lineage_to_epitope_mask = {
-    "h3n2": "wolf",
-    "h1n1pdm": "canton",
-    "vic": "None",
-    "yam": "None"
-}
-
-lineage_to_glyc_mask = {
-    "h3n2": "ha1_h3n2",
-    "h1n1pdm": "ha1_globular_head_h1n1pdm",
-    "vic": "None",
-    "yam": "None"
-}
-
 def run_live(
     lineages = None, resolutions = None,
     system="local",
@@ -53,16 +32,12 @@ def run_live(
 
             call = [
                 'flu.process.py',
-                '--json', 'prepared/flu_%s_ha_%s.json'%(lineage, resolution),
-                '--pivot_spacing', resolution_to_spacing[resolution],
-                '--epitope_mask_version', lineage_to_epitope_mask[lineage],
-                '--glyc_mask_version', lineage_to_glyc_mask[lineage]
+                '--json', 'prepared/flu_%s_ha_%s.json'%(lineage, resolution)
             ]
             if process_na:
                 call = [
                     'flu.process.py',
-                    '--json', 'prepared/flu_%s_na_%s.json'%(lineage, resolution),
-                    '--pivot_spacing', resolution_to_spacing[resolution]
+                    '--json', 'prepared/flu_%s_na_%s.json'%(lineage, resolution)
                 ]
             if (system == "qsub"):
                 call = ['qsub', 'submit_script.sh'] + call
@@ -116,7 +91,6 @@ def run_who(
                         call = [
                             'flu.process.py',
                             '--json', 'prepared/flu_%s_%s_ha_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
-                            '--pivot_spacing', resolution_to_spacing[resolution],
                             '--titers_export'
                         ]
 
@@ -124,7 +98,6 @@ def run_who(
                             call = [
                                 'flu.process.py',
                                 '--json', 'prepared/flu_%s_%s_na_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
-                                '--pivot_spacing', resolution_to_spacing[resolution],
                                 '--titers_export'
                             ]
 


### PR DESCRIPTION
@huddlej ---

This PR extends your work in PR #99 (`hotfix-masks`). I created a new `set_config_defaults` method to house these sorts of calls. This currently sets `epitope_mask_version`, `glyc_mask_version` and `pivot_spacing` based on lineage and segment when command line arguments and `None`. I also removed cruft from `run_flu.py`. This seemed to be working for me, but perhaps needs a bit more testing.
