### PR TITLE
Split augur treetime into augur refine and augur ancestral

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -1,0 +1,104 @@
+import os, shutil, time, json
+from Bio import Phylo
+from .utils import write_json
+from treetime.vcf_utils import read_vcf, write_vcf
+
+def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
+                                 marginal=False):
+    from treetime import TreeAnc
+    tt = TreeAnc(tree=tree, aln=aln, ref=ref, gtr='JC69', verbose=1)
+
+    # convert marginal (from args.inference) from 'joint' or 'marginal' to True or False
+    bool_marginal = (marginal == "marginal")
+
+    # only infer ancestral sequences, leave branch length untouched
+    tt.infer_ancestral_sequences(infer_gtr=infer_gtr, marginal=bool_marginal)
+
+    print("\nInferred ancestral sequence states using TreeTime:"
+          "\n\tSagulenko et al. TreeTime: Maximum-likelihood phylodynamic analysis"
+          "\n\tVirus Evolution, vol 4, https://academic.oup.com/ve/article/4/1/vex042/4794731\n")
+
+    return tt
+
+def prep_tree(T, attributes, is_vcf=False):
+    data = {}
+    inc = 1 # convert python numbering to start-at-1
+    for n in T.find_clades():
+        data[n.name] = {attr:n.__getattribute__(attr)
+                        for attr in attributes if hasattr(n,attr)}
+    if 'mutations' in attributes:
+        for n in T.find_clades():
+            data[n.name]['mutations'] = [[a,int(pos)+inc,d] for a,pos,d in data[n.name]['mutations']]
+    if not is_vcf and 'sequence' in attributes: # don't attach sequence if VCF!
+        for n in T.find_clades():
+            if hasattr(n, 'sequence'):
+                data[n.name]['sequence'] = ''.join(n.sequence)
+            else:
+                data[n.name]['sequence']=''
+
+    return data
+
+def run(args):
+    # check alignment type, set flags, read in if VCF
+    is_vcf = False
+    ref = None
+    node_data = {'alignment': args.alignment, 'inference': args.inference}
+    attributes = []
+    # check if tree is provided and can be read
+    for fmt in ["newick", "nexus"]:
+        try:
+            T = Phylo.read(args.tree, fmt)
+            node_data['input_tree'] = args.tree
+            break
+        except:
+            pass
+    if T is None:
+        print("ERROR: reading tree from %s failed."%args.tree)
+        return -1
+
+    if any([args.alignment.lower().endswith(x) for x in ['.vcf', '.vcf.gz']]):
+        if not args.vcf_reference:
+            print("ERROR: a reference Fasta is required with VCF-format alignments")
+            return -1
+
+        compress_seq = read_vcf(args.alignment, args.vcf_reference)
+        sequences = compress_seq['sequences']
+        ref = compress_seq['reference']
+        is_vcf = True
+        aln = sequences
+    else:
+        aln = args.alignment
+
+    tt = ancestral_sequence_inference(tree=T, aln=aln, ref=ref, marginal=args.inference)
+
+    attributes.extend(['mutations'])
+
+    if not is_vcf:
+        attributes.extend(['sequence']) # don't add sequences if VCF - huge!
+
+    if is_vcf:
+        # TreeTime overwrites ambig sites on tips during ancestral reconst.
+        # Put these back in tip sequences now, to avoid misleading
+        tt.recover_var_ambigs()
+
+    node_data['nodes'] = prep_tree(T, attributes, is_vcf)
+
+    if args.output:
+        node_data_fname = args.output
+    else:
+        node_data_fname = '.'.join(args.alignment.split('.')[:-1]) + '.node_data'
+
+    node_data_success = write_json(node_data, node_data_fname)
+
+    # If VCF, output VCF including new ancestral seqs
+    if is_vcf:
+        if args.output_vcf:
+            vcf_fname = args.output_vcf
+        else:
+            vcf_fname = '.'.join(args.alignment.split('.')[:-1]) + '.vcf'
+        write_vcf(tt.get_tree_dict(keep_var_ambigs=True), vcf_fname)
+
+    if node_data_success:
+        return 0
+    else:
+        return -1

--- a/augur/export.py
+++ b/augur/export.py
@@ -49,15 +49,6 @@ def tree_to_json(node, fields_to_export = [], top_level = [], div=0):
 
     return tree_json
 
-def process_mutations(muts):
-    realMut = [a+str(pos)+d for (a, pos, d) in muts]
-    if len(realMut)==0:
-        realMut = [""]
-    return realMut
-
-def process_mutation_dict(muts):
-    return {k:process_mutations(v) for k,v in muts.items() if len(v)}
-
 # calculate tree layout. should be obsolete with future auspice versions
 def tree_layout(T):
     yval=T.count_terminals()
@@ -174,8 +165,7 @@ def run(args):
     fields_to_export = [x for x in  node_fields
                         if x not in ['sequence', 'mutations', 'muts', 'aa_muts']]+['num_date']
     # and which fields are top level? (the rest are all in the attr dict)
-    top_level = ["clade","tvalue","yvalue", "xvalue"]\
-                +[("muts", process_mutations), ("aa_muts", process_mutation_dict)]
+    top_level = ["clade","tvalue","yvalue", "xvalue", "muts", "aa_muts"]
 
     tree_json = tree_to_json(T.root, fields_to_export=fields_to_export, top_level=top_level)
     write_json(tree_json, args.output_tree)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -111,8 +111,8 @@ def run(args):
         aln = args.alignment
 
 
-    if args.output:
-        tree_fname = args.output
+    if args.output_tree:
+        tree_fname = args.output_tree
     else:
         tree_fname = '.'.join(args.alignment.split('.')[:-1]) + '_tt.nwk'
 
@@ -154,8 +154,8 @@ def run(args):
     if T:
         import json
         tree_success = Phylo.write(T, tree_fname, 'newick', format_branch_length='%1.8f')
-        if args.node_data:
-            node_data_fname = args.node_data
+        if args.output_node_data:
+            node_data_fname = args.output_node_data
         else:
             node_data_fname = '.'.join(args.alignment.split('.')[:-1]) + '.node_data'
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -2,12 +2,11 @@ import os, shutil, time
 from Bio import Phylo
 from .utils import read_metadata, get_numerical_dates, write_json
 from treetime.vcf_utils import read_vcf, write_vcf
