### PR TITLE
Initial linting pass on much of modular augur

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1,45 +1,49 @@
 from Bio import SeqIO
-import pandas as pd
 from collections import defaultdict
-import random,os
+import random
+import os
 import numpy as np
 from .utils import read_metadata, get_numerical_dates
 
 comment_char = '#'
 
+
 def read_vcf(compressed, input_file):
     import gzip
     opn = gzip.open if compressed else open
 
-    with opn(input_file, mode='rt') as f: #'rt' necessary for gzip
+    with opn(input_file, mode='rt') as f:  # 'rt' necessary for gzip
         for line in f:
             if line[0:2] == "#C":
                 header = line.strip().split('\t')
                 seq_keep = header[header.index("FORMAT")+1:]
-                all_seq = seq_keep.copy() #because we need 'seqs to remove' for VCF
+                all_seq = seq_keep.copy()  # because we need 'seqs to remove' for VCF
                 return seq_keep, all_seq
 
 
 def write_vcf(compressed, input_file, output_file, dropped_samps):
-    #Read in/write out according to file ending
+    # Read in/write out according to file ending
     inCall = "--gzvcf" if compressed else "--vcf"
     outCall = "| gzip -c" if output_file.lower().endswith('.gz') else ""
 
     toDrop = " ".join(["--remove-indv "+s for s in dropped_samps])
-    call = ["vcftools", toDrop, inCall, input_file, "--recode --stdout", outCall, ">", output_file]
+    call = [
+        "vcftools", toDrop, inCall, input_file,
+        "--recode --stdout",
+        outCall, ">", output_file
+    ]
 
     print("Filtering samples using VCFTools with the call:")
     print(" ".join(call))
     os.system(" ".join(call))
-    os.remove('out.log') #remove vcftools log file
-
+    os.remove('out.log')  # remove vcftools log file
 
 
 def run(args):
     '''
     filter and subsample a set of sequences into an analysis set
     '''
-    #Set flags if VCF
+    # Set flags if VCF
     is_vcf = False
     is_compressed = False
     if any([args.sequences.lower().endswith(x) for x in ['.vcf', '.vcf.gz']]):
@@ -47,46 +51,49 @@ def run(args):
         if args.sequences.lower().endswith('.gz'):
             is_compressed = True
 
+    # Read in files
+    # -------------
 
-    ####Read in files
-
-    #If VCF, open and get sequence names
+    # If VCF, open and get sequence names
     if is_vcf:
         seq_keep, all_seq = read_vcf(is_compressed, args.sequences)
 
-    #if Fasta, read in file to get sequence names and sequences
+    # If Fasta, read in file to get sequence names and sequences
     else:
-        seqs = {seq.id:seq for seq in SeqIO.parse(args.sequences, 'fasta')}
+        seqs = {seq.id: seq for seq in SeqIO.parse(args.sequences, 'fasta')}
         seq_keep = list(seqs.keys())
 
     meta_dict, meta_columns = read_metadata(args.metadata)
 
+    # Filtering steps
+    # ---------------
 
-    ####Filtering steps
-    tmp = [ ]
+    tmp = []
     for s in seq_keep:
         if s in meta_dict:
             tmp.append(s)
         else:
-            print("No meta data for",s)
+            print("No meta data for", s)
     seq_keep = tmp
 
     if args.exclude and os.path.isfile(args.exclude):
         with open(args.exclude, 'r') as ifile:
-            to_exclude = set([line.strip() for line in ifile if line[0]!=comment_char])
+            to_exclude = set([line.strip() for line in ifile if line[0] != comment_char])
         seq_keep = [s for s in seq_keep if s not in to_exclude]
 
-    if is_vcf and args.min_length: #doesn't make sense for VCF, ignore.
+    if is_vcf and args.min_length:  # doesn't make sense for VCF, ignore.
         print("WARNING: Cannot use min_length for VCF files. Ignoring...")
     elif (not is_vcf) and args.min_length:
