### PR TITLE
Edits to treetime_wrapper.py Ancestral and Rooting

### DIFF
--- a/augur/treetime_wrapper.py
+++ b/augur/treetime_wrapper.py
@@ -6,9 +6,12 @@ import numpy as np
 
 def timetree(tree=None, aln=None, ref=None, dates=None, keeproot=False, branch_length_mode='auto',
              confidence=False, resolve_polytomies=True, max_iter=2,
-             infer_gtr=True, Tc=0.01, reroot='best', use_marginal=False, fixed_pi=None,
+             infer_gtr=True, Tc=0.01, reroot=None, use_marginal=False, fixed_pi=None,
              clock_rate=None, n_iqd=None, verbosity=1, **kwarks):
     from treetime import TreeTime
+
+    if reroot is None:
+        keeproot = True #though this isn't used anywhere
 
     if ref != None: #if VCF, fix pi
         #Otherwise mutation TO gaps is overestimated b/c of seq length
@@ -145,8 +148,11 @@ def run(args):
             if n.name in metadata and 'date' in metadata[n.name]:
                 n.raw_date = metadata[n.name]['date']
 
+        if args.root and len(args.root) == 1: #if anything but a list of seqs, don't send as a list
+            args.root = args.root[0]
+
         tt = timetree(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
-                      reroot=args.root or 'best',
+                      reroot=args.root, #or 'best',
                       Tc=args.coalescent or 0.01,
                       use_marginal = args.time_marginal or False,
                       branch_length_mode = args.branch_length_mode or 'auto',

--- a/augur/treetime_wrapper.py
+++ b/augur/treetime_wrapper.py
@@ -52,10 +52,13 @@ def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
     from treetime import TreeAnc
     tt = TreeAnc(tree=tree, aln=aln, ref=ref, gtr='JC69', verbose=1)
 
+    #convert marginal (from args.ancestral) from 'joint' or 'marginal' to True or False
+    bool_marginal = True if marginal == "marginal" else False
+
     if optimize_branch_length:
-        tt.optimize_seq_and_branch_len(infer_gtr=infer_gtr, marginal=marginal)
+        tt.optimize_seq_and_branch_len(infer_gtr=infer_gtr, marginal_sequences=bool_marginal)
     else: # only infer ancestral sequences, leave branch length untouched
-        tt.infer_ancestral_sequences(infer_gtr=infer_gtr, marginal=marginal)
+        tt.infer_ancestral_sequences(infer_gtr=infer_gtr, marginal=bool_marginal)
 
     print("\nInferred ancestral sequence states using TreeTime:"
           "\n\tSagulenko et al. TreeTime: Maximum-likelihood phylodynamic analysis"
@@ -158,9 +161,11 @@ def run(args):
         if args.date_confidence:
             attributes.append('num_date_confidence')
     elif args.ancestral in ['joint', 'marginal']:
-        tt = ancestral_sequence_inference(tree=T, aln=aln, marginal=args.ancestral,
-                                          optimize_branch_length=args.branchlengths=='div')
-        attributes.extend(['mutation_length', 'mutations', 'sequence'])
+        tt = ancestral_sequence_inference(tree=T, aln=aln, ref=ref, marginal=args.ancestral,
+                                          optimize_branch_length=args.branchlengths)
+        attributes.extend(['mutation_length', 'mutations'])
+        if not is_vcf:
+            attributes.extend(['sequence']) #don't add sequences if VCF - huge!
     else:
         from treetime import TreeAnc
         # instantiate treetime for the sole reason to name internal nodes

--- a/bin/augur
+++ b/bin/augur
@@ -82,12 +82,14 @@ if __name__=="__main__":
     tt_parser.add_argument('--timetree', action="store_true", help="produce timetree using treetime")
     tt_parser.add_argument('--coalescent', help="coalescent time scale in units of inverse clock rate (float), optimize as scalar ('opt'), or skyline ('skyline')")
     tt_parser.add_argument('--clock_rate', type=float, help="fixed clock rate")
-    tt_parser.add_argument('--root', type=str, choices = ['best', 'residual', 'rsq', 'min_dev'], help="root or rooting mechanism ('best' (default), 'residual', 'rsq', 'min_dev')")
+    tt_parser.add_argument('--root', nargs="+", help="rooting mechanism ('best', 'residual', 'rsq', 'min_dev') "
+                            "OR node to root by OR two nodes indicating a monophyletic group to root by")
     tt_parser.add_argument('--date_fmt', default="%Y-%m-%d", help="date format")
     tt_parser.add_argument('--date_confidence', action="store_true", help="calculate confidence intervals for node dates")
     tt_parser.add_argument('--time_marginal', action="store_true", help="assign internal nodes to their marginally most likely dates, not jointly most likely")
     tt_parser.add_argument('--ancestral', choices=["joint", "marginal"],
                                 help="calculate joint maximum likelihood ancestral sequence states")
+    tt_parser.add_argument('--branchlengths', action="store_true", help="used with --ancestral; optimize branch length before reconstructing ancestral sequences")
     tt_parser.add_argument('--branch_length_mode', default='auto', choices = ['auto', 'joint', 'marginal', 'input'],
                                 help='branch length mode of treetime to use')
     tt_parser.add_argument('--output', type=str, help='file name to write tree to')


### PR DESCRIPTION
Modified `--ancestral` option in `treetime_wrapper.py` so it runs without errors. However, variables in the call to `ancestral_sequence_inference` were a little odd - some non-boolean being treated as boolean, and `args.branchlengths` didn't exist - @rneher could you check my changes are still what you intended? 

Changed rooting functionality so that as well as the rooting mechanism, users can provide a node to root by, or two+ nodes to root by the MRCA of those nodes. I changed the default so that if the parameter `--root` is not supplied, the tree is not re-rooted. I thought this was simpler than adding another parameter (e.g. `--keeproot`), but I'm happy for this to revert if others disagree.
