### PR TITLE
KDE frequencies import/export

### DIFF
--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -50,7 +50,7 @@ def export_tip_frequency_json(process, prefix, indent):
 
     for n in process.tree.tree.get_terminals():
         freq_json[n.name] = {
-            "frequencies" : round_freqs(process.kde_frequencies.frequencies["global"][n.clade], num_dp)
+            "frequencies" : round_freqs(process.kde_frequencies.frequencies[n.clade], num_dp)
         }
 
     write_json(freq_json, prefix+'_tip-frequencies.json', indent=indent)

--- a/base/auspice_export.py
+++ b/base/auspice_export.py
@@ -41,17 +41,16 @@ def export_frequency_json(process, prefix, indent):
         process.log.notify("Cannot export frequencies - pivots do not exist")
 
 def export_tip_frequency_json(process, prefix, indent):
-    if not (hasattr(process, 'pivots') and hasattr(process, 'kde_frequencies')):
-        process.log.notify("Cannot export tip frequencies - pivots and/or kde_frequencies do not exist")
+    if not hasattr(process, 'kde_frequencies'):
+        process.log.notify("Cannot export tip frequencies - kde_frequencies do not exist")
         return
 
     num_dp = 6
-    freq_json = {'pivots':round_freqs(process.pivots, num_dp)}
+    freq_json = {'pivots':round_freqs(process.kde_frequencies.pivots, num_dp)}
 
     for n in process.tree.tree.get_terminals():
         freq_json[n.name] = {
-            "frequencies" : round_freqs(process.kde_frequencies["global"][n.clade], num_dp),
-            "weight": 1.0
+            "frequencies" : round_freqs(process.kde_frequencies.frequencies["global"][n.clade], num_dp)
         }
 
     write_json(freq_json, prefix+'_tip-frequencies.json', indent=indent)

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -178,7 +178,7 @@ class fitness_model(object):
         for node in self.nodes:
             tmp_tips = []
             if node.is_terminal():