-        seq_keep = [s for s in seq_keep if len(seqs[s])>=args.min_length]
+        seq_keep = [s for s in seq_keep if len(seqs[s]) >= args.min_length]
 
     if (args.min_date or args.max_date) and 'date' in meta_columns:
         dates = get_numerical_dates(meta_dict, fmt="%Y-%m-%d")
         if args.min_date:
-            seq_keep = [s for s in seq_keep if dates[s] and np.min(dates[s])>args.min_date]
+            seq_keep = [s for s in seq_keep
+                        if dates[s] and np.min(dates[s]) > args.min_date]
         if args.max_date:
-            seq_keep = [s for s in seq_keep if dates[s] and np.min(dates[s])<args.max_date]
+            seq_keep = [s for s in seq_keep
+                        if dates[s] and np.min(dates[s]) < args.max_date]
 
     if args.group_by and args.sequences_per_group:
         spg = args.sequences_per_group
@@ -95,7 +102,7 @@ def run(args):
         for seq_name in seq_keep:
             group = []
             if seq_name not in meta_dict:
-                print("WARNING: no metadata for %s, skipping"%seq_name)
+                print("WARNING: no metadata for %s, skipping" % seq_name)
                 continue
             else:
                 m = meta_dict[seq_name]
@@ -106,13 +113,14 @@ def run(args):
                     try:
                         year = int(m["date"].split('-')[0])
                     except:
-                        print("WARNING: no valid year, skipping",seq_name, m["date"])
+                        print("WARNING: no valid year"
+                              "skipping", seq_name, m["date"])
                         continue
-                    if c=='month':
+                    if c == 'month':
                         try:
                             month = int(m["date"].split('-')[1])
                         except:
-                            month = random.randint(1,12)
+                            month = random.randint(1, 12)
                         group.append((year, month))
                     else:
                         group.append(year)
@@ -126,35 +134,38 @@ def run(args):
                     try:
                         priorities[f[0]] = float(f[1])
                     except:
-                        print("ERROR: malformatted priority:",l)
+                        print("ERROR: malformatted priority:", l)
 
         seq_subsample = []
         for group, s in seq_names_by_group.items():
             tmp_seqs = [seq_name for seq_name in s]
             if args.priority:
-                seq_subsample.extend(sorted(tmp_seqs, key=lambda x:priorities[x], reverse=True)[:spg])
+                seq_subsample.extend(
+                    sorted(tmp_seqs, key=lambda x: priorities[x], reverse=True)[:spg]
+                )
             else:
-                seq_subsample.extend(tmp_seqs if len(s)<=spg
-                                     else random.sample(tmp_seqs, spg))
+                seq_subsample.extend(
+                    tmp_seqs if len(s) <= spg else random.sample(tmp_seqs, spg)
+                )
     else:
         seq_subsample = seq_keep
 
     if args.include and os.path.isfile(args.include):
         with open(args.include, 'r') as ifile:
-            to_include = set([line.strip() for line in ifile if line[0]!=comment_char])
+            to_include = set([line.strip() for line in ifile if line[0] != comment_char])
 
         for s in to_include:
             if s not in seq_subsample:
                 seq_subsample.append(s)
 
-
-    ####Write out files
+    # Write out files
+    # ---------------
 
     if is_vcf:
-        #get the samples to be deleted, not to keep, for VCF
+        # get the samples to be deleted, not to keep, for VCF
         dropped_samps = list(set(all_seq) - set(seq_subsample))
         write_vcf(is_compressed, args.sequences, args.output, dropped_samps)
 
     else:
-        seq_to_keep = [seq for id,seq in seqs.items() if id in seq_subsample]
+        seq_to_keep = [seq for id, seq in seqs.items() if id in seq_subsample]
         SeqIO.write(seq_to_keep, args.output, 'fasta')

--- a/augur/parse.py
+++ b/augur/parse.py
@@ -1,7 +1,17 @@
 from Bio import SeqIO
 import pandas as pd
 
