### PR TITLE
Clean up Zika snakefile

### DIFF
--- a/builds/zika/Snakefile
+++ b/builds/zika/Snakefile
@@ -16,13 +16,16 @@ config = rules.config.params
 
 rule parse:
     input:
-       config.input_fasta
+       sequences = config.input_fasta
     output:
        sequences = "results/sequences.fasta",
        metadata = "results/metadata.tsv"
     shell:
-        'augur parse --sequences {input} --output-sequences {output.sequences} --output-metadata {output.metadata} '
-            '--fields {config.fasta_fields}'
+        """
+        augur parse --sequences {input.sequences} \
+            --output-sequences {output.sequences} --output-metadata {output.metadata} \
+            --fields {config.fasta_fields}
+        """
 
 rule filter:
     input:
@@ -30,86 +33,104 @@ rule filter:
         metadata = rules.parse.output.metadata,
         exclude = config.dropped_strains
     output:
-        "results/filtered.fasta"
+        sequences = "results/filtered.fasta"
     params:
         sequences_per_category = 20,
         categories = "country year month",
         min_date = 2012
     shell:
-        'augur filter --sequences {input.sequences} --output {output} --metadata {input.metadata} '
-            '--sequences-per-category {params.sequences_per_category} '
-            '--exclude {input.exclude} --categories {params.categories} --min-date {params.min_date}'
+        """
+        augur filter --sequences {input.sequences} --metadata {input.metadata} \
+            --output {output.sequences} \
+            --categories {params.categories} \
+            --sequences-per-category {params.sequences_per_category} \
+            --exclude {input.exclude}  --min-date {params.min_date}
+        """
 
 rule align:
     input:
-        sequences = rules.filter.output,
+        sequences = rules.filter.output.sequences,
         ref = config.reference
     output:
-        "results/aligned.fasta"
+        alignment = "results/aligned.fasta"
     shell:
-        'augur align --sequences {input.sequences} --output {output} '
-         '--reference-sequence {input.ref}  --fill-gaps'
+        """
+        augur align --sequences {input.sequences} --output {output.alignment} \
+            --reference-sequence {input.ref} --fill-gaps
+        """
 
 rule tree:
     input:
-        alignment = rules.align.output
+        alignment = rules.align.output.alignment
     output:
-        tree = "results/tree_raw.nwk",
+        tree = "results/tree_raw.nwk"
     shell:
-        'augur tree --alignment {input.alignment} --output {output.tree}'
+        """
+        augur tree --alignment {input.alignment} --output {output.tree}
+        """
 
 rule timetree:
     input:
-        alignment = rules.align.output,
-        metadata = rules.parse.output.metadata,
         tree = rules.tree.output.tree,
+        alignment = rules.align.output,
+        metadata = rules.parse.output.metadata
     output:
-        node_data = "results/node_data.json",
         tree = "results/tree.nwk",
+        node_data = "results/node_data.json"
     params:
         n_iqd = 4
     shell:
-        'augur treetime --tree {input.tree} --alignment {input.alignment} '
-            '--metadata {input.metadata}'
-            ' --output {output.tree} --node-data {output.node_data}'
-            ' --timetree --date-confidence --time-marginal --coalescent opt'
-            ' --n-iqd {params.n_iqd}'
+        """
+        augur treetime --tree {input.tree} --alignment {input.alignment} \
+            --metadata {input.metadata} \
+            --output {output.tree} --node-data {output.node_data} \
+            --timetree --date-confidence --time-marginal --coalescent opt \
+            --n-iqd {params.n_iqd}
+        """
 
 rule traits:
     input:
         tree = rules.timetree.output.tree,
         metadata = rules.parse.output.metadata
     output:
-        "results/traits.json",
+        node_data = "results/traits.json",
     params:
         columns = "region country"
     shell:
-        'augur traits --confidence --tree {input.tree} --metadata {input.metadata} --output {output} --columns {params.columns}'
+        """
+        augur traits --tree {input.tree} --metadata {input.metadata} \
+            --output {output.node_data} --confidence --columns {params.columns}
+        """
 
 rule translate:
     input:
         tree = rules.timetree.output.tree,
-        ref = config.reference,
         node_data = rules.timetree.output.node_data,
+        ref = config.reference
     output:
-        "results/aa_muts.json"
+        node_data = "results/aa_muts.json"
     shell:
-        'augur translate --tree {input.tree} --node-data {input.node_data} --output {output} --reference-sequence {input.ref}'
+        """
+        augur translate --tree {input.tree} --node-data {input.node_data} \
+            --output {output.node_data} --reference-sequence {input.ref}
+        """
 
 rule export:
     input:
         tree = rules.timetree.output.tree,
-        node_data = rules.timetree.output.node_data,
         metadata = rules.parse.output.metadata,
-        traits = rules.traits.output,
-        aa_muts = rules.translate.output,
+        node_data = rules.timetree.output.node_data,
+        traits = rules.traits.output.node_data,
+        aa_muts = rules.translate.output.node_data,
         colors = config.colors,
         auspice_config = config.auspice_config
     output:
         auspice_tree = rules.all.input.auspice_tree,
         auspice_meta = rules.all.input.auspice_meta
     shell:
-        'augur export --tree {input.tree} --metadata {input.metadata}'
-            ' --node-data {input.node_data} {input.traits} {input.aa_muts}' # node decorations for the tree JSON
-            ' --colors {input.colors} --auspice-config {input.auspice_config}' #for the meta JSON
-            ' --output-tree {output.auspice_tree} --output-meta {output.auspice_meta}'
+        """
+        augur export --tree {input.tree} --metadata {input.metadata} \
+            --node-data {input.node_data} {input.traits} {input.aa_muts} \
+            --colors {input.colors} --auspice-config {input.auspice_config} \
+            --output-tree {output.auspice_tree} --output-meta {output.auspice_meta}
+        """


### PR DESCRIPTION
This is an entirely stylistic PR. It does three things:

1. Delimit shell commands with `"""` as suggested by @tsibley. I do think this makes it cleaner to read.
2. Gives every input and output a name. This changes things like `filter.output` to `filter.output.sequences` to match existing `tree.output.tree`. I think this makes for a clearer file.
3. Order shell commands more logically. I opted for inputs, then outputs, then parameters.