-                tmp_tips.append((tip_index_region_specific, node.numdate))
+                tmp_tips.append((tip_index_region_specific, node.attr["num_date"]))
                 tip_index_region_specific += 1
 
             for child in node.clades:

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -579,7 +579,7 @@ class KdeFrequencies(object):
     """
     def __init__(self, sigma_narrow=1 / 12.0, sigma_wide=3 / 12.0, proportion_wide=0.2,
                  pivot_frequency=1 / 12.0, start_date=None, end_date=None, weights=None, weights_attribute=None,
-                 max_date=None, include_internal_nodes=True):
+                 max_date=None, include_internal_nodes=False):
         """Define parameters for KDE-based frequency estimation.
 
         Args:

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -284,7 +284,8 @@ class tree_frequencies(object):
     '''
     class that estimates frequencies for nodes in the tree. each internal node is assumed
     to be named with an attribute clade, of root doesn't have such an attribute, clades
-    will be numbered in preorder. Each node is assumed to have an attribute "numdate"
+    will be numbered in preorder. Each node is assumed to have an attribute `attr` with a
+    key "num_date".
     '''
     def __init__(self, tree, pivots, node_filter=None, min_clades = 20, verbose=0, pc=1e-4, **kwargs):
         '''
@@ -320,7 +321,7 @@ class tree_frequencies(object):
         for node in self.tree.find_clades(order='postorder'):
             if node.is_terminal():
                 if self.node_filter(node):
-                    tps.append(node.numdate)
+                    tps.append(node.attr["num_date"])
                     node.leafs = np.array([leaf_count], dtype=int)
                     leaf_count+=1
                 else:
@@ -576,17 +577,135 @@ class KdeFrequencies(object):
     density estimate across discrete time points from these tip observations for
     each clade in the tree.
     """
-    def __init__(self):
-        pass
+    def __init__(self, sigma_narrow=1 / 12.0, sigma_wide=3 / 12.0, proportion_wide=0.2,
+                 pivot_frequency=1 / 12.0, start_date=None, end_date=None, weights=None, weights_attribute=None,
+                 max_date=None, include_internal_nodes=True):
+        """Define parameters for KDE-based frequency estimation.
+
+        Args:
+            sigma_narrow (float): Bandwidth for first of two Gaussians composing the KDEs
+            sigma_wide (float): Bandwidth for second of two Gaussians composing the KDEs
+            proportion_wide (float): Proportion of the second Gaussian to include in each KDE
+            pivot_frequency (float): Frequency at which pivots should occur in fractions of a year
+            start_date (float): start of the pivots interval
+            end_date (float): end of the pivots interval
+            weights (dict): Numerical weights indexed by attribute values and applied to individual tips
+            weights_attribute (str): Attribute annotated on tips of a tree to use for weighting
+            max_date (float): Maximum year beyond which tips are excluded from frequency estimation and are assigned
+                              frequencies of zero
+            include_internal_nodes (bool): Whether internal (non-tip) nodes should have their frequencies estimated
+
+        Returns:
+            KdeFrequencies
+        """
+        self.sigma_narrow = sigma_narrow
+        self.sigma_wide = sigma_wide
+        self.proportion_wide = proportion_wide
+        self.pivot_frequency = pivot_frequency
+        self.start_date = start_date
+        self.end_date = end_date
+        self.weights = weights
+        self.weights_attribute = weights_attribute
+        self.max_date = max_date
+        self.include_internal_nodes = include_internal_nodes
 
     @classmethod
-    def get_density_for_observation(cls, mu, pivots, sigmaNarrow=1/12.0, sigmaWide=3/12.0, proportionWide=0.2):
+    def from_json(cls, json_dict):
+        """Returns an instance populated with parameters and data from the given JSON dictionary.
+        """
+        params = json_dict["params"]
+        instance = cls(**params)
+
+        if "data" in json_dict:
+            instance.pivots = np.array(json_dict["data"]["pivots"])
+            frequencies = json_dict["data"]["frequencies"]
+
+            instance.frequencies = defaultdict(dict)
+            for region in frequencies:
+                for clade in frequencies[region]:
+                    instance.frequencies[region][int(clade)] = np.array(frequencies[region][clade])
+
+        return instance
+
+    def to_json(self):
+        """Returns a dictionary for the current instance that can be serialized in a JSON file.
+        """
+        frequencies_json = {
+            "params": {
+                "sigma_narrow": self.sigma_narrow,
+                "sigma_wide": self.sigma_wide,
+                "proportion_wide": self.proportion_wide,
+                "pivot_frequency": self.pivot_frequency,
+                "start_date": self.start_date,
+                "end_date": self.end_date,
+                "weights": self.weights,
+                "weights_attribute": self.weights_attribute,
+                "max_date": self.max_date,
+                "include_internal_nodes": self.include_internal_nodes
+            }
+        }
+
+        # If frequencies have been estimated, export them along with the pivots as data.
+        if hasattr(self, "frequencies"):
+            frequencies = {}
+            for region in self.frequencies:
+                frequencies[region] = {}
+
+                for clade in self.frequencies[region]:
+                    # numpy arrays are not supported by JSON and need to be converted to lists.
+                    frequencies[region][clade] = self.frequencies[region][clade].tolist()
+
+            frequencies_json["data"] = {
+                "pivots": self.pivots.tolist(),
+                "frequencies": frequencies
+            }
+
+        return frequencies_json
+
+    @classmethod
+    def calculate_pivots(cls, pivot_frequency, tree=None, start_date=None, end_date=None):
+        """
+        Calculate pivots for a given pivot frequency and either a tree or a start and end date.
+
+        If a tree is given, the start and end interval for these pivots is determined by the earliest and latest strain
+        date in the tree.
+
+        If a start and end date are given, those values determine the range of the pivots. These values and the tree
+        are mutually exclusive. If all arguments are provided, the start and end dates will be preferred over the tree.
+
+        Args:
+            pivot_frequency (float): frequency pivots should occur by fraction of a year
+            tree (Bio.Phylo): an annotated tree
+            start_date (float): start of the pivots interval
+            end_date (float): end of the pivots interval
+
+        Returns:
+            pivots (numpy array): pivots spanning the given the dates represented by the tree's tips
+        """
+        if start_date is None or end_date is None:
+            # Determine pivot start and end dates from the range of tip dates in the given tree.
+            tip_dates = [tip.attr["num_date"] for tip in tree.get_terminals()]
+            pivot_start = min(tip_dates)  # type: float
+            pivot_end = max(tip_dates)    # type: float
+        else:
+            # Use the explicitly provided start and end dates.
+            pivot_start = start_date
+            pivot_end = end_date
+
+        return np.arange(
+            pivot_start,
+            pivot_end,
+            pivot_frequency
+        )
+
+    @classmethod
+    def get_density_for_observation(cls, mu, pivots, sigma_narrow=1/12.0, sigma_wide=3/12.0, proportion_wide=0.2):
         """Build a normal distribution centered across the given floating point date,
         mu, with a standard deviation based on the given sigma value and return
         the probability mass at each pivot. These mass values per pivot will form the
         input for a kernel density estimate across multiple observations.
         """
-        return (1-proportionWide) * norm.pdf(pivots, loc=mu, scale=sigmaNarrow) + proportionWide * norm.pdf(pivots, loc=mu, scale=sigmaWide)
+        return (1-proportion_wide) * norm.pdf(pivots, loc=mu, scale=sigma_narrow) + proportion_wide * norm.pdf(pivots, loc=mu, scale=sigma_wide)
 
     @classmethod
     def get_densities_for_observations(cls, observations, pivots, max_date=None, **kwargs):
@@ -638,11 +757,9 @@ class KdeFrequencies(object):
 
         return normalized_freq_matrix
 
-    @classmethod
-    def estimate_frequencies_for_tree(cls, tree, pivots, **kwargs):
+    def estimate_frequencies_for_tree(self, tree):
         """Estimate global frequencies for all nodes in a tree across the given pivots.
         """
-
         clade_frequencies = defaultdict(dict)
 
         # Find tips within region.
@@ -655,36 +772,42 @@ class KdeFrequencies(object):
         clade_to_index = {clades[i]: i for i in range(len(clades))}
 
         # Calculate tip frequencies and normalize.
-        normalized_freq_matrix = cls.estimate_frequencies(tip_dates, pivots, normalize_to=1.0, **kwargs)
+        normalized_freq_matrix = self.estimate_frequencies(
+            tip_dates,
+            self.pivots,
+            normalize_to=1.0,
+            sigma_narrow=self.sigma_narrow,
+            sigma_wide=self.sigma_wide,
+            proportion_wide=self.proportion_wide,
+            max_date=self.max_date
+        )
 
         for clade in clades:
             clade_frequencies["global"][clade] = normalized_freq_matrix[clade_to_index[clade]]
 
-        for node in tree.find_clades(order="postorder"):
-            if not node.is_terminal():
-                clade_frequencies["global"][node.clade] = np.array([clade_frequencies["global"][child.clade]
-                                                                for child in node.clades]).sum(axis=0)
+        if self.include_internal_nodes:
+            for node in tree.find_clades(order="postorder"):
+                if not node.is_terminal():
+                    clade_frequencies["global"][node.clade] = np.array([clade_frequencies["global"][child.clade]
+                                                                        for child in node.clades]).sum(axis=0)
 
         return clade_frequencies
 
-
-    @classmethod
-    def estimate_region_weighted_frequencies_for_tree(cls, tree, pivots, regions, weights, **kwargs):
+    def estimate_weighted_frequencies_for_tree(self, tree):
         """Estimate global and regional frequencies for all nodes in a tree across the
-        given pivots. Global frequencies represent a weighted mean across regions.
-        regions is a list of region names
-        weights is a list of region weights
+        given pivots. Global frequencies represent a weighted mean across the values in
+        attribute defined by `self.weights_attribute`.
         """
-
         clade_frequencies = defaultdict(dict)
 
-        proportions = np.array(weights) / np.array(weights).sum(axis=0)
+        weight_keys, weight_values = zip(*sorted(self.weights.items()))
+        proportions = np.array(weight_values) / np.array(weight_values).sum(axis=0)
 
-        for (region, proportion) in zip(regions, proportions):
-
+        for (weight_key, proportion) in zip(weight_keys, proportions):
             # Find tips within region.
             tips = [(tip.clade, tip.attr["num_date"])
-                for tip in tree.get_terminals() if tip.attr["region"] == region]
+                    for tip in tree.get_terminals()
+                    if tip.attr[self.weights_attribute] == weight_key]
             tips = np.array(sorted(tips, key=lambda row: row[1]))
             clades = tips[:, 0].astype(int)
             tip_dates = tips[:, 1].astype(float)
@@ -693,29 +816,79 @@ class KdeFrequencies(object):
             clade_to_index = {clades[i]: i for i in range(len(clades))}
 
             # Calculate tip frequencies and normalize.
-            normalized_freq_matrix_global = cls.estimate_frequencies(tip_dates, pivots, normalize_to=proportion, **kwargs)
-            normalized_freq_matrix_regional = cls.estimate_frequencies(tip_dates, pivots, normalize_to=1.0, **kwargs)
+            normalized_freq_matrix_global = self.estimate_frequencies(
+                tip_dates,
+                self.pivots,
+                normalize_to=proportion,
+                sigma_narrow=self.sigma_narrow,
+                sigma_wide=self.sigma_wide,
+                proportion_wide=self.proportion_wide,
+                max_date=self.max_date
+            )
+            normalized_freq_matrix_regional = self.estimate_frequencies(
+                tip_dates,
+                self.pivots,
+                normalize_to=1.0,
+                sigma_narrow=self.sigma_narrow,
+                sigma_wide=self.sigma_wide,
+                proportion_wide=self.proportion_wide,
+                max_date=self.max_date
+            )
 
             for clade in clades:
                 clade_frequencies["global"][clade] = normalized_freq_matrix_global[clade_to_index[clade]]
-                clade_frequencies[region][clade] = normalized_freq_matrix_regional[clade_to_index[clade]]
+                clade_frequencies[weight_key][clade] = normalized_freq_matrix_regional[clade_to_index[clade]]
 
         for node in tree.find_clades(order="postorder"):
             if node.is_terminal():
                 # Set regional frequencies for tips from different regions to zero.
-                for region in regions:
-                    if not node.clade in clade_frequencies[region]:
-                        clade_frequencies[region][node.clade] = np.zeros_like(pivots)
-            else:
+                for weight_key in weight_keys:
+                    if not node.clade in clade_frequencies[weight_key]:
+                        clade_frequencies[weight_key][node.clade] = np.zeros_like(self.pivots)
+            elif self.include_internal_nodes:
                 clade_frequencies["global"][node.clade] = np.array(
                     [clade_frequencies["global"][child.clade] for child in node.clades]
                 ).sum(axis=0)
-                for region in regions:
-                    clade_frequencies[region][node.clade] = np.array(
-                        [clade_frequencies[region][child.clade] for child in node.clades]
+                for weight_key in weight_keys:
+                    clade_frequencies[weight_key][node.clade] = np.array(
+                        [clade_frequencies[weight_key][child.clade] for child in node.clades]
                     ).sum(axis=0)
+            else:
+                # Exclude internal nodes.
+                pass
 
         return clade_frequencies
+
+    def estimate(self, tree):
+        """
+        Estimate frequencies for a given tree using the parameters defined for this instance.
+
+        Args:
+            tree (Bio.Phylo): annotated tree whose nodes all have an `attr` attribute with at least  "num_date" key
+
+        Returns:
+            frequencies (dict): node frequencies by region
+        """
+        # Calculate pivots for the given tree.
+        self.pivots = self.calculate_pivots(
+            self.pivot_frequency,
+            tree=tree,
+            start_date=self.start_date,
+            end_date=self.end_date
+        )
+
+        if self.weights is None:
+            # Estimate unweighted frequencies for the given tree.
+            frequencies = self.estimate_frequencies_for_tree(tree)
+        else:
+            # Estimate weighted frequencies.
+            frequencies = self.estimate_weighted_frequencies_for_tree(tree)
+
+        # Store frequencies in the current instance for simplified exporting.
+        self.frequencies = frequencies
+
+        return frequencies
+
 
 if __name__=="__main__":
     plot=True

--- a/base/io_util.py
+++ b/base/io_util.py
@@ -163,7 +163,7 @@ def json_to_clade_frequencies(json_dict):
     >>> json_dict = json.load(json_fh)
     >>> frequencies = json_to_clade_frequencies(json_dict)
     >>> len(frequencies["pivots"])
-    36
+    37
     >>> frequencies["global"][202][0] > 0
     True
     """
@@ -180,5 +180,7 @@ def json_to_clade_frequencies(json_dict):
             frequencies[region] = {}
 
         frequencies[region][int(clade)] = np.array(values)
+
+    frequencies["pivots"] = json_dict["pivots"]
 
     return frequencies

--- a/base/process.py
+++ b/base/process.py
@@ -206,17 +206,36 @@ class process(object):
         # for name, msa in self.seqs.translations.iteritems():
         #     SeqIO.write(msa, self.output_path + "_aligned_" + name + ".mfa", "fasta")
 
+    def get_time_interval_as_floats(self):
+        """
+        Converts the current process's datetime interval to start and end floats.
+
+        Returns None values if the `info` attribute has no "time_interval" key defined.
+
+        Returns:
+            start_date (float): the start of the current process's time interval
+            end_date (float): the end of the current process's time interval
+        """
+        try:
+            time_interval = self.info["time_interval"]
+            start_date = time_interval[1].year + (time_interval[1].month - 1) / 12.0
+            end_date = time_interval[0].year + time_interval[0].month / 12.0
+        except KeyError:
+            self.log.fatal("Cannot space pivots without a time interval in the prepared JSON")
+            start_date = None
+            end_date = None
+
+        return start_date, end_date
 
     def get_pivots_via_spacing(self):
         try:
-            time_interval = self.info["time_interval"]
             assert("pivot_spacing" in self.config)
         except AssertionError:
-            self.log.fatal("Cannot space pivots without prividing \"pivot_spacing\" in the config")
-        except KeyError:
-            self.log.fatal("Cannot space pivots without a time interval in the prepared JSON")
-        return np.arange(time_interval[1].year+(time_interval[1].month-1)/12.0,
-                         time_interval[0].year+time_interval[0].month/12.0,
+            self.log.fatal("Cannot space pivots without providing \"pivot_spacing\" in the config")
+
+        start_date, end_date = self.get_time_interval_as_floats()
+        return np.arange(start_date,
+                         end_date,
                          self.config["pivot_spacing"])
 
     def restore_mutation_frequencies(self):

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -542,13 +542,18 @@ if __name__=="__main__":
 
         # estimate KDE tip frequencies
         if runner.config["estimate_kde_frequencies"]:
-            runner.pivots = runner.get_pivots_via_spacing()
-            runner.kde_frequencies = KdeFrequencies.estimate_region_weighted_frequencies_for_tree(
-                runner.tree.tree,
-                runner.pivots,
-                [el[0] for el in runner.info["regions"]],
-                [el[2] for el in runner.info["regions"]]
+            start_date, end_date = runner.get_time_interval_as_floats()
+
+            kde_frequencies = KdeFrequencies(
+                pivot_frequency=runner.config["pivot_spacing"],
+                start_date=start_date,
+                end_date=end_date,
+                weights={region[0]: region[2] for region in runner.info["regions"]},
+                weights_attribute="region",
+                include_internal_nodes=False
             )
+            kde_frequencies.estimate(runner.tree.tree)
+            runner.kde_frequencies = kde_frequencies
 
         if runner.info["segment"]=='ha':
             if runner.info["lineage"]=='h3n2':


### PR DESCRIPTION
This is the second part of a three part split of @huddlej's PR #159. This PR encompasses all of the functional changes of PR #159. This is primarily:

* adds functionality for importing and exporting KDE frequencies to and from JSON and defines the corresponding JSON schema
* redesigns the API for estimating weighted and unweighted frequencies
* adds an option to estimate only tip frequencies
* adds functionality to calculate pivots from a given pivot frequency and either a start/end date interval or a tree

Though see PR #159 for @huddlej's motivation and notes on schema and API.

I tested and this runs on the flu build.