### PR TITLE
KDE frequencies

### DIFF
--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -50,8 +50,7 @@ def export_tip_frequency_json(process, prefix, indent):
 
     frequencies = KdeFrequencies.estimate_frequencies_for_tree(
         process.tree.tree,
-        process.pivots,
-        process.info["regions"]
+        process.pivots
     )
 
     for n in process.tree.tree.get_terminals():

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 import sys, os, time, gzip, glob
 from base.io_util import make_dir, remove_dir, tree_to_json, write_json, myopen
+from base.frequencies import KdeFrequencies
 import json
 from pdb import set_trace
 from collections import defaultdict
@@ -40,16 +41,22 @@ def export_frequency_json(process, prefix, indent):
         process.log.notify("Cannot export frequencies - pivots do not exist")
 
 def export_tip_frequency_json(process, prefix, indent):
-    if not (hasattr(process, 'pivots') and hasattr(process, 'tree_frequencies')):
-        process.log.notify("Cannot export tip frequencies - pivots and/or tree_frequencies do not exist")
-        return;
+    if not (hasattr(process, 'pivots') and hasattr(process, 'tree')):
+        process.log.notify("Cannot export tip frequencies - pivots and/or tree do not exist")
+        return
 
-    num_dp = 6;
+    num_dp = 6
     freq_json = {'pivots':process_freqs(process.pivots, num_dp)}
+
+    frequencies = KdeFrequencies.estimate_frequencies_for_tree(
+        process.tree.tree,
+        process.pivots,
+        process.info["regions"]
+    )
 
     for n in process.tree.tree.get_terminals():
         freq_json[n.name] = {
-            "frequencies" : process_freqs(process.tree_frequencies["global"][n.clade], num_dp),
+            "frequencies" : process_freqs(frequencies["global"][n.clade], num_dp),
             "weight": 1.0
         }
 

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -6,7 +6,7 @@ import json
 from pdb import set_trace
 from collections import defaultdict
 
-def process_freqs(frequencies, num_dp):
+def round_freqs(frequencies, num_dp):
     """ round frequency estimates to useful precision (reduces file size) """
     return [round(x, num_dp) for x in frequencies]
 
@@ -15,25 +15,25 @@ def export_frequency_json(process, prefix, indent):
     # construct a json file containing all frequency estimate
     # the format is region_protein:159F for mutations and region_clade:123 for clades
     if hasattr(process, 'pivots'):
-        freq_json = {'pivots':process_freqs(process.pivots, num_dp)}
+        freq_json = {'pivots':round_freqs(process.pivots, num_dp)}
         if hasattr(process, 'mutation_frequencies'):
             freq_json['counts'] = {x:list(counts) for x, counts in process.mutation_frequency_counts.iteritems()}
             for (region, gene), tmp_freqs in process.mutation_frequencies.iteritems():
                 for mut, freq in tmp_freqs.iteritems():
                     label_str =  region+"_"+ gene + ':' + str(mut[0]+1)+mut[1]
-                    freq_json[label_str] = process_freqs(freq, num_dp)
+                    freq_json[label_str] = round_freqs(freq, num_dp)
         # repeat for clade frequencies in trees
         if hasattr(process, 'tree_frequencies'):
             for region in process.tree_frequencies:
                 for clade, freq in process.tree_frequencies[region].iteritems():
                     label_str = region+'_clade:'+str(clade)
-                    freq_json[label_str] = process_freqs(freq, num_dp)
+                    freq_json[label_str] = round_freqs(freq, num_dp)
         # repeat for named clades
         if hasattr(process, 'clades_to_nodes') and hasattr(process, 'tree_frequencies'):
             for region in process.tree_frequencies:
                 for clade, node in process.clades_to_nodes.iteritems():
                     label_str = region+'_'+str(clade)
-                    freq_json[label_str] = process_freqs(process.tree_frequencies[region][node.clade], num_dp)
+                    freq_json[label_str] = round_freqs(process.tree_frequencies[region][node.clade], num_dp)
         # write to one frequency json
         if hasattr(process, 'tree_frequencies') or hasattr(process, 'mutation_frequencies'):
             write_json(freq_json, prefix+'_frequencies.json', indent=indent)
@@ -41,21 +41,16 @@ def export_frequency_json(process, prefix, indent):
         process.log.notify("Cannot export frequencies - pivots do not exist")
 
 def export_tip_frequency_json(process, prefix, indent):
-    if not (hasattr(process, 'pivots') and hasattr(process, 'tree')):
-        process.log.notify("Cannot export tip frequencies - pivots and/or tree do not exist")
+    if not (hasattr(process, 'pivots') and hasattr(process, 'kde_frequencies')):
+        process.log.notify("Cannot export tip frequencies - pivots and/or kde_frequencies do not exist")
         return
 
     num_dp = 6
