### PR TITLE
CLI revisions

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -130,10 +130,10 @@ def run(args):
             print("ERROR: meta data with dates is required for time tree reconstruction")
             return -1
         metadata, columns = read_metadata(args.metadata)
-        if args.year_limit:
-            args.year_limit.sort()
+        if args.year_bounds:
+            args.year_bounds.sort()
         dates = get_numerical_dates(metadata, fmt=args.date_format,
-                                    min_max_year=args.year_limit)
+                                    min_max_year=args.year_bounds)
 
         # save input state string for later export
         for n in T.get_terminals():

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -3,7 +3,7 @@ from Bio import Phylo
 from .utils import read_metadata, get_numerical_dates, write_json
 from treetime.vcf_utils import read_vcf, write_vcf
 
-def refine(tree=None, aln=None, ref=None, dates=None, branch_length_mode='auto',
+def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='auto',
              confidence=False, resolve_polytomies=True, max_iter=2,
              infer_gtr=True, Tc=0.01, reroot=None, use_marginal=False, fixed_pi=None,
              clock_rate=None, clock_filter_iqd=None, verbosity=1, **kwarks):
@@ -24,8 +24,8 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_mode='auto',
     if ref is not None: # VCF -> adjust branch length
         #set branch length mode explicitly if auto, as informative-site only
         #trees can have big branch lengths, making this set incorrectly in TreeTime
-        if branch_length_mode == 'auto':
-            branch_length_mode = 'joint'
+        if branch_length_inference == 'auto':
+            branch_length_inference = 'joint'
 
     #send ref, if is None, does no harm
     tt = TreeTime(tree=tree, aln=aln, ref=ref, dates=dates,
@@ -52,7 +52,7 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_mode='auto',
         marginal = confidence
 
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
-           branch_length_mode=branch_length_mode, resolve_polytomies=resolve_polytomies,
+           branch_length_inference=branch_length_inference, resolve_polytomies=resolve_polytomies,
            max_iter=max_iter, fixed_pi=fixed_pi, fixed_clock_rate=clock_rate,
            **kwarks)
 
@@ -147,7 +147,7 @@ def run(args):
                       reroot=args.root or 'best',
                       Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
                       use_marginal = args.date_inference == 'marginal',
-                      branch_length_mode = args.branch_length_mode or 'auto',
+                      branch_length_inference = args.branch_length_inference or 'auto',
                       clock_rate=args.clock_rate, clock_filter_iqd=args.clock_filter_iqd)
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -146,7 +146,7 @@ def run(args):
         tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
                       reroot=args.root or 'best',
                       Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
-                      use_marginal = args.time_marginal or False,
+                      use_marginal = args.date_inference == 'marginal',
                       branch_length_mode = args.branch_length_mode or 'auto',
                       clock_rate=args.clock_rate, clock_filter_iqd=args.clock_filter_iqd)
 

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -8,7 +8,7 @@ def run(args):
     T = Phylo.read(args.tree, 'newick')
 
     TM_tree, TM_subs = None, None
-    if args.output_tree_model:
+    if args.titer_model == "tree":
         from .titer_model import TreeModel
         TM_tree = TreeModel(T, args.titers)
         TM_tree.prepare()
@@ -20,13 +20,13 @@ def run(args):
                       'avidity':TM_tree.compile_virus_effects(),
                       'nodes':{n.name:{"dTiter": n.dTiter, "cTiter":n.cTiter}
                                   for n in T.find_clades()}}
-        write_json(tree_model, args.output_tree_model)
+        write_json(tree_model, args.output)
         print("\nInferred titer model of type 'TreeModel' using augur:"
               "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic phenotypes of seasonal influenza viruses."
               "\n\tPNAS, vol 113, 10.1073/pnas.1525578113\n")
-        print("results written to",args.output_tree_model)
+        print("results written to", args.output)
 
-    if args.output_subs_model:
+    if args.titer_model == "substitution":
         from .titer_model import SubstitutionModel
         TM_subs = SubstitutionModel(T, args.titers)
         TM_subs.prepare()
