### PR TITLE
align and tree: Write log files as siblings to the output files

### DIFF
--- a/augur/align.py
+++ b/augur/align.py
@@ -55,7 +55,7 @@ def run(args):
 
     # align
     if args.method=='mafft':
-        cmd = "mafft --reorder --anysymbol --thread %d %s 1> %s 2>mafft_stderr"%(args.nthreads, seq_fname, output)
+        cmd = "mafft --reorder --anysymbol --thread %d %s 1> %s 2> %s.log"%(args.nthreads, seq_fname, output, output)
         os.system(cmd)
         print("\nusing mafft to align via:\n\t" + cmd +
               " \n\n\tKatoh et al, Nucleic Acid Research, vol 30, issue 14"

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -64,6 +64,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
     '''
     build tree using fasttree with parameters "-nt"
     '''
+    log_file = out_file + ".log"
 
     fasttree = find_executable([
         # Search order is based on expected parallelism and accuracy
@@ -76,7 +77,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
         "fasttree"
     ])
 
-    call = [fasttree, "-nt", aln_file, "1>", out_file, "2>", "fasttree.log"]
+    call = [fasttree, "-nt", aln_file, "1>", out_file, "2>", log_file]
     cmd = " ".join(call)
     print("Building a tree via:\n\t" + cmd +
           "\n\tPrice et al: FastTree 2 - Approximately Maximum-Likelihood Trees for Large Alignments." +
@@ -85,7 +86,7 @@ def build_fasttree(aln_file, out_file, clean_up=True):
     try:
         T = Phylo.read(out_file, 'newick')
         if clean_up:
-            os.remove('fasttree.log')
+            os.remove(log_file)
     except:
         print("TREE BUILDING FAILED")
         T=None


### PR DESCRIPTION
Instead of into the current working directory.  This associates them
more tightly and doesn't litter the working directory.