-import numpy as np
 
 def refine(tree=None, aln=None, ref=None, dates=None, branch_length_mode='auto',
              confidence=False, resolve_polytomies=True, max_iter=2,
              infer_gtr=True, Tc=0.01, reroot=None, use_marginal=False, fixed_pi=None,
-             clock_rate=None, n_iqd=None, verbosity=1, **kwarks):
+             clock_rate=None, clock_filter_iqd=None, verbosity=1, **kwarks):
     from treetime import TreeTime
 
     try: #Tc could be a number or  'opt' or 'skyline'. TreeTime expects a float or int if a number.
@@ -31,8 +30,8 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_mode='auto',
     tt = TreeTime(tree=tree, aln=aln, ref=ref, dates=dates,
                   verbose=verbosity, gtr='JC69')
 
-    if n_iqd:
-        tt.clock_filter(reroot='best', n_iqd=n_iqd, plot=False)
+    if clock_filter_iqd:
+        tt.clock_filter(reroot='best', n_iqd=clock_filter_iqd, plot=False)
         leaves = [x for x in tt.tree.get_terminals()]
         for n in leaves:
             if n.bad_branch:
@@ -62,56 +61,25 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_mode='auto',
     return tt
 
 
-def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
-                                 marginal=False, optimize_branch_length=True,
-                                 branch_length_mode='auto'):
-    from treetime import TreeAnc
-    tt = TreeAnc(tree=tree, aln=aln, ref=ref, gtr='JC69', verbose=1)
-
-    #convert marginal (from args.ancestral) from 'joint' or 'marginal' to True or False
-    bool_marginal = (marginal == "marginal")
-
-    if optimize_branch_length:
-        tt.optimize_seq_and_branch_len(infer_gtr=infer_gtr, marginal_sequences=bool_marginal,
-        							   branch_length_mode=branch_length_mode)
-    else: # only infer ancestral sequences, leave branch length untouched
-        tt.infer_ancestral_sequences(infer_gtr=infer_gtr, marginal=bool_marginal)
-
-    print("\nInferred ancestral sequence states using TreeTime:"
-          "\n\tSagulenko et al. TreeTime: Maximum-likelihood phylodynamic analysis"
-          "\n\tVirus Evolution, vol 4, https://academic.oup.com/ve/article/4/1/vex042/4794731\n")
-
-    return tt
-
 def prep_tree(T, attributes, is_vcf=False):
     data = {}
     inc = 1 #convert python numbering to start-at-1
     for n in T.find_clades():
         data[n.name] = {attr:n.__getattribute__(attr)
                         for attr in attributes if hasattr(n,attr)}
-    if 'mutations' in attributes:
-        for n in T.find_clades():
-            data[n.name]['mutations'] = [[a,int(pos)+inc,d] for a,pos,d in data[n.name]['mutations']]
-    if not is_vcf and 'sequence' in attributes: #don't attach sequence if VCF!
-        for n in T.find_clades():
-            if hasattr(n, 'sequence'):
-                data[n.name]['sequence'] = ''.join(n.sequence)
-            else:
-                data[n.name]['sequence']=''
-
     return data
 
 def run(args):
     # check alignment type, set flags, read in if VCF
     is_vcf = False
     ref = None
-    tree_meta = {'alignment':args.alignment}
+    node_data = {'alignment': args.alignment}
     attributes = ['branch_length']
     # check if tree is provided an can be read
     for fmt in ["newick", "nexus"]:
         try:
             T = Phylo.read(args.tree, fmt)
-            tree_meta['input_tree'] = args.tree
+            node_data['input_tree'] = args.tree
             break
         except:
             pass
@@ -121,7 +89,7 @@ def run(args):
 
     if not args.alignment:
         # fake alignment to appease treetime when only using it for naming nodes...
-        if args.ancestral or args.timetree:
+        if args.timetree:
             print("ERROR: alignment is required for ancestral reconstruction or timetree inference")
             return -1
         from Bio import SeqRecord, Seq, Align
@@ -168,34 +136,20 @@ def run(args):
                       Tc=args.coalescent if args.coalescent is not None else 0.01, #Otherwise can't set to 0
                       use_marginal = args.time_marginal or False,
                       branch_length_mode = args.branch_length_mode or 'auto',
-                      clock_rate=args.clock_rate, n_iqd=args.n_iqd)
+                      clock_rate=args.clock_rate, clock_filter_iqd=args.clock_filter_iqd)
 
-        tree_meta['clock'] = {'rate':tt.date2dist.clock_rate,
-                              'intercept':tt.date2dist.intercept,
-                              'rtt_Tmrca':-tt.date2dist.intercept/tt.date2dist.clock_rate}
-        attributes.extend(['numdate', 'clock_length', 'mutation_length', 'mutations', 'raw_date', 'date'])
-        if not is_vcf:
-            attributes.extend(['sequence']) #don't add sequences if VCF - huge!
+        node_data['clock'] = {'rate': tt.date2dist.clock_rate,
+                              'intercept': tt.date2dist.intercept,
+                              'rtt_Tmrca': -tt.date2dist.intercept/tt.date2dist.clock_rate}
+        attributes.extend(['numdate', 'clock_length', 'mutation_length', 'raw_date', 'date'])
         if args.date_confidence:
             attributes.append('num_date_confidence')
-    elif args.ancestral in ['joint', 'marginal']:
-        tt = ancestral_sequence_inference(tree=T, aln=aln, ref=ref, marginal=args.ancestral,
-                                          optimize_branch_length=args.branchlengths,
-                                          branch_length_mode=args.branch_length_mode)
-        attributes.extend(['mutation_length', 'mutations'])
-        if not is_vcf:
-            attributes.extend(['sequence']) #don't add sequences if VCF - huge!
     else:
         from treetime import TreeAnc
         # instantiate treetime for the sole reason to name internal nodes
         tt = TreeAnc(tree=T, aln=aln, ref=ref, gtr='JC69', verbose=1)
 
-    if is_vcf and (args.ancestral or args.timetree):
-        #TreeTime overwrites ambig sites on tips during ancestral reconst.
-        #Put these back in tip sequences now, to avoid misleading
-        tt.recover_var_ambigs()
-
-    tree_meta['nodes'] = prep_tree(T, attributes, is_vcf)
+    node_data['nodes'] = prep_tree(T, attributes, is_vcf)
 
     if T:
         import json
