### PR TITLE
Flu file stem renaming

### DIFF
--- a/builds/avian/avian.prepare.py
+++ b/builds/avian/avian.prepare.py
@@ -115,7 +115,7 @@ if __name__=="__main__":
         config["file_prefix"] = params.file_prefix
         segment_addendum = False
     else:
-        config["file_prefix"] = "avian_h7n9"
+        config["file_prefix"] = "flu_avian_h7n9"
         segment_addendum = True
 
     config["segments"] = params.segments

--- a/builds/avian/avian.process.py
+++ b/builds/avian/avian.process.py
@@ -12,7 +12,7 @@ def collect_args():
     """
     parser = base.process.collect_args()
     parser.set_defaults(
-        json="prepared/avian_h7n9_ha.json"
+        json="prepared/flu_avian_h7n9_ha.json"
     )
     return parser
 

--- a/builds/avian/run_avian.py
+++ b/builds/avian/run_avian.py
@@ -13,7 +13,7 @@ def build(
     for segment in segments:
         call = [
             'avian.process.py',
-            '--json', 'prepared/avian_h7n9_%s.json'%(segment)]
+            '--json', 'prepared/flu_avian_h7n9_%s.json'%(segment)]
         if (system == "qsub"):
             call = ['qsub', 'submit_script.sh'] + call
         elif (system == "sbatch"):

--- a/builds/avian/run_avian.py
+++ b/builds/avian/run_avian.py
@@ -16,6 +16,9 @@ def build(
             '--json', 'prepared/flu_avian_h7n9_%s.json'%(segment)]
         if (system == "qsub"):
             call = ['qsub', 'submit_script.sh'] + call
+        elif (system == "rhino"):
+            concat = '"' + ' '.join( ['python'] + call ) + '"'
+            call = ['sbatch', '-n', '1', '-c', '2', '--mem', '16192', '--time', '12:00:00', '--wrap', concat]
         elif (system == "sbatch"):
             call = ['python'] + call
             concat = '"' + ' '.join(call) + '"'

--- a/builds/flu/flu.prepare.py
+++ b/builds/flu/flu.prepare.py
@@ -73,7 +73,7 @@ def make_config(lineage, resolution, params):
     if params.file_prefix:
         file_prefix = params.file_prefix
     else:
-        file_prefix = "flu_{}_{}_{}".format(lineage, params.segments[0], resolution) # flu_h3n2_ha_6y
+        file_prefix = "flu_seasonal_{}_{}_{}".format(lineage, params.segments[0], resolution) # flu_seasonal_h3n2_ha_6y
 
     config = {
         "dir": "flu",

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -469,7 +469,7 @@ def plot_titer_matrix_grouped(titer_model, titers, virus_clades=None, serum_clad
         import seaborn as sns
         plt.figure(figsize=(7, 0.6*len(rows)+1))
         if title is not None:
-            title = title.replace("flu_", "").replace("_ha_", "_").replace("_2y_", "_")
+            title = title.replace("flu_seasonal_", "").replace("_ha_", "_").replace("_2y_", "_")
             title = title.replace("h3n2", "H3N2").replace("h1n1pdm", "H1N1pdm").replace("vic", "Vic").replace("yam", "Yam")
             title = title.replace("who", "WHO").replace("cdc", "CDC").replace("crick", "Crick").replace("niid", "NIID").replace("vidrl", "VIDRL")
             title = title.replace("hi", "HI").replace("fra", "FRA")

--- a/builds/flu/run_flu.py
+++ b/builds/flu/run_flu.py
@@ -24,7 +24,7 @@ def run_live(
                     '--segments', " ".join(segments),
                     '--sequences', seq_files,
                     '--titers', '../../../fauna/data/%s_public_hi_cell_titers.tsv'%(lineage),
-                    '--file_prefix', 'flu_%s_*segment*_%s'%(lineage, resolution)]
+                    '--file_prefix', 'flu_seasonal_%s_*segment*_%s'%(lineage, resolution)]
                 if frequencies == "complete":
                     call = call + ['--complete_frequencies']
                 print(' '.join(call))
@@ -32,7 +32,7 @@ def run_live(
 
             call = [
                 'flu.process.py',
-                '--json', 'prepared/flu_%s_ha_%s.json'%(lineage, resolution)
+                '--json', 'prepared/flu_seasonal_%s_ha_%s.json'%(lineage, resolution)
             ]
             if lineage == "h3n2":
                 call = call + ['--annotate_fitness', '--predictors', 'cTiterSub', '--predictors_params', '1.13', '--predictors_sds', '0.72']
@@ -40,7 +40,7 @@ def run_live(
             if process_na:
                 call = [
                     'flu.process.py',
-                    '--json', 'prepared/flu_%s_na_%s.json'%(lineage, resolution)
+                    '--json', 'prepared/flu_seasonal_%s_na_%s.json'%(lineage, resolution)
                 ]
             if (system == "qsub"):
                 call = ['qsub', 'submit_script.sh'] + call
@@ -85,7 +85,7 @@ def run_who(
                                 '--segments', " ".join(segments),
                                 '--sequences', seq_files,
                                 '--titers', '../../../fauna/data/%s_%s_%s_%s_titers.tsv'%(lineage, build, assay, passage),
-                                '--file_prefix', 'flu_%s_%s_*segment*_%s_%s_%s'%(build, lineage, resolution, passage, assay)]
+                                '--file_prefix', 'flu_seasonal_%s_%s_*segment*_%s_%s_%s'%(build, lineage, resolution, passage, assay)]
                             if frequencies == "complete":
                                 call = call + ['--complete_frequencies']
                             print(' '.join(call))
@@ -93,14 +93,14 @@ def run_who(
 
                         call = [
                             'flu.process.py',
-                            '--json', 'prepared/flu_%s_%s_ha_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
+                            '--json', 'prepared/flu_seasonal_%s_%s_ha_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
                             '--titers_export'
                         ]
 
                         if process_na:
                             call = [
                                 'flu.process.py',
-                                '--json', 'prepared/flu_%s_%s_na_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
+                                '--json', 'prepared/flu_seasonal_%s_%s_na_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
                                 '--titers_export'
                             ]
 

--- a/builds/flu/run_flu.py
+++ b/builds/flu/run_flu.py
@@ -85,7 +85,7 @@ def run_who(
                                 '--segments', " ".join(segments),
                                 '--sequences', seq_files,
                                 '--titers', '../../../fauna/data/%s_%s_%s_%s_titers.tsv'%(lineage, build, assay, passage),
-                                '--file_prefix', 'flu_seasonal_%s_%s_*segment*_%s_%s_%s'%(build, lineage, resolution, passage, assay)]
+                                '--file_prefix', 'flu_%s_%s_*segment*_%s_%s_%s'%(build, lineage, resolution, passage, assay)]
                             if frequencies == "complete":
                                 call = call + ['--complete_frequencies']
                             print(' '.join(call))
@@ -93,14 +93,14 @@ def run_who(
 
                         call = [
                             'flu.process.py',
-                            '--json', 'prepared/flu_seasonal_%s_%s_ha_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
+                            '--json', 'prepared/flu_%s_%s_ha_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
                             '--titers_export'
                         ]
 
                         if process_na:
                             call = [
                                 'flu.process.py',
-                                '--json', 'prepared/flu_seasonal_%s_%s_na_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
+                                '--json', 'prepared/flu_%s_%s_na_%s_%s_%s.json'%(build, lineage, resolution, passage, assay),
                                 '--titers_export'
                             ]
 


### PR DESCRIPTION
@huddlej, @jameshadfield, @barneypotter24 and @rneher ---

I've renamed `flu_h3n2_ha_3y` file stem to `flu_seasonal_h3n2_ha_3y` and renamed `avian_h7n9_ha` to `flu_avian_h7n9_ha`. I did this for consistency and future proofing. We're going to want a swine H3N2 at some point. Makes much more sense to put this under a `flu_` umbrella than to have `swine`, `avian`, etc... as base level.

Also, @jameshadfield, I think this works better for your "all flu" builds. I would go with `flu_all` or `flu_historic` for these.

I've updated `manifest_guest.json` in auspice to match. I purposely did not modify WHO flu builds, these are still in the format `flu_who_h3n2_ha_2y_cell_hi`.