### PR TITLE
Trim extraneous fields from meta.json

### DIFF
--- a/augur/export.py
+++ b/augur/export.py
@@ -72,10 +72,9 @@ def tree_layout(T):
 
 
 def summarise_publications(metadata):
-    #Return one format to go into 'author_info' and one to go into 'authors' in 'controls'
+    # Return one format to go into 'author_info' and one to go into 'authors' in 'controls'
     control_authors = defaultdict(lambda: {"count": 0, "subcats": {} })
     author_info = defaultdict(lambda: {"n": 0, "title": "?" })
-    mapping = {}
     for n, d in metadata.items():
         if "authors" not in d:
             mapping[n] = None
@@ -83,14 +82,13 @@ def summarise_publications(metadata):
             continue
 
         authors = d["authors"]
-        mapping[n] = authors
         author_info[authors]["n"] += 1
         control_authors[authors]["count"] += 1
         for attr in ["title", "journal", "paper_url"]:
             if attr in d:
                 author_info[authors][attr] = d[attr]
 
-    return (author_info, mapping, control_authors)
+    return (author_info, control_authors)
 
 """please leave this (uncalled) function until we are sure WHO nextflu can run without it"""
 def make_control_json(T, controls):
@@ -138,9 +136,8 @@ def export_metadata_json(T, metadata, tree_meta, config, color_map_file, lat_lon
     meta_subset = {k:v for k,v in metadata.items() if k in terminals}
     color_maps = read_color_maps(color_map_file)
 
-    (author_info, seq_to_author, control_authors) = summarise_publications(meta_subset)
+    (author_info, control_authors) = summarise_publications(meta_subset)
     meta_json["author_info"] = author_info
-    meta_json["seq_author_map"] = seq_to_author
 
     if "annotations" not in tree_meta: #if haven't run tree through treetime
         meta_json["annotations"] = {}

--- a/augur/export.py
+++ b/augur/export.py
@@ -90,27 +90,6 @@ def summarise_publications(metadata):
 
     return (author_info, control_authors)
 
-"""please leave this (uncalled) function until we are sure WHO nextflu can run without it"""
-def make_control_json(T, controls):
-    controls_json = {}
-    for super_cat, fields in controls.items():
-        cat_count = {}
-        for n in T.get_terminals():
-            tmp = cat_count
-            for field in fields:
-                tmp["name"] = field
-                if hasattr(n, field):
-                    cat = n.__getattribute__(field)
-                else:
-                    cat='unknown'
-                if cat in tmp:
-                    tmp[cat]['count']+=1
-                else:
-                    tmp[cat] = {'count':1, 'subcats':{}}
-                tmp = tmp[cat]['subcats']
-        controls_json[super_cat] = cat_count
-    return controls_json
-
 def read_color_maps(fname):
     cm = defaultdict(list)
     try:
@@ -159,15 +138,10 @@ def export_metadata_json(T, metadata, tree_meta, config, color_map_file, lat_lon
         meta_json["annotations"] = tree_meta['annotations']
 
     meta_json.update(config)
-    if len(config["controls"]):
-        # the following is not needed in nextstrain, but may be in nextflu
-        # meta_json["controls"] = make_control_json(T, config["controls"])
-        meta_json["controls"] = {}
-        meta_json["controls"]["authors"]= control_authors
 
-    if "geographic location" in config["controls"]:
+    if "geo" in config:
         geo={}
-        for geo_field in config["controls"]["geographic location"]:
+        for geo_field in config["geo"]:
             geo[geo_field]={}
             for n, v in tree_meta["nodes"].items():
                 if geo_field in v:

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -58,21 +58,18 @@ def export_tip_frequency_json(process, prefix, indent):
 
 def summarise_publications_from_tree(tree):
     info = defaultdict(lambda: {"n": 0, "title": "?"})
-    mapping = {}
     for clade in tree.find_clades():
         if not clade.is_terminal():
             continue
         if "authors" not in clade.attr:
-            mapping[clade.name] = None
             print("Error - {} had no authors".format(clade.name))
             continue
         authors = clade.attr["authors"]
-        mapping[clade.name] = authors
         info[authors]["n"] += 1
         for attr in ["title", "journal", "paper_url"]:
             if attr in clade.attr:
                 info[authors][attr] = clade.attr[attr]
-    return (info, mapping)
+    return info
 
 def extract_annotations(runner):
     annotations = {}
@@ -99,10 +96,8 @@ def export_metadata_json(process, prefix, indent):
         virus_count += 1
     meta_json["virus_count"] = virus_count
 
-    (author_info, seq_to_author) = summarise_publications_from_tree(process.tree.tree)
+    author_info = summarise_publications_from_tree(process.tree.tree)
     meta_json["author_info"] = author_info
-    meta_json["seq_author_map"] = seq_to_author
-
 
     # join up config color options with those in the input JSONs.
     col_opts = process.config["auspice"]["color_options"]

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -134,7 +134,5 @@ def export_metadata_json(process, prefix, indent):
         meta_json["commit"] = git.Repo(search_parent_directories=True).head.object.hexsha
     except ImportError:
         meta_json["commit"] = "unknown"
-    if len(process.config["auspice"]["controls"]):
-        meta_json["controls"] = process.make_control_json(process.config["auspice"]["controls"])
     meta_json["geo"] = process.lat_longs
     write_json(meta_json, prefix+'_meta.json')

--- a/base/config.py
+++ b/base/config.py
@@ -92,9 +92,6 @@ def combine_configs(config_type, user_config):
     # update key by key so that if the value is itself a dictionary
     # they can be merged together... (recursively)
     config = merge(config, user_config)
-    if "geo_inference" in config and config["geo_inference"] != False and "geographic location" not in config["auspice"]["controls"]:
-        config["auspice"]["controls"]["geographic location"] = config["geo_inference"]
-
 
     if config_type == "prepare" and "title" not in config:
         config["title"] = config["file_prefix"]

--- a/base/process.py
+++ b/base/process.py
@@ -654,27 +654,6 @@ class process(object):
 
         return model
 
-    def make_control_json(self, controls):
-        controls_json = {}
-        for super_cat, fields in controls.iteritems():
-            cat_count = {}
-            for n in self.tree.tree.get_terminals():
-                tmp = cat_count
-                for field in fields:
-                    tmp["name"] = field
-                    if field in n.attr:
-                        cat = n.attr[field]
-                    else:
-                        cat='unknown'
-                    if cat in tmp:
-                        tmp[cat]['count']+=1
-                    else:
-                        tmp[cat] = {'count':1, 'subcats':{}}
-                    tmp = tmp[cat]['subcats']
-            controls_json[super_cat] = cat_count
-        return controls_json
-
-
     def auspice_export(self):
         '''
         export the tree, sequences, frequencies to json files for auspice visualization

--- a/builds/WNV/wnv.process.py
+++ b/builds/WNV/wnv.process.py
@@ -29,7 +29,6 @@ config = {
             "authors": {"key":"authors", "legendTitle":"Authors", "menuItem":"authors", "type":"discrete"},
             "host": {"key":"host", "legendTitle":"Host Species", "menuItem":"host", "type":"discrete"},
         },
-        "controls": {},
         "defaults": {
             'mapTriplicate': False,
             'colorBy': "state"

--- a/builds/avian/avian.process.py
+++ b/builds/avian/avian.process.py
@@ -34,8 +34,7 @@ config = {
             "host":{"key":"host", "legendTitle":"Host", "menuItem":"host", "type":"discrete", "color_map": []},
             "num_date":{"key":"num_date", "legendTitle":"Sampling date", "menuItem":"date", "type":"continuous"},
             "gt":{"key":"genotype", "legendTitle":"Genotype", "menuItem":"genotype", "type":"discrete"}
-        },
-        "controls": {'geographic location':['country'], 'authors':['authors']}
+        }
     },
     "newick_tree_options": {}
 }

--- a/builds/dengue/dengue.process.py
+++ b/builds/dengue/dengue.process.py
@@ -51,7 +51,6 @@ def make_config (prepared_json, args):
                 "region":{"key":"region", "legendTitle":"Region", "menuItem":"region", "type":"discrete"},
                 "gt":{"key":"genotype", "legendTitle":"Genotype", "menuItem":"genotype", "type":"discrete"},
             },
-            "controls": {'authors':['authors']},
             "defaults": {'geoResolution': 'region', 'colorBy': 'region', 'distanceMeasure': 'div', 'mapTriplicate': True}
             },
 

--- a/builds/ebola/ebola.process.py
+++ b/builds/ebola/ebola.process.py
@@ -20,11 +20,10 @@ config = {
     "geo_inference": ['country', 'division'], # what traits to perform this on
     "auspice": { ## settings for auspice JSON export
         "color_options": {
-            "authors": {"key":"authors", "legendTitle":"Authors", "menuItem":"authors", "type":"discrete"},        
+            "authors": {"key":"authors", "legendTitle":"Authors", "menuItem":"authors", "type":"discrete"},
             "country": {"key":"country", "legendTitle":"Country", "menuItem":"country", "type":"discrete"},
             "division": {"key":"division", "legendTitle":"Division", "menuItem":"division", "type":"discrete"},
         },
-        "controls": {'geographic location':['country', 'division'], 'authors':['authors']},
         "defaults": {
             "colorBy": "division",
             "geoResolution": "division"
@@ -49,8 +48,6 @@ if __name__=="__main__":
 
     if params.json:
         config["in"] = params.json
-
-    config["newick_tree_options"]["raxml"] = not params.no_raxml
 
     runner = process(config)
     runner.align()

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -61,7 +61,6 @@ def make_config(prepared_json, args):
                 "region":{"menuItem":"region", "legendTitle":"Region", "key":"region", "type":"discrete"},
                 "clade_membership": {"menuItem": "clade", "legendTitle": "Clade", "key": "clade_membership", "type": "discrete"},
             },
-            "controls": {'authors':['authors']},
             "defaults": {'colorBy': 'clade_membership',
                 'geoResolution': 'region',
                 'mapTriplicate': True},

--- a/builds/lassa/lassa.process.py
+++ b/builds/lassa/lassa.process.py
@@ -22,9 +22,8 @@ config = {
         "panels": ['tree', 'map', 'entropy'],
         "color_options": {
             "country": {"key":"country", "legendTitle":"Country", "menuItem":"country", "type":"discrete", "color_map": []},
-            "host_species": {"key":"host_species", "legendTitle":"Host", "menuItem":"host", "type":"discrete", "color_map": []}            
+            "host_species": {"key":"host_species", "legendTitle":"Host", "menuItem":"host", "type":"discrete", "color_map": []}
         },
-        "controls": {'geographic location':['country'], 'authors':['authors']},
         "defaults": {
             "colorBy": "country",
             "geoResolution": "country"

--- a/builds/lassa/metadata/config.json
+++ b/builds/lassa/metadata/config.json
@@ -18,14 +18,9 @@
   "region": {
   }
  },
- "controls": {
-  "geographic location": {
-   "country": {
-   },
-   "region": {
-   }
-  }
- },
+ "geo": [
+   "country"
+ ],
  "filters": [
   "country",
   "region",

--- a/builds/tb/data/config.json
+++ b/builds/tb/data/config.json
@@ -18,12 +18,9 @@
   "cluster": {
   }
  },
- "controls": {
-  "geographic location": {
-   "location": {
-   }
-  }
- },
+ "geo": [
+   "location"
+ ],
  "filters": [
   "location", 
   "cluster", 

--- a/builds/zika/config/auspice_config.json
+++ b/builds/zika/config/auspice_config.json
@@ -24,14 +24,10 @@
     "region": {
     }
   },
-  "controls": {
-    "geographic location": {
-      "country": {
-      },
-      "region": {
-      }
-    }
-  },
+  "geo": [
+    "country",
+    "region"
+  ],
   "maintainer": [
     "Trevor Bedford",
     "http://bedford.io/team/trevor-bedford/"

--- a/builds/zika/zika.process.py
+++ b/builds/zika/zika.process.py
@@ -36,7 +36,6 @@ config = {
             "region": {"key":"region", "legendTitle":"Region", "menuItem":"region", "type":"discrete"},
             "country": {"key":"country", "legendTitle":"Country", "menuItem":"country", "type":"discrete"}
         },
-        "controls": {'authors':['authors']},
         "defaults": {'mapTriplicate': True}
     },
     "timetree_options": {


### PR DESCRIPTION
This is an extension of PR #138. This removes the export of `seq_author_map` and `controls` from meta.json. This change is made to both old and new augur. I confirmed that the resulting `meta.json` files work in both current auspice and old Nextflu.