-    freq_json = {'pivots':process_freqs(process.pivots, num_dp)}
-
-    frequencies = KdeFrequencies.estimate_frequencies_for_tree(
-        process.tree.tree,
-        process.pivots
-    )
+    freq_json = {'pivots':round_freqs(process.pivots, num_dp)}
 
     for n in process.tree.tree.get_terminals():
         freq_json[n.name] = {
-            "frequencies" : process_freqs(frequencies["global"][n.clade], num_dp),
+            "frequencies" : round_freqs(process.kde_frequencies["global"][n.clade], num_dp),
             "weight": 1.0
         }
 

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -622,7 +622,7 @@ class KdeFrequencies(object):
         normalized_freq_matrix = freq_matrix.copy()
 
         # Find columns that can be meaningfully normalized.
-        nonzero_columns = np.where(freq_matrix.sum(axis=0) > 1)[0]
+        nonzero_columns = np.where(freq_matrix.sum(axis=0) > 0)[0]
 
         # Normalize by column.
         normalized_freq_matrix[:, nonzero_columns] = freq_matrix[:, nonzero_columns] / freq_matrix[:, nonzero_columns].sum(axis=0)

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -630,32 +630,21 @@ class KdeFrequencies(object):
         return normalized_freq_matrix
 
     @classmethod
-    def estimate_frequencies(cls, tip_dates, pivots, tip_populations, **kwargs):
+    def estimate_frequencies(cls, tip_dates, pivots, **kwargs):
         """Estimate frequencies of the given observations across the given pivots.
-
-        Initial frequencies are weighted by the size of the population where
-        each observation originated and the resulting weighted values are
-        normalized to sum to 1.
         """
         # Calculate base frequencies from observations.
         freq_matrix = cls.get_frequencies_from_observations(tip_dates, pivots, **kwargs)
 
-        # Weight initial frequencies by region population size.
-        weighted_freq_matrix = freq_matrix * tip_populations
-
         # Normalize frequencies to sum to 1.
-        normalized_freq_matrix = cls.normalize_frequencies(weighted_freq_matrix)
+        normalized_freq_matrix = cls.normalize_frequencies(freq_matrix)
 
         return normalized_freq_matrix
 
     @classmethod
