### PR TITLE
DRM Mapping Working for TB

### DIFF
--- a/augur/export.py
+++ b/augur/export.py
@@ -149,6 +149,15 @@ def export_metadata_json(T, metadata, tree_meta, config, color_map_file, geo_inf
             col_opts[trait]["key"] = trait
             col_opts[trait]["color_map"] = color_maps[trait]
 
+    #Adds things for which there's a colour in the file - like DRMs!
+    for trait in color_maps:
+        if trait not in col_opts:
+            col_opts[trait] = {}
+            col_opts[trait]["legendTitle"] = trait
+            col_opts[trait]["menuItem"] = trait
+            col_opts[trait]["key"] = trait
+            col_opts[trait]["color_map"] = color_maps[trait]
+
     if "annotations" in tree_meta:
         meta_json["annotations"] = tree_meta['annotations']
 
@@ -196,6 +205,7 @@ def run(args):
     if args.aa_muts: other_files.append(args.aa_muts)
     if args.titer_tree_model: other_files.append(args.titer_tree_model)
     if args.titer_subs_model: other_files.append(args.titer_subs_model)
+    if args.drms: other_files.append(args.drms)
 
     tree_meta = read_node_data(args.node_data, other_files=other_files)
     tree_meta = tree_meta_info(tree_meta, seq_meta) #attach author name to node

--- a/augur/find_drm.py
+++ b/augur/find_drm.py
@@ -1,0 +1,210 @@
+import numpy as np
+import colorsys
+from treetime.vcf_utils import read_vcf
+from collections import defaultdict
+from .utils import write_json
+import shutil, json
+
+def read_in_DRMs(drm_file):
+    '''
+    Reads in and stores position, ref & alt base, drug, AA change, and gene
+    of drug resistance mutations (DRMs)
+    This reads in the file-format below - don't know if standardized!
+
+    KEY	GENOMIC_POSITION	REF_BASE	ALT_BASE	LOCUS	GENE	SUBSTITUTION	DRUG	SOURCE	COMMENT
+    1	6505	G	T	Rv0005	gyrB	D461N	FQ	Malik_PLOS_ONE_2012
+    2	6505	G	C	Rv0005	gyrB	D461N	FQ	Malik_PLOS_ONE_2012
+    3	6618	G	A	Rv0005	gyrB	N499D	FQ	Malik_PLOS_ONE_2012
+    '''
+    import pandas as pd
+
+    DRMs = {}
+    drmPositions = []
+
+    df = pd.read_csv(drm_file, sep='\t')
+    for mi, m in df.iterrows():
+        pos = m.GENOMIC_POSITION-1 #put in python numbering
+        drmPositions.append(pos)
+
+        if pos in DRMs:
+            DRMs[pos]['base'].append(m.ALT_BASE)
+            DRMs[pos]['AA'].append(m.SUBSTITUTION)
+        else:
+            DRMs[pos] = {}
+            DRMs[pos]['base'] = [m.ALT_BASE]
+            DRMs[pos]['drug'] = m.DRUG
+            DRMs[pos]['AA'] = [m.SUBSTITUTION]
+            DRMs[pos]['gene'] = m.GENE
+
+    drmPositions = np.array(drmPositions)
+    drmPositions = np.unique(drmPositions)
+    drmPositions = np.sort(drmPositions)
+
+    DRM_info = {'DRMs': DRMs,
+            'drmPositions': drmPositions}
+
+    return DRM_info
+
+def drugTranslate(x):
+    '''
+    As above file format gives drugs as abbreviations, convert here.
+    '''
+    return {
+        'RIF': 'Rifampicin',
+        'FQ': 'Fluoroquinolones',
+        'ETH': 'Ethionamide',
+        'EMB': 'Ethambutol',
+        'SM': 'Streptomycin',
+        'PZA': 'Pyrazinamide',
+        'CAP': 'Capreomycin',
+        'INH': 'Isoniazid',
+        'KAN': 'Kanamycin',
+        'AK': 'Amikacin'
+    }[x]
+
+def get_N_HexCol(n=5):
+    '''
+    Auto-generate colours for DRMs to prevent users having to do it
+
+    modified from jhrf's answer on stackoverflow: (modified to py3 from ceprio's answer)
+    https://stackoverflow.com/questions/876853/generating-color-ranges-in-python
+    '''
+    import colorsys
+
+    HSV_tuples = [(x*1.0/n, 0.7, 0.7) for x in range(n)]
+    hex_out = []
+    for rgb in HSV_tuples:
+        rgb = map(lambda x: int(x*255),colorsys.hsv_to_rgb(*rgb))
+        hex_out.append('#%02x%02x%02x' % tuple(rgb))
+        #hex_out.append("#"+"".join(map(lambda x: chr(x).encode('hex'),rgb)))
+    return hex_out
+
+
+def find_drms(DRM_info, sequences):
+    '''
+    Looks for DRM mutations which match in position and alt base in
+    the sequence dict
+
+    '''
+    drmPositions = DRM_info['drmPositions']
+    DRMs = DRM_info['DRMs']
+    seqDRM = {}
+    for key in drmPositions:
+        for seq,v in sequences.items():
+            try:
+                base = sequences[seq][key]
+                if base in DRMs[key]['base']:
+                    if seq not in seqDRM:
+                        seqDRM[seq] = {}
+                    i=0
+                    while base != DRMs[key]['base'][i]:
+                        i+=1
+                    seqDRM[seq][DRMs[key]['AA'][i]] = DRMs[key]['drug']
+
+            except KeyError:
+                continue
+    return seqDRM
+
+
+def attach_drms(seqDRM, sequences):
+    '''
+    'Attaches' DRMs to nodes so format is correct to output as json
+    Also collects up all DRM options that colours will need to be generated for
+    '''
+    drm_meta = defaultdict(lambda: {"Drug_Resistance": '0' })
+
+    drugMuts = {}
+    drugMuts["Drug_Resistance"] = ['0'] #strings because makes it easier to work elsewhere
+    for seq in sequences.keys():
+        if seq in seqDRM:
+            tempList = []
+            for mut,drug in seqDRM[seq].items():
+                drugs = drug.split(';')
+                for drug in drugs:
+                    trDrug = drugTranslate(drug)
+                    if trDrug in drm_meta[seq]:
+                        drm_meta[seq][trDrug] = ",".join([drm_meta[seq][trDrug],mut])
+                    else:
+                        drm_meta[seq][trDrug] = mut
+
+                    if trDrug in drugMuts:
+                        if drm_meta[seq][trDrug] not in drugMuts[trDrug]:
+                            drugMuts[trDrug].append(drm_meta[seq][trDrug])
+                    else:
+                        drugMuts[trDrug] = [ drm_meta[seq][trDrug] ]
+
+                tempList.append(trDrug)
+            numResist = str(len(tempList))
+            drm_meta[seq]["Drug_Resistance"] = numResist
+            if numResist not in drugMuts["Drug_Resistance"]:
+                drugMuts["Drug_Resistance"].append(numResist)
+        else:
+            drm_meta[seq]["Drug_Resistance"] = '0'
+
+    return drm_meta, drugMuts
+
+def run(args):
+    '''
+    This should be modified to work on Fasta-input files!!
+    '''
+    '''
+    alignment <- vcf alignment
+    vcf_reference <- vcf ref
+    drm_file <- drm file
+    '''
+
+    ## check file format and read in sequences
+    is_vcf = False
+    if any([args.alignment.lower().endswith(x) for x in ['.vcf', '.vcf.gz']]):
+        if not args.vcf_reference:
+            print("ERROR: a reference Fasta is required with VCF-format alignments")
+            return -1
+        is_vcf = True
+        compress_seq = read_vcf(args.alignment, args.vcf_reference)
+        sequences = compress_seq['sequences']
+        ref = compress_seq['reference']
+        aln = sequences
+    else:
+        #fill in fasta-format processing
+        aln = args.alignment
+
+    DRM_info = read_in_DRMs(args.drm_file)
+
+    #Find the DRMs and store them
+    seqDRM = find_drms(DRM_info, sequences)
+
+    #Get json format; collect all unique options to generate colours for
+    drm_meta, drugMuts = attach_drms(seqDRM, sequences)
+
+    #write out json
+    with open(args.output, 'w') as results:
+        json.dump({"nodes":drm_meta}, results, indent=1)
+
+    #Generate colours
+    newColAdds = []
+    drugMuts["Drug_Resistance"].sort()
+    for drug,muts in drugMuts.items():
+        cols = get_N_HexCol(len(muts))
+        drugCol = [ "\t".join([drug, muts[i], cols[i]]) for i in range(len(muts)) ]
+        drugCol.append("")
+        newColAdds = newColAdds + drugCol
+
+    #copy and add to existing color file, if supplied:
+    write_status = 'w'
+    if args.color_defs:
+        shutil.copyfile(args.color_defs, args.col_output)
+        write_status = 'a'
+        newColAdds = ['',''] + newColAdds #skips a line, looks nice
+
+    with open(args.col_output, write_status) as the_file:
+        the_file.write("\n".join(newColAdds))
+
+
+
+
+
+
+
+
+
+

--- a/bin/augur
+++ b/bin/augur
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 from augur import align, tree, traits, parse, filter, export, translate
-from augur import mask, treetime_wrapper, titers
+from augur import mask, treetime_wrapper, titers, find_drm
 
 if __name__=="__main__":
     import argparse
@@ -129,6 +129,18 @@ if __name__=="__main__":
     traits_parser.add_argument('--output', default='traits.json', help='')
     traits_parser.set_defaults(func=traits.run)
 
+    ## FIND_DRM.PY
+    drm_parser = subparsers.add_parser('find_drm', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    drm_parser.add_argument('--alignment', required=True, help="alignment to search for DRMs in (can include ancestral seqs)")
+    drm_parser.add_argument('--vcf_reference', type=str, help='fasta file of the sequence the VCF was mapped to')
+    drm_parser.add_argument('--drm_file', type=str, help='file that includes DRMs to identify')
+    drm_parser.add_argument('--color_defs', type=str, help="file with color definitions "
+                            "(will be combined with colors generated for DRMs in new output file, if supplied)")
+    drm_parser.add_argument('--output', type=str, help='output json with DRM information')
+    drm_parser.add_argument('--col_output', type=str, help='file with colours generated for DRMs '
+                            '(will be combined with values from --color_defs if supplied)')
+    drm_parser.set_defaults(func=find_drm.run)
+
     ## TITERS.PY
     titers_parser = subparsers.add_parser('titers', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     titers_parser.add_argument('--titers', required=True, type=str, help="file with titer measurements")
@@ -145,6 +157,7 @@ if __name__=="__main__":
     export_parser.add_argument('--node_data', required=True, help="json file with meta data for each node")
     export_parser.add_argument('--traits',help="json file with trait inferences")
     export_parser.add_argument('--aa_muts',help="json file with amino acid mutations")
+    export_parser.add_argument('--drms', help="json file with DRM information")
     export_parser.add_argument('--titer_tree_model',type=str, help="json file with tree titer model")
     export_parser.add_argument('--titer_subs_model',type=str, help="json file with substitution titer model")
     export_parser.add_argument('--config', help="file with auspice configuration")


### PR DESCRIPTION
Adds `find_drm.py` which reads in a file of drug resistance mutations (DRMs), finds them in the alignment (including ancestral sequences if the output from a treetime run is provided), converts them into json format, and generates colours for all options. 

A few important points:

1. The DRM file format expected is what was given to me by the TB group here, but I rather doubt it's a standard format. Unsure what we should require or how we should handle this. 

2. Because of the high number of 'things to colour' associated with DRMs, this script auto-generates colours to save users the trouble. At the moment, I handle this by letting users provide their 'original' colour file (containing regions, countries, etc), and this is copied, renamed, and the new 'DRM colours' appended to it. Then this new 'complete' colour file can be passed to `export`. Alternatively, we could allow the user to specify multiple colour files to `export` as we currently do with the jsons. Unsure what's best.

3. `export` is modified to now add entries to `color_options` in `meta.json` if they exist in the colour file. This means all the DRM options generated will be added without the user having to specify them by adding manually to the `config.json` (particularly as you're unlikely to know what DRMs you'll need to add beforehand). 