@@ -205,17 +159,4 @@ def run(args):
         else:
             node_data_fname = '.'.join(args.alignment.split('.')[:-1]) + '.node_data'
 
-        with open(node_data_fname, 'w') as ofile:
-            meta_success = json.dump(tree_meta, ofile)
-
-    #If VCF and ancestral reconst. was done, output VCF including new ancestral seqs
-    if is_vcf and (args.ancestral or args.timetree):
-        if args.output_vcf:
-            vcf_fname = args.output_vcf
-        else:
-            vcf_fname = '.'.join(args.alignment.split('.')[:-1]) + '.vcf'
-        write_vcf(tt.get_tree_dict(keep_var_ambigs=True), vcf_fname)
-
-        return 0 if (tree_success and meta_success) else -1
-    else:
-        return -1
+        write_json(node_data, node_data_fname)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -4,7 +4,7 @@ from .utils import read_metadata, get_numerical_dates, write_json
 from treetime.vcf_utils import read_vcf, write_vcf
 import numpy as np
 
-def timetree(tree=None, aln=None, ref=None, dates=None, branch_length_mode='auto',
+def refine(tree=None, aln=None, ref=None, dates=None, branch_length_mode='auto',
              confidence=False, resolve_polytomies=True, max_iter=2,
              infer_gtr=True, Tc=0.01, reroot=None, use_marginal=False, fixed_pi=None,
              clock_rate=None, n_iqd=None, verbosity=1, **kwarks):
@@ -163,7 +163,7 @@ def run(args):
         if args.root and len(args.root) == 1: #if anything but a list of seqs, don't send as a list
             args.root = args.root[0]
 
-        tt = timetree(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
+        tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
                       reroot=args.root or 'best',
                       Tc=args.coalescent if args.coalescent is not None else 0.01, #Otherwise can't set to 0
                       use_marginal = args.time_marginal or False,

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -166,6 +166,9 @@ def translate_vcf_feature(sequences, ref, feature):
     else:
         return prot
 
+def construct_mut(start, pos, end):
+    return str(start) + str(pos) + str(end)
+
 def assign_aa_vcf(tree, translations):
     aa_muts = {}
 
@@ -181,11 +184,11 @@ def assign_aa_vcf(tree, translations):
                     #if pos in both, check if same
                     if pos in n_muts and pos in c_muts:
                         if n_muts[pos] != c_muts[pos]:
-                            tmp.append((n_muts[pos],int(pos+1),c_muts[pos]))
+                            tmp.append(construct_mut(n_muts[pos], int(pos+1), c_muts[pos]))
                     elif pos in n_muts:
-                        tmp.append((n_muts[pos],int(pos+1),prot['reference'][pos]))
+                        tmp.append(construct_mut(n_muts[pos], int(pos+1), prot['reference'][pos]))
                     elif pos in c_muts:
-                        tmp.append((prot['reference'][pos],int(pos+1),c_muts[pos]))
+                        tmp.append(construct_mut(prot['reference'][pos], int(pos+1), c_muts[pos]))
 
                 aa_muts[c.name]["aa_muts"][fname] = tmp
 
@@ -287,7 +290,7 @@ def run(args):
             for fname, aln in translations.items():
                 for c in n:
                     if c.name in aln and n.name in aln:
-                        tmp = [(a,pos+1,d) for pos, (a,d) in
+                        tmp = [construct_mut(a, int(pos+1), d) for pos, (a,d) in
                                 enumerate(zip(aln[n.name], aln[c.name])) if a!=d]
                     aa_muts[c.name]["aa_muts"][fname] = tmp
 

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -133,8 +133,8 @@ def attach_tree_meta_data(T, node_meta):
 
 
 def write_json(data, file_name, indent=1):
-    import json
-    import os
+    import json, os
+    success = False
 
     #in case auspice folder does not exist yet
     if not os.path.exists(os.path.dirname(file_name)):
@@ -148,8 +148,10 @@ def write_json(data, file_name, indent=1):
     except IOError:
         raise
     else:
-        json.dump(data, handle, indent=indent)
+        success = json.dump(data, handle, indent=indent)
         handle.close()
+
+    return success
 
 
 def load_features(reference, feature_names=None):

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -148,8 +148,9 @@ def write_json(data, file_name, indent=1):
     except IOError:
         raise
     else:
-        success = json.dump(data, handle, indent=indent)
+        json.dump(data, handle, indent=indent)
         handle.close()
+        success=True
 
     return success
 

--- a/bin/augur
+++ b/bin/augur
@@ -85,18 +85,14 @@ if __name__=="__main__":
     refine_parser.add_argument('--date-format', default="%Y-%m-%d", help="date format")
     refine_parser.add_argument('--date-confidence', action="store_true", help="calculate confidence intervals for node dates")
     refine_parser.add_argument('--time-marginal', action="store_true", help="assign internal nodes to their marginally most likely dates, not jointly most likely")
-    refine_parser.add_argument('--ancestral', choices=["joint", "marginal"],
-                                help="calculate joint maximum likelihood ancestral sequence states")
-    refine_parser.add_argument('--branchlengths', action="store_true", help="used with --ancestral; optimize branch length before reconstructing ancestral sequences")
     refine_parser.add_argument('--branch-length-mode', default='auto', choices = ['auto', 'joint', 'marginal', 'input'],
                                 help='branch length mode of treetime to use')
     refine_parser.add_argument('--output', type=str, help='file name to write tree to')
-    refine_parser.add_argument('--n-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
+    refine_parser.add_argument('--clock-filter-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
                              'interquartile ranges from the root-to-tip vs time regression')
     refine_parser.add_argument('--nthreads', type=int, default=2,
                                 help="number of threads used")
     refine_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
-    refine_parser.add_argument('--output-vcf', type=str, help='name of output VCF file which will include ancestral seqs, if treetime or ancestral is run')
     refine_parser.add_argument('--year-limit', type=int, nargs='+', help='specify min or max & min years for samples with XX in year')
     refine_parser.set_defaults(func=refine.run)
 

--- a/bin/augur
+++ b/bin/augur
@@ -76,7 +76,8 @@ if __name__=="__main__":
     refine_parser.add_argument('--alignment', help="alignment in fasta or VCF format")
     refine_parser.add_argument('--tree',required=True, help="prebuilt Newick")
     refine_parser.add_argument('--metadata', type=str, help="tsv/csv table with meta data for sequences")
-    refine_parser.add_argument('--node-data', type=str, help='file name to write additional node data')
+    refine_parser.add_argument('--output-tree', type=str, help='file name to write tree to')
+    refine_parser.add_argument('--output-node-data', type=str, help='file name to write branch lengths as node data')
     refine_parser.add_argument('--timetree', action="store_true", help="produce timetree using treetime")
     refine_parser.add_argument('--coalescent', help="coalescent time scale in units of inverse clock rate (float), optimize as scalar ('opt'), or skyline ('skyline')")
     refine_parser.add_argument('--clock-rate', type=float, help="fixed clock rate")
@@ -87,9 +88,8 @@ if __name__=="__main__":
     refine_parser.add_argument('--time-marginal', action="store_true", help="assign internal nodes to their marginally most likely dates, not jointly most likely")
     refine_parser.add_argument('--branch-length-mode', default='auto', choices = ['auto', 'joint', 'marginal', 'input'],
                                 help='branch length mode of treetime to use')
-    refine_parser.add_argument('--output', type=str, help='file name to write tree to')
     refine_parser.add_argument('--clock-filter-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
-                             'interquartile ranges from the root-to-tip vs time regression')
+                                'interquartile ranges from the root-to-tip vs time regression')
     refine_parser.add_argument('--nthreads', type=int, default=2,
                                 help="number of threads used")
     refine_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')

--- a/bin/augur
+++ b/bin/augur
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
-from augur import align, tree, refine, traits, parse, filter, translate
-from augur import mask, titers, export
+from augur import parse, filter, align, tree, refine, ancestral
+from augur import traits, translate, mask, titers, export
 
 if __name__=="__main__":
     import argparse
@@ -100,6 +100,16 @@ if __name__=="__main__":
     refine_parser.add_argument('--year-limit', type=int, nargs='+', help='specify min or max & min years for samples with XX in year')
     refine_parser.set_defaults(func=refine.run)
 
+    ## ANCESTRAL.PY
+    ancestral_parser = subparsers.add_parser('ancestral', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    ancestral_parser.add_argument('--tree',required=True, help="prebuilt Newick")
+    ancestral_parser.add_argument('--alignment', help="alignment in fasta or VCF format")
+    ancestral_parser.add_argument('--output', type=str, help='file name to mutations to')
+    ancestral_parser.add_argument('--inference', default='joint', choices=["joint", "marginal"],
+                                    help="calculate joint or marginal maximum likelihood ancestral sequence states")
+    ancestral_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
+    ancestral_parser.add_argument('--output-vcf', type=str, help='name of output VCF file which will include ancestral seqs')
+    ancestral_parser.set_defaults(func=ancestral.run)
 
     ## TRANSLATE.PY
     translate_parser = subparsers.add_parser('translate', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/bin/augur
+++ b/bin/augur
@@ -100,7 +100,7 @@ if __name__=="__main__":
     ancestral_parser = subparsers.add_parser('ancestral', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     ancestral_parser.add_argument('--tree',required=True, help="prebuilt Newick")
     ancestral_parser.add_argument('--alignment', help="alignment in fasta or VCF format")
-    ancestral_parser.add_argument('--output', type=str, help='file name to mutations to')
+    ancestral_parser.add_argument('--output', type=str, help='file name to save mutations and ancestral sequences to')
     ancestral_parser.add_argument('--inference', default='joint', choices=["joint", "marginal"],
                                     help="calculate joint or marginal maximum likelihood ancestral sequence states")
     ancestral_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')

--- a/bin/augur
+++ b/bin/augur
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
-from augur import align, tree, traits, parse, filter, export, translate
-from augur import mask, treetime_wrapper, titers
+from augur import align, tree, refine, traits, parse, filter, translate
+from augur import mask, titers, export
 
 if __name__=="__main__":
     import argparse
@@ -71,34 +71,35 @@ if __name__=="__main__":
     tree_parser.set_defaults(func=tree.run)
 
 
-    ## TREETIME_WRAPPER.PY
-    tt_parser = subparsers.add_parser('treetime', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    tt_parser.add_argument('--alignment', help="alignment in fasta or VCF format")
-    tt_parser.add_argument('--tree',required=True, help="prebuilt Newick")
-    tt_parser.add_argument('--metadata', type=str, help="tsv/csv table with meta data for sequences")
-    tt_parser.add_argument('--node-data', type=str, help='file name to write additional node data')
-    tt_parser.add_argument('--timetree', action="store_true", help="produce timetree using treetime")
-    tt_parser.add_argument('--coalescent', help="coalescent time scale in units of inverse clock rate (float), optimize as scalar ('opt'), or skyline ('skyline')")
-    tt_parser.add_argument('--clock-rate', type=float, help="fixed clock rate")
-    tt_parser.add_argument('--root', nargs="+", help="rooting mechanism ('best', 'residual', 'rsq', 'min_dev') "
-                            "OR node to root by OR two nodes indicating a monophyletic group to root by")
-    tt_parser.add_argument('--date-format', default="%Y-%m-%d", help="date format")
-    tt_parser.add_argument('--date-confidence', action="store_true", help="calculate confidence intervals for node dates")
-    tt_parser.add_argument('--time-marginal', action="store_true", help="assign internal nodes to their marginally most likely dates, not jointly most likely")
-    tt_parser.add_argument('--ancestral', choices=["joint", "marginal"],
+    ## REFINE.PY
+    refine_parser = subparsers.add_parser('refine', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    refine_parser.add_argument('--alignment', help="alignment in fasta or VCF format")
+    refine_parser.add_argument('--tree',required=True, help="prebuilt Newick")
+    refine_parser.add_argument('--metadata', type=str, help="tsv/csv table with meta data for sequences")
+    refine_parser.add_argument('--node-data', type=str, help='file name to write additional node data')
+    refine_parser.add_argument('--timetree', action="store_true", help="produce timetree using treetime")
+    refine_parser.add_argument('--coalescent', help="coalescent time scale in units of inverse clock rate (float), optimize as scalar ('opt'), or skyline ('skyline')")
+    refine_parser.add_argument('--clock-rate', type=float, help="fixed clock rate")
+    refine_parser.add_argument('--root', nargs="+", help="rooting mechanism ('best', 'residual', 'rsq', 'min_dev') "
+                                "OR node to root by OR two nodes indicating a monophyletic group to root by")
+    refine_parser.add_argument('--date-format', default="%Y-%m-%d", help="date format")
+    refine_parser.add_argument('--date-confidence', action="store_true", help="calculate confidence intervals for node dates")
+    refine_parser.add_argument('--time-marginal', action="store_true", help="assign internal nodes to their marginally most likely dates, not jointly most likely")
+    refine_parser.add_argument('--ancestral', choices=["joint", "marginal"],
                                 help="calculate joint maximum likelihood ancestral sequence states")
-    tt_parser.add_argument('--branchlengths', action="store_true", help="used with --ancestral; optimize branch length before reconstructing ancestral sequences")
-    tt_parser.add_argument('--branch-length-mode', default='auto', choices = ['auto', 'joint', 'marginal', 'input'],
+    refine_parser.add_argument('--branchlengths', action="store_true", help="used with --ancestral; optimize branch length before reconstructing ancestral sequences")
+    refine_parser.add_argument('--branch-length-mode', default='auto', choices = ['auto', 'joint', 'marginal', 'input'],
                                 help='branch length mode of treetime to use')
-    tt_parser.add_argument('--output', type=str, help='file name to write tree to')
-    tt_parser.add_argument('--n-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
+    refine_parser.add_argument('--output', type=str, help='file name to write tree to')
+    refine_parser.add_argument('--n-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
                              'interquartile ranges from the root-to-tip vs time regression')
-    tt_parser.add_argument('--nthreads', type=int, default=2,
-                             help="number of threads used")
-    tt_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
-    tt_parser.add_argument('--output-vcf', type=str, help='name of output VCF file which will include ancestral seqs, if treetime or ancestral is run')
-    tt_parser.add_argument('--year-limit', type=int, nargs='+', help='specify min or max & min years for samples with XX in year')
-    tt_parser.set_defaults(func=treetime_wrapper.run)
+    refine_parser.add_argument('--nthreads', type=int, default=2,
+                                help="number of threads used")
+    refine_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
+    refine_parser.add_argument('--output-vcf', type=str, help='name of output VCF file which will include ancestral seqs, if treetime or ancestral is run')
+    refine_parser.add_argument('--year-limit', type=int, nargs='+', help='specify min or max & min years for samples with XX in year')
+    refine_parser.set_defaults(func=refine.run)
+
 
     ## TRANSLATE.PY
     translate_parser = subparsers.add_parser('translate', formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/builds/tb/Snakefile
+++ b/builds/tb/Snakefile
@@ -67,13 +67,13 @@ rule refine:
         ref = config.ref
     output:
         tree = "results/tree.nwk",
-        node_data = "results/node_data.json",
+        node_data = "results/branch_lengths.json",
     params:
         root = 'residual'
     shell:
         """
         augur refine --tree {input.tree} --alignment {input.aln} --metadata {input.metadata} \
-            --output {output.tree} --node-data {output.node_data} --vcf-reference {input.ref} \
+            --output-tree {output.tree} --output-node-data {output.node_data} --vcf-reference {input.ref} \
             --timetree --root {params.root} --coalescent 0.0
         """
 
@@ -124,8 +124,8 @@ rule traits:
 rule export:
     input:
         tree = rules.refine.output.tree,
-        node_data = rules.refine.output.node_data,
         metadata = config.meta,
+        branch_lengths = rules.refine.output.node_data,
         traits = rules.traits.output,
         nt_muts = rules.ancestral.output.nt_data,
         aa_muts = rules.translate.output.aa_data,
@@ -137,6 +137,6 @@ rule export:
         meta = rules.all.input.auspice_meta
     shell:
         'augur export --tree {input.tree} --metadata {input.metadata}'
-            ' --node-data {input.node_data} {input.traits} {input.aa_muts} {input.nt_muts}'
+            ' --node-data {input.branch_lengths} {input.traits} {input.aa_muts} {input.nt_muts}'
             ' --auspice-config {input.config} --colors {input.color_defs} --output-tree {output.tree}'
             ' --lat-longs {input.geo_info} --output-meta {output.meta}'

--- a/builds/tb/Snakefile
+++ b/builds/tb/Snakefile
@@ -59,7 +59,7 @@ rule tree:
     shell:
         'augur tree --keep-vcf-fasta --strip-sites {input.sites} --alignment {input.aln} --vcf-reference {input.ref} --output {output} --method {params.method}'
 
-rule timetree:
+rule refine:
 	input:
 		aln = rules.mask.output,
         ref = config.ref,
@@ -72,16 +72,16 @@ rule timetree:
 	params:
 		root = 'residual'
 	shell:
-		'augur treetime --alignment {input.aln} --tree {input.tree} --metadata {input.metadata}'
+		'augur refine --alignment {input.aln} --tree {input.tree} --metadata {input.metadata}'
 		' --output {output.tree} --node-data {output.node_data} --vcf-reference {input.ref}'
 		' --timetree --root {params.root} --output-vcf {output.vcf} --coalescent 0.0 '
 
 rule translate:
 	input:
-		tree = rules.timetree.output.tree,
+		tree = rules.refine.output.tree,
 		ref = config.ref,
 		gene_ref = config.generef,
-		vcf = rules.timetree.output.vcf,
+		vcf = rules.refine.output.vcf,
 		genes = config.genes
 	output:
 		aa_data = "results/aa_muts.json",
@@ -93,7 +93,7 @@ rule translate:
 
 rule traits:
 	input:
-		tree = rules.timetree.output.tree,
+		tree = rules.refine.output.tree,
 		meta = config.meta
 	output:
 		"results/traits.json"
@@ -105,8 +105,8 @@ rule traits:
 
 rule export:
 	input:
-		tree = rules.timetree.output.tree,
-		node_data = rules.timetree.output.node_data,
+		tree = rules.refine.output.tree,
+		node_data = rules.refine.output.node_data,
 		metadata = config.meta,
 		traits = rules.traits.output,
 		aa_muts = rules.translate.output.aa_data,

--- a/builds/tb/Snakefile
+++ b/builds/tb/Snakefile
@@ -25,18 +25,18 @@ config = rules.config.params #so we can use config.x rather than rules.config.pa
 #end of config definition
 
 rule filter:
-	input:
-		seq = config.seq,
-		meta = config.meta,
-		exclude = config.exclude
-	output:
-		"results/filtered.vcf.gz"
-	params:
-		vpc = 10,
-		cat = "year month",
-		min_len = 200000
-	shell:
-		"augur filter --sequences {input.seq} --output {output} --metadata {input.meta} --exclude {input.exclude}"
+    input:
+        seq = config.seq,
+        meta = config.meta,
+        exclude = config.exclude
+    output:
+        "results/filtered.vcf.gz"
+    params:
+        vpc = 10,
+        cat = "year month",
+        min_len = 200000
+    shell:
+        "augur filter --sequences {input.seq} --output {output} --metadata {input.meta} --exclude {input.exclude}"
 
 rule mask:
     input:
@@ -60,21 +60,22 @@ rule tree:
         'augur tree --keep-vcf-fasta --strip-sites {input.sites} --alignment {input.aln} --vcf-reference {input.ref} --output {output} --method {params.method}'
 
 rule refine:
-	input:
-		aln = rules.mask.output,
-        ref = config.ref,
-		metadata = config.meta,
-		tree = rules.tree.output
-	output:
-		tree = "results/tree.nwk",
-		node_data = "results/node_data.json",
-		vcf = "results/treetime.vcf"
-	params:
-		root = 'residual'
-	shell:
-		'augur refine --alignment {input.aln} --tree {input.tree} --metadata {input.metadata}'
-		' --output {output.tree} --node-data {output.node_data} --vcf-reference {input.ref}'
-		' --timetree --root {params.root} --output-vcf {output.vcf} --coalescent 0.0 '
+    input:
+        tree = rules.tree.output,
+        aln = rules.mask.output,
+        metadata = config.meta,
+        ref = config.ref
+    output:
+        tree = "results/tree.nwk",
+        node_data = "results/node_data.json",
+    params:
+        root = 'residual'
+    shell:
+        """
+        augur refine --tree {input.tree} --alignment {input.aln} --metadata {input.metadata} \
+            --output {output.tree} --node-data {output.node_data} --vcf-reference {input.ref} \
+            --timetree --root {params.root} --coalescent 0.0
+        """
 
 rule ancestral:
     input:
@@ -94,47 +95,47 @@ rule ancestral:
         """
 
 rule translate:
-	input:
-		tree = rules.refine.output.tree,
-		ref = config.ref,
-		gene_ref = config.generef,
-		vcf = rules.ancestral.output.vcf,
-		genes = config.genes
-	output:
-		aa_data = "results/aa_muts.json",
-		vcf_out = "results/translations.vcf"
-	shell:
-		'augur translate --tree {input.tree} --genes {input.genes} --vcf-reference {input.ref}'
-		' --vcf-input {input.vcf} --output {output.aa_data} --reference-sequence {input.gene_ref}'
-		' --vcf-output {output.vcf_out}'
+    input:
+        tree = rules.refine.output.tree,
+        ref = config.ref,
+        gene_ref = config.generef,
+        vcf = rules.ancestral.output.vcf,
+        genes = config.genes
+    output:
+        aa_data = "results/aa_muts.json",
+        vcf_out = "results/translations.vcf"
+    shell:
+        'augur translate --tree {input.tree} --genes {input.genes} --vcf-reference {input.ref}'
+        ' --vcf-input {input.vcf} --output {output.aa_data} --reference-sequence {input.gene_ref}'
+        ' --vcf-output {output.vcf_out}'
 
 rule traits:
-	input:
-		tree = rules.refine.output.tree,
-		meta = config.meta
-	output:
-		"results/traits.json"
-	params:
-		traits = 'location cluster'
-	shell:
-		'augur traits --tree {input.tree} --metadata {input.meta}'
-		' --columns {params.traits} --output {output}'
+    input:
+        tree = rules.refine.output.tree,
+        meta = config.meta
+    output:
+        "results/traits.json"
+    params:
+        traits = 'location cluster'
+    shell:
+        'augur traits --tree {input.tree} --metadata {input.meta}'
+        ' --columns {params.traits} --output {output}'
 
 rule export:
-	input:
-		tree = rules.refine.output.tree,
-		node_data = rules.refine.output.node_data,
-		metadata = config.meta,
-		traits = rules.traits.output,
-		aa_muts = rules.translate.output.aa_data,
-		color_defs = config.colors,
-		config = config.config,
-		geo_info = config.geo_info
-	output:
-		tree = rules.all.input.auspice_tree,
-		meta = rules.all.input.auspice_meta
-	shell:
-		'augur export --tree {input.tree} --metadata {input.metadata}'
-			' --node-data {input.node_data} {input.traits} {input.aa_muts}'
-			' --auspice-config {input.config} --colors {input.color_defs} --output-tree {output.tree}'
-			' --lat-longs {input.geo_info} --output-meta {output.meta}'
+    input:
+        tree = rules.refine.output.tree,
+        node_data = rules.refine.output.node_data,
+        metadata = config.meta,
+        traits = rules.traits.output,
+        aa_muts = rules.translate.output.aa_data,
+        color_defs = config.colors,
+        config = config.config,
+        geo_info = config.geo_info
+    output:
+        tree = rules.all.input.auspice_tree,
+        meta = rules.all.input.auspice_meta
+    shell:
+        'augur export --tree {input.tree} --metadata {input.metadata}'
+            ' --node-data {input.node_data} {input.traits} {input.aa_muts}'
+            ' --auspice-config {input.config} --colors {input.color_defs} --output-tree {output.tree}'
+            ' --lat-longs {input.geo_info} --output-meta {output.meta}'

--- a/builds/tb/Snakefile
+++ b/builds/tb/Snakefile
@@ -83,15 +83,15 @@ rule ancestral:
         alignment = rules.mask.output,
         ref = config.ref
     output:
-        node_data = "results/nt_muts.json",
-        vcf = "results/nt_muts.vcf"
+        nt_data = "results/nt_muts.json",
+        vcf_out = "results/nt_muts.vcf"
     params:
         inference = "joint"
     shell:
         """
         augur ancestral --tree {input.tree} --alignment {input.alignment} \
-            --output {output.node_data} --inference {params.inference} \
-            --output-vcf {output.vcf} --vcf-reference {input.ref}
+            --output {output.nt_data} --inference {params.inference} \
+            --output-vcf {output.vcf_out} --vcf-reference {input.ref}
         """
 
 rule translate:
@@ -99,7 +99,7 @@ rule translate:
         tree = rules.refine.output.tree,
         ref = config.ref,
         gene_ref = config.generef,
-        vcf = rules.ancestral.output.vcf,
+        vcf = rules.ancestral.output.vcf_out,
         genes = config.genes
     output:
         aa_data = "results/aa_muts.json",
@@ -127,6 +127,7 @@ rule export:
         node_data = rules.refine.output.node_data,
         metadata = config.meta,
         traits = rules.traits.output,
+        nt_muts = rules.ancestral.output.nt_data,
         aa_muts = rules.translate.output.aa_data,
         color_defs = config.colors,
         config = config.config,
@@ -136,6 +137,6 @@ rule export:
         meta = rules.all.input.auspice_meta
     shell:
         'augur export --tree {input.tree} --metadata {input.metadata}'
-            ' --node-data {input.node_data} {input.traits} {input.aa_muts}'
+            ' --node-data {input.node_data} {input.traits} {input.aa_muts} {input.nt_muts}'
             ' --auspice-config {input.config} --colors {input.color_defs} --output-tree {output.tree}'
             ' --lat-longs {input.geo_info} --output-meta {output.meta}'

--- a/builds/tb/Snakefile
+++ b/builds/tb/Snakefile
@@ -76,12 +76,29 @@ rule refine:
 		' --output {output.tree} --node-data {output.node_data} --vcf-reference {input.ref}'
 		' --timetree --root {params.root} --output-vcf {output.vcf} --coalescent 0.0 '
 
+rule ancestral:
+    input:
+        tree = rules.refine.output.tree,
+        alignment = rules.mask.output,
+        ref = config.ref
+    output:
+        node_data = "results/nt_muts.json",
+        vcf = "results/nt_muts.vcf"
+    params:
+        inference = "joint"
+    shell:
+        """
+        augur ancestral --tree {input.tree} --alignment {input.alignment} \
+            --output {output.node_data} --inference {params.inference} \
+            --output-vcf {output.vcf} --vcf-reference {input.ref}
+        """
+
 rule translate:
 	input:
 		tree = rules.refine.output.tree,
 		ref = config.ref,
 		gene_ref = config.generef,
-		vcf = rules.refine.output.vcf,
+		vcf = rules.ancestral.output.vcf,
 		genes = config.genes
 	output:
 		aa_data = "results/aa_muts.json",

--- a/builds/zika/Snakefile
+++ b/builds/zika/Snakefile
@@ -78,14 +78,14 @@ rule refine:
         tree = "results/tree.nwk",
         node_data = "results/node_data.json"
     params:
-        n_iqd = 4
+        clock_filter_iqd = 4
     shell:
         """
         augur refine --tree {input.tree} --alignment {input.alignment} \
             --metadata {input.metadata} \
             --output {output.tree} --node-data {output.node_data} \
             --timetree --date-confidence --time-marginal --coalescent opt \
-            --n-iqd {params.n_iqd}
+            --clock-filter-iqd {params.clock_filter_iqd}
         """
 
 rule ancestral:

--- a/builds/zika/Snakefile
+++ b/builds/zika/Snakefile
@@ -76,14 +76,14 @@ rule refine:
         metadata = rules.parse.output.metadata
     output:
         tree = "results/tree.nwk",
-        node_data = "results/node_data.json"
+        node_data = "results/branch_lengths.json"
     params:
         clock_filter_iqd = 4
     shell:
         """
         augur refine --tree {input.tree} --alignment {input.alignment} \
             --metadata {input.metadata} \
-            --output {output.tree} --node-data {output.node_data} \
+            --output-tree {output.tree} --output-node-data {output.node_data} \
             --timetree --date-confidence --time-marginal --coalescent opt \
             --clock-filter-iqd {params.clock_filter_iqd}
         """
@@ -102,6 +102,19 @@ rule ancestral:
             --output {output.node_data} --inference {params.inference}
         """
 
+rule translate:
+    input:
+        tree = rules.refine.output.tree,
+        node_data = rules.ancestral.output.node_data,
+        ref = config.reference
+    output:
+        node_data = "results/aa_muts.json"
+    shell:
+        """
+        augur translate --tree {input.tree} --node-data {input.node_data} \
+            --output {output.node_data} --reference-sequence {input.ref}
+        """
+
 rule traits:
     input:
         tree = rules.refine.output.tree,
@@ -116,24 +129,11 @@ rule traits:
             --output {output.node_data} --confidence --columns {params.columns}
         """
 
-rule translate:
-    input:
-        tree = rules.refine.output.tree,
-        node_data = rules.ancestral.output.node_data,
-        ref = config.reference
-    output:
-        node_data = "results/aa_muts.json"
-    shell:
-        """
-        augur translate --tree {input.tree} --node-data {input.node_data} \
-            --output {output.node_data} --reference-sequence {input.ref}
-        """
-
 rule export:
     input:
         tree = rules.refine.output.tree,
         metadata = rules.parse.output.metadata,
-        node_data = rules.refine.output.node_data,
+        branch_lengths = rules.refine.output.node_data,
         traits = rules.traits.output.node_data,
         nt_muts = rules.ancestral.output.node_data,
         aa_muts = rules.translate.output.node_data,
@@ -145,7 +145,7 @@ rule export:
     shell:
         """
         augur export --tree {input.tree} --metadata {input.metadata} \
-            --node-data {input.node_data} {input.traits} {input.nt_muts} {input.aa_muts} \
+            --node-data {input.branch_lengths} {input.traits} {input.nt_muts} {input.aa_muts} \
             --colors {input.colors} --auspice-config {input.auspice_config} \
             --output-tree {output.auspice_tree} --output-meta {output.auspice_meta}
         """

--- a/builds/zika/Snakefile
+++ b/builds/zika/Snakefile
@@ -135,6 +135,7 @@ rule export:
         metadata = rules.parse.output.metadata,
         node_data = rules.refine.output.node_data,
         traits = rules.traits.output.node_data,
+        nt_muts = rules.ancestral.output.node_data,
         aa_muts = rules.translate.output.node_data,
         colors = config.colors,
         auspice_config = config.auspice_config
@@ -144,7 +145,7 @@ rule export:
     shell:
         """
         augur export --tree {input.tree} --metadata {input.metadata} \
-            --node-data {input.node_data} {input.traits} {input.aa_muts} \
+            --node-data {input.node_data} {input.traits} {input.nt_muts} {input.aa_muts} \
             --colors {input.colors} --auspice-config {input.auspice_config} \
             --output-tree {output.auspice_tree} --output-meta {output.auspice_meta}
         """

--- a/builds/zika/Snakefile
+++ b/builds/zika/Snakefile
@@ -88,6 +88,20 @@ rule refine:
             --n-iqd {params.n_iqd}
         """
 
+rule ancestral:
+    input:
+        tree = rules.refine.output.tree,
+        alignment = rules.align.output
+    output:
+        node_data = "results/nt_muts.json"
+    params:
+        inference = "joint"
+    shell:
+        """
+        augur ancestral --tree {input.tree} --alignment {input.alignment} \
+            --output {output.node_data} --inference {params.inference}
+        """
+
 rule traits:
     input:
         tree = rules.refine.output.tree,
@@ -105,7 +119,7 @@ rule traits:
 rule translate:
     input:
         tree = rules.refine.output.tree,
-        node_data = rules.refine.output.node_data,
+        node_data = rules.ancestral.output.node_data,
         ref = config.reference
     output:
         node_data = "results/aa_muts.json"

--- a/builds/zika/Snakefile
+++ b/builds/zika/Snakefile
@@ -69,7 +69,7 @@ rule tree:
         augur tree --alignment {input.alignment} --output {output.tree}
         """
 
-rule timetree:
+rule refine:
     input:
         tree = rules.tree.output.tree,
         alignment = rules.align.output,
@@ -81,7 +81,7 @@ rule timetree:
         n_iqd = 4
     shell:
         """
-        augur treetime --tree {input.tree} --alignment {input.alignment} \
+        augur refine --tree {input.tree} --alignment {input.alignment} \
             --metadata {input.metadata} \
             --output {output.tree} --node-data {output.node_data} \
             --timetree --date-confidence --time-marginal --coalescent opt \
@@ -90,7 +90,7 @@ rule timetree:
 
 rule traits:
     input:
-        tree = rules.timetree.output.tree,
+        tree = rules.refine.output.tree,
         metadata = rules.parse.output.metadata
     output:
         node_data = "results/traits.json",
@@ -104,8 +104,8 @@ rule traits:
 
 rule translate:
     input:
-        tree = rules.timetree.output.tree,
-        node_data = rules.timetree.output.node_data,
+        tree = rules.refine.output.tree,
+        node_data = rules.refine.output.node_data,
         ref = config.reference
     output:
         node_data = "results/aa_muts.json"
@@ -117,9 +117,9 @@ rule translate:
 
 rule export:
     input:
-        tree = rules.timetree.output.tree,
+        tree = rules.refine.output.tree,
         metadata = rules.parse.output.metadata,
-        node_data = rules.timetree.output.node_data,
+        node_data = rules.refine.output.node_data,
         traits = rules.traits.output.node_data,
         aa_muts = rules.translate.output.node_data,
         colors = config.colors,


### PR DESCRIPTION
This is my attempt at addressing #133. This does a few different things:

#### 1. Rename `augur treetime` to `augur refine`

I did this for largely semantic reasons. Where you would for example want to take a BEAST tree through the pipeline. Seemed reasonable to "refine" this tree, but I thought I would add confusion to need to run "treetime" (synonymous with "timetree" in most people's minds). Similar story for skipping timetree inference and going directly from ML tree from `augur tree` through the rest of the pipeline. Here, I would not expose rooting functions in `augur tree` and keeping all rooting in `augur refine`. ML tree has to go through `augur refine` even if `--timetree` is not run.

With this approach, all trees need refining to produce a `node_data.json` file that is necessary for later steps in the pipeline. There is no way to get through the pipeline without refining, even if it just produces a `tree.nwk` with internal node labels. I would purposely make it to that `augur tree` produces an "unrefined" tree without internal node labels so that downstream steps can easily warn the user that `augur refine` needs to be run.

#### 2. Move ancestral state reconstruction out of `augur refine` and into `augur ancestral`

This doesn't reduce the command line option array to `augur refine` sizably but I do think it significantly improves file IO. I believe the fact that it needed to be called `node_data.json` was indicative that this file was overloaded. Now output from `augur refine` can be called `branch_lengths.json` and just includes:
```
  "PRVABC59": {
   "branch_length": 0.001280070478900094,
   "numdate": 2015.9993155373031,
   "clock_length": 0.001280070478900094,
   "mutation_length": 0.0020497652584097964,
   "raw_date": "2015-12-XX",
   "date": "2015-12-31",
   "num_date_confidence": [2015.9273565373035, 2015.9993155373031]
  },
```
And `nt_muts.json` produced by `augur ancestral` includes:
```
 "PRVABC59": {
   "sequence": "GAATCAGACTGCG...",
   "muts": ["T329C", "T762C", "G1170T", ...]
 }
```
This feels like it's no longer overloading `node_data.json`. And it's clear why `augur translate` would need the output of `augur ancestral`.

This also reduces file output of `augur refine` in `tb/Snakefile` from 3 files to 2 (and I think we can improve this further, but I'd like this to be a separate PR).

#### 3. Streamline mutation format in nt_muts.json and aa_muts.json

Previously, `node_data.json` and `aa_muts.json` encoded mutations as `[ ["T", 329, "C"], [ ["T", 762, "C"] ]` and then used the function `process_mutations` in `augur export` to convert to `tree.json` format `["T329C", "T762C"]`. Now, `nt_muts.json` and `aa_muts.json` just use string format directly.

I think this also results in more readable files.

#### 4. Rename `--n-iqd` in `augur refine` to `--clock-filter-iqd`

`n-iqd` was super opaque, while `clock-filter-iqd` at least let's you know what's going on.

#### 5. Be explicit with `--output-tree` and `--output-node-data` for `augur refine`

This is to match the behavior of `augur parse` and `augur export`.

#### 6. Update `zika/Snakefile` and `tb/Snakefile` to be compatible with above changes.

This adds the additional rule `ancestral` to each. I tested and both appear to fully work. There was a tabs vs spaces issue in `tb/Snakefile` where in resolving to spaces it makes it look like I've made more extensive changes than I actually have.