-    def estimate_frequencies_for_tree(cls, tree, pivots, regions, **kwargs):
+    def estimate_frequencies_for_tree(cls, tree, pivots, **kwargs):
         """Estimate global and regional frequencies for all nodes in a tree across the
         given pivots.
-
-        Frequencies are weighted by the population size of the each individual
-        observation's region as defined in the given regions tuple.
-
         """
         # Collect all tips from the given tree and sort by their observation date.
         tips = np.array(sorted([(tip.clade, tip.attr["num_date"], tip.attr["region"])
@@ -664,38 +653,13 @@ class KdeFrequencies(object):
         clades = tips[:, 0].astype(int)
         tip_dates = tips[:, 1].astype(float)
         tip_regions = tips[:, 2]
-
-        # Calculate the total global population size.
-        population_by_region = {region_data[0]: region_data[2] for region_data in regions}
-        total_population = 0
-        for region, population in population_by_region.items():
-            total_population += population
-
-        # Create a vector of population proportions (relative to the total
-        # global population) by tip based on each tip's region.
-        tip_populations = []
-        for region in tip_regions:
-            tip_populations.append(population_by_region[region] / total_population)
-
-        # Reshape vector of population proportions to an N x 1 matrix for N
-        # total observations. This allows each row of the frequency matrix
-        # (i.e., an individual observation's frequencies) to be scaled by the
-        # same value across all time points.
-        tip_populations = np.array(tip_populations).reshape((len(tip_populations), -1))
+        regions = np.unique(tip_regions)
 
         # Map clade ids to their corresponding frequency matrix row index.
         clade_to_index = {clades[i]: i for i in range(len(clades))}
 
-        # Map tips to regions for quick lookup in the frequency matrix.
-        tip_index_by_region = defaultdict(list)
-        for node in tree.get_terminals():
-            tip_index_by_region[node.attr["region"]].append(clade_to_index[node.clade])
-
-        for region in tip_index_by_region:
-            tip_index_by_region[region] = np.array(tip_index_by_region[region])
-
         # Calculate tip frequencies weighted by tip population sizes and then normalized.
-        normalized_freq_matrix = cls.estimate_frequencies(tip_dates, pivots, tip_populations, **kwargs)
+        normalized_freq_matrix = cls.estimate_frequencies(tip_dates, pivots, **kwargs)
 
         # Calculate clade frequencies as the sum of respective tip frequencies
         # both globally and across all regions.
@@ -706,7 +670,7 @@ class KdeFrequencies(object):
                 clade_frequencies["global"][node.clade] = normalized_freq_matrix[clade_to_index[node.clade]]
 
                 # Get regional frequencies.
-                for region in tip_index_by_region:
+                for region in regions:
                     if node.attr["region"] == region:
                         clade_frequencies[region][node.clade] = normalized_freq_matrix[clade_to_index[node.clade]]
                     else:
@@ -715,7 +679,7 @@ class KdeFrequencies(object):
             else:
                 clade_frequencies["global"][node.clade] = np.array([clade_frequencies["global"][child.clade]
                                                                   for child in node.clades]).sum(axis=0)
-                for region in tip_index_by_region:
+                for region in regions:
                     clade_frequencies[region][node.clade] = np.array([clade_frequencies[region][child.clade]
                                                                       for child in node.clades]).sum(axis=0)
 

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -580,7 +580,7 @@ class KdeFrequencies(object):
         pass
 
     @classmethod
-    def get_counts_from_observation(cls, mu, pivots, sigma=3 / 12.0):
+    def get_counts_from_observation(cls, mu, pivots, sigma=1 / 12.0):
         """Build a normal distribution centered across the given floating point date,
         mu, with a standard deviation based on the given sigma value and return
         the probability mass between pivots for each pivot. These mass values

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -616,12 +616,6 @@ class KdeFrequencies(object):
             else:
                 counts, bin_edges = cls.get_counts_from_observation(obs, pivots, **kwargs)
 
-                # Zero out counts from pivots after the given maximum date to
-                # prevent numerical errors associated with normalizing very
-                # small values to 1.
-                if max_date is not None:
-                    counts[pivots > max_date] = 0.0
-
             freq_matrix[i] = counts
 
         return freq_matrix
@@ -633,8 +627,8 @@ class KdeFrequencies(object):
         """
         normalized_freq_matrix = freq_matrix.copy()
 
-        # Find columns that can be divided by their sum.
-        nonzero_columns = np.nonzero(freq_matrix.sum(axis=0))[0]
+        # Find columns that can be meaningfully normalized.
+        nonzero_columns = np.where(freq_matrix.sum(axis=0) > 1)[0]
 
         # Normalize by column.
         normalized_freq_matrix[:, nonzero_columns] = freq_matrix[:, nonzero_columns] / freq_matrix[:, nonzero_columns].sum(axis=0)

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -677,6 +677,10 @@ class KdeFrequencies(object):
         for region in tip_regions:
             tip_populations.append(population_by_region[region] / total_population)
 
+        # Reshape vector of population proportions to an N x 1 matrix for N
+        # total observations. This allows each row of the frequency matrix
+        # (i.e., an individual observation's frequencies) to be scaled by the
+        # same value across all time points.
         tip_populations = np.array(tip_populations).reshape((len(tip_populations), -1))
 
         # Map clade ids to their corresponding frequency matrix row index.

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -683,13 +683,9 @@ class KdeFrequencies(object):
         clade_to_index = {clades[i]: i for i in range(len(clades))}
 
         # Map tips to regions for quick lookup in the frequency matrix.
-        tip_index_by_region = {}
+        tip_index_by_region = defaultdict(list)
         for node in tree.get_terminals():
-            region = node.attr["region"]
-            if not region in tip_index_by_region:
-                tip_index_by_region[region] = []
-
-            tip_index_by_region[region].append(clade_to_index[node.clade])
+            tip_index_by_region[node.attr["region"]].append(clade_to_index[node.clade])
 
         for region in tip_index_by_region:
             tip_index_by_region[region] = np.array(tip_index_by_region[region])

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -580,13 +580,13 @@ class KdeFrequencies(object):
         pass
 
     @classmethod
-    def get_density_for_observation(cls, mu, pivots, sigma=1/12.0):
+    def get_density_for_observation(cls, mu, pivots, sigmaNarrow=1/12.0, sigmaWide=3/12.0, proportionWide=0.0):
         """Build a normal distribution centered across the given floating point date,
         mu, with a standard deviation based on the given sigma value and return
         the probability mass at each pivot. These mass values per pivot will form the
         input for a kernel density estimate across multiple observations.
         """
-        return norm.pdf(pivots, loc=mu, scale=sigma)
+        return (1-proportionWide) * norm.pdf(pivots, loc=mu, scale=sigmaNarrow) + proportionWide * norm.pdf(pivots, loc=mu, scale=sigmaWide)
 
     @classmethod
     def get_densities_for_observations(cls, observations, pivots, max_date=None, **kwargs):

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -580,52 +580,49 @@ class KdeFrequencies(object):
         pass
 
     @classmethod
-    def get_counts_from_observation(cls, mu, pivots, sigma=1 / 12.0):
+    def get_density_for_observation(cls, mu, pivots, sigma=1/12.0):
         """Build a normal distribution centered across the given floating point date,
         mu, with a standard deviation based on the given sigma value and return
-        the probability mass between pivots for each pivot. These mass values
-        per pivot will form the input for a kernel density estimate across
-        multiple observations.
+        the probability mass at each pivot. These mass values per pivot will form the
+        input for a kernel density estimate across multiple observations.
         """
-        dt = pivots[1] - pivots[0]
-        bins = [pivots[0] - 0.5 * dt] + list(pivots + 0.5 * dt)
-        counts = np.diff(norm.cdf(bins, loc=mu, scale=sigma))
-        return counts
+        return norm.pdf(pivots, loc=mu, scale=sigma)
 
     @classmethod
-    def get_frequencies_from_observations(cls, observations, pivots, max_date=None, **kwargs):
-        """Create a matrix of frequencies for one or more observations across the given
+    def get_densities_for_observations(cls, observations, pivots, max_date=None, **kwargs):
+        """Create a matrix of densities for one or more observations across the given
         pivots with one row per observation and one column per pivot.
 
         Observations can be optionally filtered by a maximum date such that all
-        frequencies are estimated to be zero after that date.
+        densities are estimated to be zero after that date.
         """
-        freq_matrix = np.zeros((len(observations), len(pivots)))
+        density_matrix = np.zeros((len(observations), len(pivots)))
         for i, obs in enumerate(observations):
             # If the given observation occurred outside the given pivots or
             # after the given maximum date, do not try to estimate its
             # frequency.
             if (obs < pivots[0] or obs > pivots[-1]) or (max_date is not None and obs > max_date):
-                counts = np.zeros_like(pivots)
+                density = np.zeros_like(pivots)
             else:
-                counts = cls.get_counts_from_observation(obs, pivots, **kwargs)
+                density = cls.get_density_for_observation(obs, pivots, **kwargs)
 
-            freq_matrix[i] = counts
+            density_matrix[i] = density
 
-        return freq_matrix
+        return density_matrix
 
     @classmethod
-    def normalize_frequencies(cls, freq_matrix):
-        """Normalize the values of a given frequency matrix to 1 across all columns
-        (time points) with non-zero sums.
+    def normalize_to_frequencies(cls, density_matrix):
+        """Normalize the values of a given density matrix to 1 across all columns
+        (time points) with non-zero sums. This converts kernal PDF mass into a
+        frequency estimate.
         """
-        normalized_freq_matrix = freq_matrix.copy()
+        normalized_freq_matrix = density_matrix.copy()
 
         # Find columns that can be meaningfully normalized.
-        nonzero_columns = np.where(freq_matrix.sum(axis=0) > 0)[0]
+        nonzero_columns = np.where(density_matrix.sum(axis=0) > 0)[0]
 
         # Normalize by column.
-        normalized_freq_matrix[:, nonzero_columns] = freq_matrix[:, nonzero_columns] / freq_matrix[:, nonzero_columns].sum(axis=0)
+        normalized_freq_matrix[:, nonzero_columns] = density_matrix[:, nonzero_columns] / density_matrix[:, nonzero_columns].sum(axis=0)
 
         return normalized_freq_matrix
 
@@ -634,10 +631,10 @@ class KdeFrequencies(object):
         """Estimate frequencies of the given observations across the given pivots.
         """
         # Calculate base frequencies from observations.
-        freq_matrix = cls.get_frequencies_from_observations(tip_dates, pivots, **kwargs)
+        density_matrix = cls.get_densities_for_observations(tip_dates, pivots, **kwargs)
 
         # Normalize frequencies to sum to 1.
-        normalized_freq_matrix = cls.normalize_frequencies(freq_matrix)
+        normalized_freq_matrix = cls.normalize_to_frequencies(density_matrix)
 
         return normalized_freq_matrix
 

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -616,8 +616,8 @@ class KdeFrequencies(object):
 
     @classmethod
     def normalize_frequencies(cls, freq_matrix):
-        """Normalize the values of a given frequency matrix to 1 across all columns with
-        non-zero sums.
+        """Normalize the values of a given frequency matrix to 1 across all columns
+        (time points) with non-zero sums.
         """
         normalized_freq_matrix = freq_matrix.copy()
 

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -595,7 +595,7 @@ class KdeFrequencies(object):
     @classmethod
     def get_frequencies_from_observations(cls, observations, pivots, max_date=None, **kwargs):
         """Create a matrix of frequencies for one or more observations across the given
-        pivots.
+        pivots with one row per observation and one column per pivot.
 
         Observations can be optionally filtered by a maximum date such that all
         frequencies are estimated to be zero after that date.

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -7,6 +7,7 @@ from base.fitness_model import process_predictor_args
 from base.process import process
 from base.utils import fix_names
 from base.io_util import write_json
+from base.frequencies import KdeFrequencies
 from flu_titers import HI_model, HI_export, vaccine_distance
 from scores import calculate_sequence_scores, calculate_metadata_scores, calculate_phylogenetic_scores
 from flu_info import clade_designations, lineage_to_epitope_mask, lineage_to_glyc_mask, resolution_to_pivot_spacing, vaccine_choices
@@ -24,6 +25,7 @@ def parse_args():
 
     parser.add_argument('--no_mut_freqs', default=False, action='store_true', help="skip mutation frequencies")
     parser.add_argument('--no_tree_freqs', default=False, action='store_true', help="skip tree (clade) frequencies")
+    parser.add_argument('--no_kde_freqs', default=False, action='store_true', help="skip KDE tip frequencies")
     parser.add_argument('--pivot_spacing', type=float, help="month per pivot")
     parser.add_argument('--titers_export', default=False, action='store_true', help="export titers.json file")
     parser.add_argument('--annotate_fitness', default=False, action='store_true', help="run fitness prediction model and annotate fitnesses on tree nodes")
@@ -74,6 +76,7 @@ def make_config(prepared_json, args):
         "build_tree": not args.no_tree,
         "estimate_mutation_frequencies": not args.no_mut_freqs,
         "estimate_tree_frequencies": not args.no_tree_freqs,
+        "estimate_kde_frequencies": not args.no_kde_freqs,
         "ha_masks": "metadata/ha_masks.tsv",
         "epitope_mask_version": args.epitope_mask_version,
         "tolerance_mask_version": args.tolerance_mask_version,
@@ -531,12 +534,20 @@ if __name__=="__main__":
         runner.timetree_setup_filter_run()
         runner.run_geo_inference()
 
-        # estimate tree frequencies here.
+        # estimate tree frequencies
         if runner.config["estimate_tree_frequencies"]:
             pivots = runner.get_pivots_via_spacing()
             runner.estimate_tree_frequencies(pivots=pivots)
             for regionTuple in runner.info["regions"]:
                 runner.estimate_tree_frequencies(region=str(regionTuple[0]))
+
+        # estimate KDE tip frequencies
+        if runner.config["estimate_kde_frequencies"]:
+            runner.pivots = runner.get_pivots_via_spacing()
+            runner.kde_frequencies = KdeFrequencies.estimate_frequencies_for_tree(
+                runner.tree.tree,
+                runner.pivots
+            )
 
         if runner.info["segment"]=='ha':
             if runner.info["lineage"]=='h3n2':


### PR DESCRIPTION
This PR adds code to calculate clade frequencies using a KDE-style approach. The new `KdeFrequencies` class creates a normal distribution for each tip in a given tree centered on the tip's collection date with a fixed standard deviation provided by the user. Tip frequencies are calculated by discretizing the normal distributions into discrete windows of time (pivots), weighting the resulting frequencies by the population size of each tip's region, and normalizing the resulting values to sum to 1.

The `KdeFrequencies` class provides a class method that can estimate frequencies from a tree like so:

```python
clade_frequencies = KdeFrequencies.estimate_frequencies_for_tree(
    tree,
    pivots,
    regions,
    sigma=3/12.0,
    max_date=None
)
```

A maximum date (float) can be passed to the method to censor all observations after that date from the frequency calculations. The following figure shows frequency trajectories for three large clades with all values after 2017 censored. The solid blue lines show the original top-down (nested) frequency estimations. The orange dots show the new bottom-up (KDE) estimations. The triangles along the x-axis shown individual observations with those prior to the max date in black and those afterwards in yellow. The trajectory for clade 3457 is able to extend past the max date threshold in 2017 because the normal distributions of the prior observations have non-zero values past that threshold.

![image](https://user-images.githubusercontent.com/85372/40148005-bcf4da06-5920-11e8-962c-4a6e01a34171.png)

This PR does not complete address region-specific frequencies. Currently these frequencies are calculated but they are not normalized to sum to 1 within a region.