### PR TITLE
tree.py now works with VCF-input

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -1,6 +1,8 @@
 import os, shutil, time
 from Bio import Phylo
 from .utils import read_metadata, get_numerical_dates, write_json
+from treetime.vcf_utils import read_vcf, write_vcf
+import numpy as np
 
 def build_raxml(aln_file, out_file, clean_up=True, nthreads=2):
     '''
@@ -94,15 +96,21 @@ def build_iqtree(aln_file, out_file, iqmodel="HKY+F", clean_up=True, nthreads=2)
 
 
 def timetree(tree=None, aln=None, ref=None, dates=None, keeproot=False, branch_length_mode='auto',
-             confidence=False, resolve_polytomies=True, max_iter=2, dateLimits=None,
+             confidence=False, resolve_polytomies=True, max_iter=2, 
              infer_gtr=True, Tc=0.01, reroot='best', use_marginal=False, fixed_pi=None,
              clock_rate=None, n_iqd=None, **kwarks):
     from treetime import TreeTime
 
-    dL_int = None
-    if dateLimits:
-        dL_int = [int(x) for x in dateLimits]
-        dL_int.sort()
+    if ref != None: #if VCF, fix pi
+        #Otherwise mutation TO gaps is overestimated b/c of seq length
+        fixed_pi = [ref.count(base)/len(ref) for base in ['A','C','G','T','-']]
+        if fixed_pi[-1] == 0:
+            fixed_pi[-1] = 0.05
+            fixed_pi = [v-0.01 for v in fixed_pi]
+        
+        #set this explicitly, as informative-site only trees can have big branch lengths,
+        #making this set incorrectly in TreeTime
+        branch_length_mode = 'joint'
 
     #send ref, if is None, does no harm
     tt = TreeTime(tree=tree, aln=aln, ref=ref, dates=dates,
@@ -145,15 +153,16 @@ def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
 
     return tt
 
-def prep_tree(T, attributes):
+def prep_tree(T, attributes, is_vcf=False):
     data = {}
+    inc = 1 if is_vcf else 0 #convert python numbering to start-at-1
     for n in T.find_clades():
         data[n.name] = {attr:n.__getattribute__(attr)
                         for attr in attributes if hasattr(n,attr)}
     if 'mutations' in attributes:
         for n in T.find_clades():
-            data[n.name]['mutations'] = [[a,int(pos),d] for a,pos,d in data[n.name]['mutations']]
-    if 'sequence' in attributes:
+            data[n.name]['mutations'] = [[a,int(pos)+inc,d] for a,pos,d in data[n.name]['mutations']]
+    if not is_vcf and 'sequence' in attributes: #don't attach sequence if VCF!
         for n in T.find_clades():
             if hasattr(n, 'sequence'):
                 data[n.name]['sequence'] = ''.join(n.sequence)
@@ -162,11 +171,81 @@ def prep_tree(T, attributes):
 
     return data
 
+def write_out_informative_fasta(compress_seq, alignment, stripFile=None):
+    from Bio import SeqIO
+    from Bio.SeqRecord import SeqRecord
+    from Bio.Seq import Seq
+
+    sequences = compress_seq['sequences']
+    ref = compress_seq['reference']
+    positions = compress_seq['positions']
+
+    #If want to exclude sites from initial treebuild, read in here
+    #IF FIND STANDARDIZED DRM FILE FORMAT, IMPLEMENT HERE
+    strip_pos = []
+    if stripFile:
+        with open(stripFile, 'r') as ifile:
+            strip_pos = [int(line.strip()) for line in ifile]
+
+    #Get sequence names
+    seqNames = list(sequences.keys())
+
+    #Check non-ref sites to see if informative
+    printPositionMap = False    #If true, prints file mapping Fasta position to real position
+    sites = []
+    pos = []
+
+    for key in positions:
+        if key not in strip_pos:
+            pattern = []
+            for k in sequences.keys():
+                #looping try/except is faster than list comprehension
+                try:
+                    pattern.append(sequences[k][key])
+                except KeyError:
+                    pattern.append(ref[key])
+            origPattern = list(pattern)
+            if '-' in pattern or 'N' in pattern:
+                #remove gaps/Ns to see if otherwise informative
+                pattern = [value for value in origPattern if value != '-' and value != 'N']
+            un = np.unique(pattern, return_counts=True)
+            #If not all - or N, not all same base, and >1 differing base, append
+            if len(un[0])!=0 and len(un[0])!=1 and not (len(un[0])==2 and min(un[1])==1):
+                sites.append(origPattern)
+                pos.append("\t".join([str(len(pos)+1),str(key)]))
+
+    #Rotate and convert to SeqRecord
+    sites = np.asarray(sites)
+    align = np.rot90(sites)
+    seqNamesCorr = list(reversed(seqNames))
+    toFasta = [ SeqRecord(id=seqNamesCorr[i], seq=Seq("".join(align[i])), description='') for i in range(len(sequences.keys()))]
+
+    fasta_file = '/'.join(alignment.split('/')[:-1]) + '/informative_sites.fasta'
+
+    #now output this as fasta to read into raxml or iqtree
+    SeqIO.write(toFasta, fasta_file, 'fasta')
+
+    #If want a position map, print:
+    if printPositionMap:
+        with open(fasta_file+".positions.txt", 'w') as the_file:
+            the_file.write("\n".join(pos))
+
+    return fasta_file
+
 
 def run(args):
-    # check alignment type, construct reduced alignment if needed
-    if any([args.alignment.endswith(x) for x in ['.vcf', '.vcf.gz']]):
-        aln = "make alignment from VCF"
+    # check alignment type, set flags, read in if VCF
+    is_vcf = False
+    ref = None
+    if any([args.alignment.lower().endswith(x) for x in ['.vcf', '.vcf.gz']]):
+        if not args.vcf_reference:
+            print("ERROR: a reference Fasta is required with VCF-format alignments")
+            return -1
+        compress_seq = read_vcf(args.alignment, args.vcf_reference)
+        sequences = compress_seq['sequences']
+        ref = compress_seq['reference']
+        is_vcf = True
+        aln = sequences
     else:
         aln = args.alignment
 
@@ -195,33 +274,48 @@ def run(args):
 
     # without tree, attempt to build tree
     if T is None:
+        # construct reduced alignment if needed
+        if is_vcf:
+            variable_fasta = write_out_informative_fasta(compress_seq, args.alignment, stripFile=args.strip_sites)
+            fasta = variable_fasta
+        else:
+            fasta = aln
+
         if args.iqmodel and not args.method=='iqtree':
             print("Cannot specify model unless using IQTree. Model specification ignored.")
 
         tree_meta['topology method'] = args.method
         if args.method=='raxml':
-            T = build_raxml(aln, tree_fname, args.nthreads)
+            T = build_raxml(fasta, tree_fname, args.nthreads)
         elif args.method=='iqtree':
-            T = build_iqtree(aln, tree_fname, args.iqmodel, args.nthreads)
+            T = build_iqtree(fasta, tree_fname, args.iqmodel, args.nthreads)
         else: #use fasttree - if add more options, put another check here
-            T = build_fasttree(aln, tree_fname)
+            T = build_fasttree(fasta, tree_fname)
         end = time.time()
         print("Building original tree took {} seconds".format(str(end-start)))
+
+        if is_vcf and not args.keep_vcf_fasta:
+            os.remove(variable_fasta)
 
     if args.timetree and T:
         if args.metadata is None:
             print("ERROR: meta data with dates is required for time tree reconstruction")
             return -1
         metadata, columns = read_metadata(args.metadata)
-        dates = get_numerical_dates(metadata, fmt=args.date_fmt)
+        if args.year_limit: 
+            args.year_limit.sort()
+        dates = get_numerical_dates(metadata, fmt=args.date_fmt, min_max_year=args.year_limit)
 
-        tt = timetree(tree=T, aln=aln, dates=dates, confidence=args.date_confidence,
-                      reroot=args.root if args.root else 'best',
+        tt = timetree(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
+                      reroot=args.root if args.root else 'best', 
                       clock_rate=args.clock_rate, n_iqd=args.n_iqd)
+
         tree_meta['clock'] = {'rate':tt.date2dist.clock_rate,
                               'intercept':tt.date2dist.intercept,
                               'rtt_Tmrca':-tt.date2dist.intercept/tt.date2dist.clock_rate}
-        attributes.extend(['numdate', 'clock_length', 'mutation_length', 'mutations', 'sequence'])
+        attributes.extend(['numdate', 'clock_length', 'mutation_length', 'mutations'])
+        if not is_vcf:
+            attributes.extend(['sequence']) #don't add sequences if VCF - huge!
         if args.date_confidence:
             attributes.append('num_date_confidence')
     elif args.ancestral in ['joint', 'marginal']:
@@ -231,11 +325,16 @@ def run(args):
     else:
         tt = None
 
-    tree_meta['nodes'] = prep_tree(T, attributes)
+    if is_vcf:
+        #TreeTime overwrites ambig sites on tips during ancestral reconst.
+        #Put these back in tip sequences now, to avoid misleading
+        tt.recover_var_ambigs()
+
+    tree_meta['nodes'] = prep_tree(T, attributes, is_vcf)
 
     if T:
         import json
-        tree_success = Phylo.write(T, tree_fname, 'newick')
+        tree_success = Phylo.write(T, tree_fname, 'newick', format_branch_length='%1.8f')
         if args.timetree or args.ancestral in ['joint', 'marginal']:
             if args.node_data:
                 node_data_fname = args.node_data
@@ -246,6 +345,14 @@ def run(args):
                 meta_success = json.dump(tree_meta, ofile)
         else:
             meta_success=True
+
+    #If VCF and ancestral reconst. was done, output VCF including new ancestral seqs
+    if is_vcf and (args.ancestral or args.treetime):
+        if args.output_vcf:
+            vcf_fname = args.output_vcf
+        else:
+            vcf_fname = '.'.join(args.alignment.split('.')[:-1]) + '.vcf'
+        write_vcf(tt.get_tree_dict(keep_var_ambigs=True), vcf_fname)
 
         return 0 if (tree_success and meta_success) else -1
     else:

--- a/bin/augur
+++ b/bin/augur
@@ -30,7 +30,7 @@ if __name__=="__main__":
     align_parser.add_argument('--cat', nargs='+', help="categories with respect to subsample")
     align_parser.add_argument('--output', help="output file")
     align_parser.set_defaults(func=filter.run)
-    
+
     ### MASK.PY -- mask specified sites from a VCF file
     align_parser = subparsers.add_parser('mask', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     align_parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF format")
@@ -73,7 +73,7 @@ if __name__=="__main__":
                              'interquartile ranges from the root-to-tip vs time regression')
     tree_parser.add_argument('--nthreads', type=int, default=2,
                              help="number of threads used")
-    tree_parser.add_argument('--vcf_reference', type=str, help='fasta file of the sequence the VCF was mapped to')                         
+    tree_parser.add_argument('--vcf_reference', type=str, help='fasta file of the sequence the VCF was mapped to')
     tree_parser.add_argument('--keep_vcf_fasta', action="store_true", help='do not delete informative-site fasta created when '
                              'making tree from VCF input')
     tree_parser.add_argument('--strip_sites', type=str, help='file name of sites to exclude for raw tree building (VCF only)')
@@ -92,6 +92,10 @@ if __name__=="__main__":
     translate_parser.add_argument('--alignment_output', type=str, help="write the alignment of each gene to file,"
                                   "specify the file name like so: 'my_alignment_GENE.fasta' where 'GENE'"
                                    "will be replaced by the name of the gene")
+    translate_parser.add_argument('--vcf_input', type=str, help='VCF file with original and ancestral sequences')
+    translate_parser.add_argument('--vcf_reference', type=str, help='fasta file of the sequence the VCF was mapped to')
+    translate_parser.add_argument('--vcf_output', type=str, help='write a faux-VCF alignment of the translations to a file.'
+                                   'a corresponding fasta reference will be generated')
     translate_parser.set_defaults(func=translate.run)
 
     ## TRAITS.PY

--- a/bin/augur
+++ b/bin/augur
@@ -55,11 +55,11 @@ if __name__=="__main__":
     tree_parser = subparsers.add_parser('tree', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     tree_parser.add_argument('--alignment', required=True, help="alignment to build tree from")
     tree_parser.add_argument('--method', default='iqtree', choices=["fasttree", "raxml", "iqtree"], help="tree builder to use")
-    tree_parser.add_argument('--tree', help="prebuild newick -- no tree will be build if provided")
+    tree_parser.add_argument('--tree', help="prebuilt newick -- no tree will be built if provided")
     tree_parser.add_argument('--metadata', type=str, help="tsv/csv table with meta data for sequences")
     tree_parser.add_argument('--timetree', action="store_true", help="produce timetree using treetime")
     tree_parser.add_argument('--clock_rate', type=float, help="fixed clock rate")
-    tree_parser.add_argument('--root', type=str, help="root or rooting mechanism")
+    tree_parser.add_argument('--root', type=str, help="root or rooting mechanism ('best' (default), 'rsq', 'min_dev')")
     tree_parser.add_argument('--date_fmt', default="%Y-%m-%d", help="date format")
     tree_parser.add_argument('--date_confidence', action="store_true", help="calculate confidence intervals for node dates")
     tree_parser.add_argument('--ancestral', default="None", choices=["joint", "marginal", "None"],
@@ -72,7 +72,13 @@ if __name__=="__main__":
     tree_parser.add_argument('--n_iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
                              'interquartile ranges from the root-to-tip vs time regression')
     tree_parser.add_argument('--nthreads', type=int, default=2,
-                             help="number of threads used by mafft")
+                             help="number of threads used")
+    tree_parser.add_argument('--vcf_reference', type=str, help='fasta file of the sequence the VCF was mapped to')                         
+    tree_parser.add_argument('--keep_vcf_fasta', action="store_true", help='do not delete informative-site fasta created when '
+                             'making tree from VCF input')
+    tree_parser.add_argument('--strip_sites', type=str, help='file name of sites to exclude for raw tree building (VCF only)')
+    tree_parser.add_argument('--output_vcf', type=str, help='name of output VCF file which will include ancestral seqs, if treetime or ancestral is run')
+    tree_parser.add_argument('--year_limit', type=int, nargs='+', help='specify min or max & min years for samples with XX in year')
     tree_parser.set_defaults(func=tree.run)
 
     ## TRANSLATE.PY

--- a/builds/tb/Snakefile
+++ b/builds/tb/Snakefile
@@ -1,22 +1,63 @@
+rule data:
+    input:
+        seq = "data/lee_2015.vcf.gz",
+        meta = "data/meta.tsv",
+        exclude = "data/dropped_strains.txt",
+        mask = "data/Locus_to_exclude_Mtb.bed",
+        ref = "data/ref.fasta",
+        drms = "data/DRMs.txt",
+        sites = "data/drm_sites.txt"
+    params:
+        method = 'iqtree'
+
 rule filter:
 	input:
-		seq = "data/lee_2015.vcf.gz",
-		meta = "data/meta.tsv",
-		exclude = "data/dropped_strains.txt"
+		seq = rules.data.input.seq,
+		meta = rules.data.input.meta,
+		exclude = rules.data.input.exclude
 	output:
 		"results/filtered.vcf.gz"
 	params:
 		vpc = 30,
 		cat = "year month"
 	shell:
-        "augur filter --sequences {input.seq} --output {output} --min_date 1992 --metadata {input.meta} --viruses_per_cat {params.vpc} --exclude {input.exclude} --cat {params.cat}"
+		"augur filter --sequences {input.seq} --output {output} --metadata {input.meta} --exclude {input.exclude}"
 
 rule mask:
     input:
-        seq = "results/filtered.vcf.gz",
-        mask = "data/Locus_to_exclude_Mtb.bed"
+        seq = rules.filter.output,
+        mask = rules.data.input.mask
     output:
-       "results/masked.vcf"
+       "results/masked.vcf.gz"
     shell:
         "augur mask --sequences {input.seq} --output {output} --mask {input.mask}"
-   
+
+rule tree:
+    input:
+        aln = rules.mask.output,
+        ref = rules.data.input.ref,
+        sites = rules.data.input.sites
+    output:
+        "results/tree_raw.nwk"
+    params:
+        method = rules.data.params.method
+    shell:
+        'augur tree --keep_vcf_fasta --strip_sites {input.sites} --alignment {input.aln} --vcf_reference {input.ref} --output {output} --method {params.method}'
+        
+rule timetree:
+	input:
+		aln = rules.mask.output,
+        ref = rules.data.input.ref,
+		metadata = rules.data.input.meta,
+		tree = rules.tree.output
+	output:
+		tree = "results/tree.nwk",
+		node_data = "results/node_data.json",
+		vcf = "results/treetime.vcf"
+	params:
+		root = 'residual'
+	shell:
+		'augur tree --alignment {input.aln} --tree {input.tree} --metadata {input.metadata}'
+		' --output {output.tree} --node_data {output.node_data} --vcf_reference {input.ref}'
+		' --timetree --root {params.root} --output_vcf {output.vcf} --year_limit 2016 2000'  
+

--- a/builds/tb/Snakefile
+++ b/builds/tb/Snakefile
@@ -6,7 +6,9 @@ rule data:
         mask = "data/Locus_to_exclude_Mtb.bed",
         ref = "data/ref.fasta",
         drms = "data/DRMs.txt",
-        sites = "data/drm_sites.txt"
+        sites = "data/drm_sites.txt",
+        generef = "data/Mtb_H37Rv_NCBI_Annot.gff",
+        genes = "data/genes.txt"
     params:
         method = 'iqtree'
 
@@ -43,7 +45,7 @@ rule tree:
         method = rules.data.params.method
     shell:
         'augur tree --keep_vcf_fasta --strip_sites {input.sites} --alignment {input.aln} --vcf_reference {input.ref} --output {output} --method {params.method}'
-        
+
 rule timetree:
 	input:
 		aln = rules.mask.output,
@@ -59,5 +61,22 @@ rule timetree:
 	shell:
 		'augur tree --alignment {input.aln} --tree {input.tree} --metadata {input.metadata}'
 		' --output {output.tree} --node_data {output.node_data} --vcf_reference {input.ref}'
-		' --timetree --root {params.root} --output_vcf {output.vcf} --year_limit 2016 2000'  
+		' --timetree --root {params.root} --output_vcf {output.vcf} --year_limit 2016 2000'
+
+rule translate:
+	input:
+		tree = rules.timetree.output.tree,
+		ref = rules.data.input.ref,
+		gene_ref = rules.data.input.generef,
+		vcf = rules.timetree.output.vcf,
+		genes = rules.data.input.genes
+	output:
+		aa_data = "results/aa_muts.json",
+		vcf_out = "results/translations.vcf"
+	shell:
+		'augur translate --tree {input.tree} --genes {input.genes} --vcf_reference {input.ref}'
+		' --vcf_input {input.vcf} --output {output.aa_data} --reference_sequence {input.gene_ref}'
+		' --vcf_output {output.vcf_out}'
+
+
 


### PR DESCRIPTION
Introduces a few more arguments to `augur` in `tree.py`:

`--vcf_reference`
The Fasta file the VCF input is mapped to

`--keep_vcf_fasta`
For tree-building, a Fasta containing only informative sites is created and sent to the tree-builder. This true/false flag allows users to specify they don't want this intermediate file deleted

`--strip_sites`
This is used to strip DRM sites from initial tree-building for TB in VCF-input, but should be expanded to be usable on Fasta-input as well. Sites are only excluded from initial tree-building (to avoid impact on topology), not TreeTime/ancestral reconstruction (as reconstructing ancestral drug susceptibility/resistance could be of interest). 

`--output_vcf` 
In Fasta-input, sequences (including reconstructed) are stored in the `.json` file, but this isn't very practical for VCF-input, so a new VCF-style file is created.

`--year_limit`
Some TB samples don't even have a year, and letting TreeTime pick any date can lead to strange outcomes. This lets user set min or min & max year of sampling for sequences with years ending in XX (ex: 19XX or 20XX). 