### PR TITLE
perform lat long matching respecting case

### DIFF
--- a/augur/export.py
+++ b/augur/export.py
@@ -119,7 +119,7 @@ def export_metadata_json(T, metadata, tree_meta, config, color_mapping, lat_long
             geo[geo_field]={}
             for node, attrs in tree_meta["nodes"].items():
                 if geo_field in attrs:
-                    loc = attrs[geo_field].lower()
+                    loc = attrs[geo_field]
                     if loc not in geo[geo_field]:
                         if (geo_field,loc) in lat_long_mapping:
                             geo[geo_field][loc] = lat_long_mapping[(geo_field,loc)]


### PR DESCRIPTION
Previously, the geo demes (in the metatdata.tsv) were converted into lowercase for matching against the parsed lat_longs file. The demes were then saved to the meta.JSON in lowercase, which meant that they may not match the demes as saved on the tree nodes (which wern't converted to lowercase).

This PR parses the geographic resolution & demes from the lat_longs file in lowercase, and then matches the metadata.tsv resolution & demes in lowercase, however the demes are exported as they appeared in the metadata.tsv. This allows (e.g.) `WA` to be specified in the metadata.tsv, get the lat_longs from `wa` in the lat_longs file, but still be exported on both the nodes & meta JSONs as `WA`

Resolves #160  