-forbidden_characters = [(' ','_'),('-','_'),  ('(','_'),(')','_'),(':','_'),(',','_'),(';','_'),('\\','_')]
+forbidden_characters = [
+    (' ', '_'),
+    ('-', '_'),
+    ('(', '_'),
+    (')', '_'),
+    (':', '_'),
+    (',', '_'),
+    (';', '_'),
+    ('\\', '_')
+]
+
 
 def fix_dates(d, dayfirst=True):
     '''
@@ -13,13 +23,13 @@ def fix_dates(d, dayfirst=True):
     try:
         dto, _, res = pd.core.tools.datetimes.parse_time_string(d, dayfirst=dayfirst)
         if res == 'year':
-            return "%d-XX-XX"%dto.year
+            return "%d-XX-XX" % dto.year
         elif res == 'month':
-            return "%d-%02d-XX"%(dto.year, dto.month)
+            return "%d-%02d-XX" % (dto.year, dto.month)
         else:
-            return "%d-%02d-%02d"%(dto.year, dto.month, dto.day)
+            return "%d-%02d-%02d" % (dto.year, dto.month, dto.day)
     except Exception as e:
-        print("WARNING: unable to parse %s as date"%d, e)
+        print("WARNING: unable to parse %s as date" % d, e)
         return d
 
 
@@ -49,15 +59,17 @@ def run(args):
 
         seq.name = seq.id = tmp_name
         seq.description = ''
-        meta_data[seq.id] = {k:v for k,v in zip(args.fields, fields) }
+        meta_data[seq.id] = {k: v for k, v in zip(args.fields, fields)}
         meta_data[seq.id].pop('strain')
         # parse dates and convert to a canonical format
         if args.fix_dates and 'date' in args.fields:
-            meta_data[seq.id]['date'] = fix_dates(meta_data[seq.id]['date'],
-                                        dayfirst=args.fix_dates=='dayfirst')
+            meta_data[seq.id]['date'] = fix_dates(
+                                            meta_data[seq.id]['date'],
+                                            dayfirst=args.fix_dates == 'dayfirst'
+                                        )
 
     # output results to a new fasta alignment and tsv/csv via pandas
     SeqIO.write(seqs, args.output_sequences, 'fasta')
     df = pd.DataFrame.from_dict(meta_data, orient='index')
     df.to_csv(args.output_metadata, index_label='strain',
-              sep='\t' if args.output_metadata[-3:]=='tsv' else ',')
+              sep='\t' if args.output_metadata[-3:] == 'tsv' else ',')

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -1,8 +1,6 @@
-import numpy as np
-from collections import defaultdict
-import json, os
 from Bio import Phylo
-from .utils import read_metadata, read_node_data, write_json
+from .utils import write_json
+
 
 def run(args):
     T = Phylo.read(args.tree, 'newick')
@@ -15,14 +13,21 @@ def run(args):
         TM_tree.train()
 
         # export the tree model
-        tree_model = {'titers':TM_tree.compile_titers(),
-                      'potency':TM_tree.compile_potencies(),
-                      'avidity':TM_tree.compile_virus_effects(),
-                      'nodes':{n.name:{"dTiter": n.dTiter, "cTiter":n.cTiter}
-                                  for n in T.find_clades()}}
+        tree_model = {
+            'titers': TM_tree.compile_titers(),
+            'potency': TM_tree.compile_potencies(),
+            'avidity': TM_tree.compile_virus_effects(),
+            'nodes': {
+                n.name: {
+                    "dTiter": n.dTiter,
+                    "cTiter": n.cTiter
+                } for n in T.find_clades()
+            }
+        }
         write_json(tree_model, args.output)
         print("\nInferred titer model of type 'TreeModel' using augur:"
-              "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic phenotypes of seasonal influenza viruses."
+              "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic"
+              "phenotypes of seasonal influenza viruses."
               "\n\tPNAS, vol 113, 10.1073/pnas.1525578113\n")
         print("results written to", args.output)
 
@@ -33,13 +38,15 @@ def run(args):
         TM_subs.train()
 
         # export the substitution model
-        subs_model = {'titers':TM_subs.compile_titers(),
-                      'potency':TM_subs.compile_potencies(),
-                      'avidity':TM_subs.compile_virus_effects(),
-                      'substitution':TM_subs.compile_substitution_effects()}
+        subs_model = {
+            'titers': TM_subs.compile_titers(),
+            'potency': TM_subs.compile_potencies(),
+            'avidity': TM_subs.compile_virus_effects(),
+            'substitution': TM_subs.compile_substitution_effects()}
         write_json(subs_model, args.output)
 
         print("\nInferred titer model of type 'SubstitutionModel' using augur:"
-              "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic phenotypes of seasonal influenza viruses."
+              "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic"
+              "phenotypes of seasonal influenza viruses."
               "\n\tPNAS, vol 113, 10.1073/pnas.1525578113\n")
         print("results written to", args.output)

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -1,9 +1,11 @@
 import numpy as np
 from collections import defaultdict
-import json, os, sys
-import pandas as pd
+import json
+import os
+import sys
 from .utils import read_metadata
 TINY = 1e-12
+
 
 def mugration_inference(tree=None, seq_meta=None, field='country', confidence=True,
                         infer_gtr=True, root_state=None, missing='?'):
@@ -14,7 +16,7 @@ def mugration_inference(tree=None, seq_meta=None, field='country', confidence=Tr
     from Bio import Phylo
 
     T = Phylo.read(tree, 'newick')
-    nodes = {n.name:n for n in T.get_terminals()}
+    nodes = {n.name: n for n in T.get_terminals()}
 
     # Determine alphabet only counting tips in the tree
     places = set()
@@ -27,39 +29,40 @@ def mugration_inference(tree=None, seq_meta=None, field='country', confidence=Tr
     # construct GTR (flat for now). The missing DATA symbol is a '-' (ord('-')==45)
     places = sorted(places)
     nc = len(places)
-    if nc>180:
+    if nc > 180:
         print("ERROR: geo_inference: can't have more than 180 places!", file=sys.stderr)
-        return None,None
-    elif nc==1:
-        print("WARNING: geo_inference: only one place found -- set every internal node to %s!"%places[0], file=sys.stderr)
-        return None,None
-    elif nc==0:
+        return None, None
+    elif nc == 1:
+        print("WARNING: geo_inference: only one place found --"
+              "set every internal node to %s!" % places[0], file=sys.stderr)
+        return None, None
+    elif nc == 0:
         print("ERROR: geo_inference: list of places is empty!", file=sys.stderr)
-        return None,None
+        return None, None
     else:
         # set up model
-        alphabet = {chr(65+i):place for i,place in enumerate(places)}
-        model = GTR.custom(pi = np.ones(nc, dtype=float)/nc, W=np.ones((nc,nc)),
-                          alphabet = np.array(sorted(alphabet.keys())))
+        alphabet = {chr(65+i): place for i, place in enumerate(places)}
+        model = GTR.custom(pi=np.ones(nc, dtype=float)/nc, W=np.ones((nc, nc)),
+                           alphabet=np.array(sorted(alphabet.keys())))
 
         missing_char = chr(65+nc)
-        alphabet[missing_char]=missing
+        alphabet[missing_char] = missing
         model.profile_map[missing_char] = np.ones(nc)
         model.ambiguous = missing_char
-        alphabet_rev = {v:k for k,v in alphabet.items()}
+        alphabet_rev = {v: k for k, v in alphabet.items()}
 
         # construct pseudo alignment
         pseudo_seqs = []
         for name, meta in seq_meta.items():
             if name in nodes:
-                s=alphabet_rev[meta[field]] if field in meta else missing_char
+                s = alphabet_rev[meta[field]] if field in meta else missing_char
                 pseudo_seqs.append(SeqRecord(Seq(s), name=name, id=name))
         aln = MultipleSeqAlignment(pseudo_seqs)
 
         # set up treetime and infer
         from treetime import TreeAnc
         tt = TreeAnc(tree=tree, aln=aln, gtr=model, convert_upper=False, verbose=0)
-        tt.use_mutation_length=False
+        tt.use_mutation_length = False
         tt.infer_ancestral_sequences(infer_gtr=infer_gtr, store_compressed=False, pc=5.0,
                                      marginal=True, normalized_rate=False)
 
@@ -73,15 +76,17 @@ def mugration_inference(tree=None, seq_meta=None, field='country', confidence=Tr
                 pdis = node.marginal_profile[0]
                 S = -np.sum(pdis*np.log(pdis+TINY))
 
-                marginal = [(alphabet[tt.gtr.alphabet[i]], pdis[i]) for i in range(len(tt.gtr.alphabet))]
-                marginal.sort(key=lambda x: x[1], reverse=True) # sort on likelihoods
-                marginal = [(a, b) for a, b in marginal if b > 0.001][:4] #only take stuff over .1% and the top 4 elements
-                conf = {a:b for a,b in marginal}
+                marginal = [
+                    (alphabet[tt.gtr.alphabet[i]], pdis[i]) for i in range(len(tt.gtr.alphabet))
+                ]
+                marginal.sort(key=lambda x: x[1], reverse=True)  # sort on likelihoods
+                # only take stuff over .1% and the top 4 elements
+                marginal = [(a, b) for a, b in marginal if b > 0.001][:4]
+                conf = {a: b for a, b in marginal}
                 node.__setattr__(field + "_entropy", S)
                 node.__setattr__(field + "_confidence", conf)
 
         return tt, alphabet
-
 
 
 def run(args):
@@ -91,10 +96,9 @@ def run(args):
     mugration_states = defaultdict(dict)
     for column in args.columns:
         tt, alphabet = mugration_inference(tree=tree_fname, seq_meta=traits,
-                            field=column, confidence=args.confidence)
-        if tt is None: # something went wrong
+                                           field=column, confidence=args.confidence)
+        if tt is None:  # something went wrong
             continue
-
 
         for node in tt.tree.find_clades():
             mugration_states[node.name][column] = node.__getattribute__(column)
@@ -102,20 +106,21 @@ def run(args):
                 mugration_states[node.name][column+'_confidence'] = node.__getattribute__(column+'_confidence')
                 mugration_states[node.name][column+'_entropy'] = node.__getattribute__(column+'_entropy')
 
-        #if args.output is default (no dir), including '/' messes up writing
+        # if args.output is default (no dir), including '/' messes up writing
         prefix = os.path.dirname(args.output)+'/' if len(os.path.dirname(args.output)) != 0 else ''
-        with open(prefix+'%s.mugration_model.txt'%column, 'w') as ofile:
+        with open(prefix+'%s.mugration_model.txt' % column, 'w') as ofile:
             ofile.write('Map from character to field name\n')
-            for k,v in alphabet.items():
+            for k, v in alphabet.items():
                 ofile.write(k+':\t'+str(v)+'\n')
             ofile.write('\n\n')
 
             ofile.write(str(tt.gtr))
 
     with open(args.output, 'w') as results:
-        json.dump({"nodes":mugration_states}, results, indent=1)
+        json.dump({"nodes": mugration_states}, results, indent=1)
 
     print("\nInferred ancestral states of discrete character using TreeTime:"
           "\n\tSagulenko et al. TreeTime: Maximum-likelihood phylodynamic analysis"
-          "\n\tVirus Evolution, vol 4, https://academic.oup.com/ve/article/4/1/vex042/4794731\n", file=sys.stdout)
-    print("results written to",args.output, file=sys.stdout)
+          "\n\tVirus Evolution, vol 4, http://dx.doi.org/10.1093/ve/vex042\n",
+          file=sys.stdout)
+    print("results written to", args.output, file=sys.stdout)


### PR DESCRIPTION
This is a linting pass using flake8 (from PR #169). This PR is separate from whether we choose pylint or flake8.

I have made no functional changes here, just followed the linting rules. This largely caught a bunch of white-space issues like `a=b` vs `a = b`, but did catch unused imports. Pylint would go further than this, but I thought this good for a first pass.

I tested with zika and tb and both are working.