@@ -37,10 +37,9 @@ def run(args):
                       'potency':TM_subs.compile_potencies(),
                       'avidity':TM_subs.compile_virus_effects(),
                       'substitution':TM_subs.compile_substitution_effects()}
-        write_json(subs_model, args.output_subs_model)
+        write_json(subs_model, args.output)
 
         print("\nInferred titer model of type 'SubstitutionModel' using augur:"
               "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic phenotypes of seasonal influenza viruses."
               "\n\tPNAS, vol 113, 10.1073/pnas.1525578113\n")
-        print("results written to",args.output_subs_model)
-
+        print("results written to", args.output)

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -251,7 +251,7 @@ def run(args):
 
     # construct reduced alignment if needed
     if is_vcf:
-        variable_fasta = write_out_informative_fasta(compress_seq, args.alignment, stripFile=args.strip_sites)
+        variable_fasta = write_out_informative_fasta(compress_seq, args.alignment, stripFile=args.exclude_sites)
         fasta = variable_fasta
     else:
         fasta = aln

--- a/bin/augur
+++ b/bin/augur
@@ -95,7 +95,7 @@ if __name__=="__main__":
     refine_parser.add_argument('--nthreads', type=int, default=2,
                                 help="number of threads used")
     refine_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
-    refine_parser.add_argument('--year-limit', type=int, nargs='+', help='specify min or max & min years for samples with XX in year')
+    refine_parser.add_argument('--year-bounds', type=int, nargs='+', help='specify min or max & min prediction bounds for samples with XX in year')
     refine_parser.set_defaults(func=refine.run)
 
     ## ANCESTRAL.PY

--- a/bin/augur
+++ b/bin/augur
@@ -88,7 +88,7 @@ if __name__=="__main__":
     refine_parser.add_argument('--date-confidence', action="store_true", help="calculate confidence intervals for node dates")
     refine_parser.add_argument('--date-inference', default='joint', choices=["joint", "marginal"],
                                 help="assign internal nodes to their marginally most likely dates, not jointly most likely")
