### PR TITLE
take more file formats for sites to exclude

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -177,9 +177,21 @@ def write_out_informative_fasta(compress_seq, alignment, stripFile=None):
     #IF FIND STANDARDIZED DRM FILE FORMAT, IMPLEMENT HERE
     strip_pos = []
     if stripFile:
-        with open(stripFile, 'r') as ifile:
-            strip_pos = [int(line.strip()) for line in ifile]
+        if stripFile.lower().endswith('.bed'): #BED format file
+            import pandas as pd
+            bed = pd.read_csv(stripFile, sep='\t')
+            for index, row in bed.iterrows():
+                strip_pos.extend(list(range(row[1], row[2]+1)))
 
+        else: #site-per-line format or DRM-file format
+            with open(stripFile, 'r') as ifile:
+                line1 = ifile.readline()
+                if '\t' in line1: #DRM-file format
+                    strip_pos = [int(line.strip().split('\t')[1]) for line in ifile]
+                else: #site-per-line
+                    strip_pos.append(int(line1.strip())) #add back 1st line
+
+    strip_pos = np.unique(strip_pos)
     #Get sequence names
     seqNames = list(sequences.keys())
 


### PR DESCRIPTION
From issue #153 , `tree` is modified to take 3 types of input:
- BED file format (detected by file ending in .bed)
- one site per line .txt input (if not the above and contains no tabs - current format used)
- tab-delimited 'DRM' format, where it takes the 2nd column

The third format is not standard and based on the DRM file format I received from the Gagneux lab, but is the format taken by `find-drm` (which I'll add soon). If a standard format for DRM sites is found I can modify this again. 