### PR TITLE
Fix issues caused by incorrectly truncating stop codons

### DIFF
--- a/builds/flu/scores.py
+++ b/builds/flu/scores.py
@@ -130,8 +130,7 @@ def calculate_sequence_scores(tree, mask_file, lineage, segment, epitope_mask_ve
     root_total_aa_seq = get_total_peptide(root, segment)
 
     # Confirm that mask and sequence lengths are equal.
-    # assert len(root_total_aa_seq) == len(epitope_mask), "Sequence and mask lengths are not equal: %s != %s." % (len(root_total_aa_seq), len(epitope_mask))
-    # FIXME this is breaking for H1N1pdm
+    assert len(root_total_aa_seq) == len(epitope_mask), "Sequence and mask lengths are not equal: %s != %s." % (len(root_total_aa_seq), len(epitope_mask))
 
     # Setup receptor binding site mask.
     rbs_mask_name = "%s_%s_rbs" % (lineage, segment)


### PR DESCRIPTION
This PR addresses issues with both epitope mask/amino acid sequence length mismatches and incorrectly truncated stop codons.

The new approach is to check for a stop codon in the coding sequence of the reference and then dynamically adjust the end coordinate of any protein with a stop codon. This prevents the stop codon from ever being translated in any sequences downstream.

I have tested this change with H3N2, H1N1pdm, Vic, Yam, and Zika, but this could use additional testing/review by someone with fresh eyes.