### PR TITLE
Remove treetime_augur submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "treetime_augur"]
-	path = treetime_augur
-	url = https://github.com/neherlab/treetime

--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Augur is the bioinformatic processing pipeline to track evolution from sequence 
 
 ## Install
 
-To install augur, clone the git repository and its submodules
+To install augur, clone the git repository:
 
 ```
 git clone https://github.com/nextstrain/augur.git
 cd augur
-git submodule update --init
 ```
 
 Augur has a number of python dependencies that are listed in `requirements.txt` and are best installed via a package manager like conda or pip.

--- a/base/tree.py
+++ b/base/tree.py
@@ -11,9 +11,9 @@ from Bio import Phylo
 import cPickle as pickle
 from collections import OrderedDict
 try:
-    from treetime_augur import TreeTime
+    from treetime import TreeTime
 except ImportError:
-    print("Couldn't import treetime_augur. Here's the searched paths:")
+    print("Couldn't import treetime. Here's the searched paths:")
     pprint(sys.path)
 
 def resolve_polytomies(tree):
@@ -293,7 +293,7 @@ class tree(object):
         infer a "mugration" model by pretending each region corresponds to a sequence
         state and repurposing the GTR inference and ancestral reconstruction
         '''
-        from treetime_augur import GTR
+        from treetime import GTR
         # Determine alphabet
         places = set()
         for node in self.tree.find_clades():

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-norecursedirs = treetime_augur
 addopts = --doctest-modules tests/ base/

--- a/requirements-locked.txt
+++ b/requirements-locked.txt
@@ -40,5 +40,6 @@ smmap2==2.0.3
 subprocess32==3.5.2
 tox==2.9.1
 traitlets==4.3.2
+treetime==0.3.0
 virtualenv==16.0.0
 wcwidth==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas >=0.16.2, ==0.16.*
 pytest >=3.2.1, ==3.*
 seaborn >=0.6.0, ==0.6.*
 tox >=2.8.2, ==2.*
+git+https://github.com/neherlab/treetime.git#egg=treetime


### PR DESCRIPTION
**This shouldn't be merged until https://github.com/neherlab/treetime/pull/44 is merged.**

---

While a custom version was necessary at one point, this vendored code
has been pointing at the TreeTime mainline for over a year, since the
commit "move treetime back to master" (32230e4).

Remove it and the complications of submodules in favor of requiring
TreeTime as a (mostly) normal dep in requirements.txt.

Note that this change depends on PR #44 in TreeTime¹ which contains the
commit "Declare deps in setup.py so this is an installable library".

¹ https://github.com/neherlab/treetime/pull/44