-    refine_parser.add_argument('--branch-length-mode', default='auto', choices = ['auto', 'joint', 'marginal', 'input'],
+    refine_parser.add_argument('--branch-length-inference', default='auto', choices = ['auto', 'joint', 'marginal', 'input'],
                                 help='branch length mode of treetime to use')
     refine_parser.add_argument('--clock-filter-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
                                 'interquartile ranges from the root-to-tip vs time regression')

--- a/bin/augur
+++ b/bin/augur
@@ -68,7 +68,7 @@ if __name__=="__main__":
     tree_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
     tree_parser.add_argument('--keep-vcf-fasta', action="store_true", help='do not delete informative-site fasta created when '
                              'making tree from VCF input')
-    tree_parser.add_argument('--strip-sites', type=str, help='file name of sites to exclude for raw tree building (VCF only)')
+    tree_parser.add_argument('--exclude-sites', type=str, help='file name of sites to exclude for raw tree building (VCF only)')
     tree_parser.set_defaults(func=tree.run)
 
 

--- a/bin/augur
+++ b/bin/augur
@@ -137,8 +137,9 @@ if __name__=="__main__":
     titers_parser = subparsers.add_parser('titers', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     titers_parser.add_argument('--titers', required=True, type=str, help="file with titer measurements")
     titers_parser.add_argument('--tree', '-t', type=str, required=True, help="tree to perform fit titer model to")
-    titers_parser.add_argument('--output-tree-model', type=str, help='JSON file to save tree model')
-    titers_parser.add_argument('--output-subs-model', type=str, help='JSON file to save subs model')
+    titers_parser.add_argument('--titer-model', default='substitution', choices=["substitution", "tree"],
+                                help="titer model to use, see Neher et al. 2016 for details")
+    titers_parser.add_argument('--output', '-o', type=str, help='JSON file to save titer model')
     titers_parser.set_defaults(func=titers.run)
 
     ## EXPORT.PY

--- a/bin/augur
+++ b/bin/augur
@@ -86,7 +86,8 @@ if __name__=="__main__":
                                 "OR node to root by OR two nodes indicating a monophyletic group to root by")
     refine_parser.add_argument('--date-format', default="%Y-%m-%d", help="date format")
     refine_parser.add_argument('--date-confidence', action="store_true", help="calculate confidence intervals for node dates")
-    refine_parser.add_argument('--time-marginal', action="store_true", help="assign internal nodes to their marginally most likely dates, not jointly most likely")
+    refine_parser.add_argument('--date-inference', default='joint', choices=["joint", "marginal"],
+                                help="assign internal nodes to their marginally most likely dates, not jointly most likely")
     refine_parser.add_argument('--branch-length-mode', default='auto', choices = ['auto', 'joint', 'marginal', 'input'],
                                 help='branch length mode of treetime to use')
     refine_parser.add_argument('--clock-filter-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '

--- a/builds/tb/Snakefile
+++ b/builds/tb/Snakefile
@@ -63,7 +63,7 @@ rule tree:
     params:
         method = 'iqtree'
     shell:
-        'augur tree --keep-vcf-fasta --strip-sites {input.sites} --alignment {input.aln} --vcf-reference {input.ref} --output {output} --method {params.method}'
+        'augur tree --keep-vcf-fasta --exclude-sites {input.sites} --alignment {input.aln} --vcf-reference {input.ref} --output {output} --method {params.method}'
 
 rule refine:
     input:

--- a/builds/zika/Snakefile
+++ b/builds/zika/Snakefile
@@ -85,7 +85,7 @@ rule refine:
         augur refine --tree {input.tree} --alignment {input.alignment} \
             --metadata {input.metadata} \
             --output-tree {output.tree} --output-node-data {output.node_data} \
-            --timetree --date-confidence --time-marginal --coalescent opt \
+            --timetree --date-confidence --date-inference marginal --coalescent opt \
             --clock-filter-iqd {params.clock_filter_iqd}
         """
 


### PR DESCRIPTION
This represents the rest of a pass through `bin/augur`. I tried to make the interface as consistent as possible across modules. This involved several small changes (each a separate commit in this PR).

#### 1. Rename tree `--strip-sites` to `--exclude-sites`

I thought that it seemed more natural to "exclude" sites from an analysis than it did to "strip
 them. I also liked making this consistent with `augur filter` where we "exclude" strains, we don't "strip" them from the input.

#### 2. Rename `--coalescent` to `--coalescent-timescale`

I thought that `--coalescent` was too similar to the store true flag of `--timetree`. Signaled to me whether or not to use the coalescent. Calling it `--coalescent-timescale` helps with this and also makes it less opaque when `--coalescent-timescale 0.0001` is encountered in a snakefile.

#### 3. Rename `--year-limit` to `--year-bounds`

When I first read `--year-limit` I took it to mean to filter tips between these years. I changed this to `--year-bounds` to help here thinking that this is more statistically appropriate: https://en.wikipedia.org/wiki/Uniform_distribution_(continuous). Distributions have "boundaries"; they don't have "limits".

#### 4. Rename `--time-marginal` to `--date-inference`

Two things. I wanted "date" instead of "time" to be consistent with `--date-confidence`. I changed it to a set of options with a default to be consistent with `augur ancestral --inference` and `augur refine --branch-length-inference`. This makes it so all the arguments that want to know "joint" vs "marginal" are referred to as "inference".

#### 5. Rename `--branch-length-mode` to `--branch-length-inference`

As above, make "joint" vs "marginal" arguments consistent.

#### 6. Create `--titer-model` option and reduce to single `--output`

I think common to just want a single one of these models ("substitution" vs "tree") and was not clear that you got this by just giving a single option of the two `--output-subs-model` and `--output-tree-model`. I think a single `--output` is much more standard.

----------------------

If there are disagreements, I'm happy to refactor the PR to drop individual changes.