### PR TITLE
Calculate global KDE frequencies via weighted regional frequencies

### DIFF
--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -701,7 +701,12 @@ class KdeFrequencies(object):
                 clade_frequencies[region][clade] = normalized_freq_matrix_regional[clade_to_index[clade]]
 
         for node in tree.find_clades(order="postorder"):
-            if not node.is_terminal():
+            if node.is_terminal():
+                # Set regional frequencies for tips from different regions to zero.
+                for region in regions:
+                    if not node.clade in clade_frequencies[region]:
+                        clade_frequencies[region][node.clade] = np.zeros_like(pivots)
+            else:
                 clade_frequencies["global"][node.clade] = np.array(
                     [clade_frequencies["global"][child.clade] for child in node.clades]
                 ).sum(axis=0)

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -544,9 +544,11 @@ if __name__=="__main__":
         # estimate KDE tip frequencies
         if runner.config["estimate_kde_frequencies"]:
             runner.pivots = runner.get_pivots_via_spacing()
-            runner.kde_frequencies = KdeFrequencies.estimate_frequencies_for_tree(
+            runner.kde_frequencies = KdeFrequencies.estimate_region_weighted_frequencies_for_tree(
                 runner.tree.tree,
-                runner.pivots
+                runner.pivots,
+                [el[0] for el in runner.info["regions"]],
+                [el[2] for el in runner.info["regions"]]
             )
 
         if runner.info["segment"]=='ha':

--- a/builds/flu/flu_info.py
+++ b/builds/flu/flu_info.py
@@ -5,20 +5,19 @@ It lives in a seperate file simply to make flu.prepare.py less cluttered
 
 segments = ["pb2", "pb1", "pa", "ha", "np", "na", "mp", "ns"]
 
-# regions is list of tuples (region, acronym, popsize)
+# regions is list of tuples (region, acronym, popsize in billions)
 # acronym = "" means ignore for frequency calcs
 regions = [
-    ('africa',            "", 1.216e9),
-    ('europe',            "EU", 0.739e9),
-    ('north_america',     "NA", 0.58e9),
-    ('china',             "AS", 1.4e9),
-    ('south_asia',        "AS", 1.75e9),
-    ('japan_korea',       "AS", 0.2e9),
-    ('south_pacific',     "OC", 0.002e9),
-    ('oceania',           "OC", 0.038e9),
-    ('south_america',     "", 0.422e9),
-    ('southeast_asia',    "AS", 0.618e9),
-    ('west_asia',         "AS", 0.245e9)
+    ('africa',            "",   1.02),
+    ('europe',            "EU", 0.74),
+    ('north_america',     "NA", 0.54),
+    ('china',             "AS", 1.36),
+    ('south_asia',        "AS", 1.45),
+    ('japan_korea',       "AS", 0.20),
+    ('oceania',           "OC", 0.04),
+    ('south_america',     "",   0.41),
+    ('southeast_asia',    "AS", 0.62),
+    ('west_asia',         "AS", 0.75)
 ]
 
 outliers = {


### PR DESCRIPTION
This PR switches calculation of `tip-frequencies` to be explicitly region weighted rather than relying on subsampling to do this approximately. In this case, I start by calculating normalized frequencies for samples within a single region. For example, here is China:

<img width="928" alt="china-only" src="https://user-images.githubusercontent.com/1176109/40323133-5e6ffc96-5ce9-11e8-8a3c-4904cfaa829e.png">

And here is Europe:

<img width="935" alt="europe" src="https://user-images.githubusercontent.com/1176109/40323141-6661400e-5ce9-11e8-8d3a-5d93dae767f5.png">

These regional frequencies are then combined to give global frequencies. When combining, each region is weighted according to population size. This method is exactly what we [had been doing for mutation frequencies](https://github.com/nextstrain/augur/blob/master/base/process.py#L347). Without doing this weighting recent samples are heavily skewed to US and Europe, like so:

<img width="936" alt="regions_old" src="https://user-images.githubusercontent.com/1176109/40323503-6a05082a-5cea-11e8-99c7-a67bab69cecf.png">

With this weighting in place, regions are completely flat through time:

<img width="937" alt="regions_new" src="https://user-images.githubusercontent.com/1176109/40323518-764671d2-5cea-11e8-953c-0a64e5b49aeb.png">

Previously on `master`, we had A2 dominating recent global frequencies like so:

<img width="935" alt="clades_old" src="https://user-images.githubusercontent.com/1176109/40323615-c0aae74e-5cea-11e8-8477-f2ecb571ef39.png">

However, there is no evidence of this from outside the US and Europe. With `region-weights` we have:

<img width="935" alt="clades_new" src="https://user-images.githubusercontent.com/1176109/40323668-f799f646-5cea-11e8-949f-d905f21d66f5.png">

You'll see that back before 2017.8 estimates are pretty similar, but diverge after 2017.8 due to sampling effects.

I prefer the more conservative globally weighted frequencies. Live https://nextstrain.org/flu/seasonal/h3n2/ha/2y shows current `master` while staging https://nextstrain.org/flu/seasonal/h3n2/ha/2y shows `region-weights`.