### PR TITLE
Introduce include/exclude-where

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -80,6 +80,22 @@ def run(args):
             to_exclude = set([line.strip() for line in ifile if line[0]!=comment_char])
         seq_keep = [s for s in seq_keep if s not in to_exclude]
 
+    if args.exclude_where:
+        to_exclude = []
+        for ex in args.exclude_where:
+            col, val = ex.split("=")
+            print(col, val)
+            for seq_name in seq_keep:
+                group = []
+                if seq_name not in meta_dict:
+                    print("WARNING: no metadata for %s, skipping"%seq_name)
+                    continue
+                else:
+                    m = meta_dict[seq_name]
+                    if m[col] == val:
+                        to_exclude.append(seq_name)
+        seq_keep = [s for s in seq_keep if s not in set(to_exclude)]
+
     if is_vcf and args.min_length: #doesn't make sense for VCF, ignore.
         print("WARNING: Cannot use min_length for VCF files. Ignoring...")
     elif (not is_vcf) and args.min_length:
@@ -151,6 +167,22 @@ def run(args):
             if s not in seq_subsample:
                 seq_subsample.append(s)
 
+    if args.include_where:
+        to_include = []
+        for ex in args.include_where:
+            col, val = ex.split("=")
+            for seq_name in all_seq:
+                group = []
+                if seq_name not in meta_dict:
+                    print("WARNING: no metadata for %s, skipping"%seq_name)
+                    continue
+                else:
+                    m = meta_dict[seq_name]
+                    if m[col] == val:
+                        to_include.append(seq_name)
+        for s in to_include:
+            if s not in seq_subsample:
+                seq_subsample.append(s)
 
     ####Write out files
 

--- a/bin/augur
+++ b/bin/augur
@@ -33,6 +33,8 @@ if __name__=="__main__":
     filter_parser.add_argument('--priority', type=str, help="file with list priority scores for sequences (strain\tpriority)")
     filter_parser.add_argument('--sequences-per-group', type=int, help="subsample to no more than this number of sequences per category")
     filter_parser.add_argument('--group-by', nargs='+', help="categories with respect to subsample; two virtual fields, \"month\" and \"year\", are supported if they don't already exist as real fields but a \"date\" field does exist")
+    filter_parser.add_argument('--exclude-where', nargs='+', help="exclude samples with these values. ex: host=rat")
+    filter_parser.add_argument('--include-where', nargs='+', help="include samples with these values. ex: host=rat")
     filter_parser.add_argument('--output', '-o', help="output file")
     filter_parser.set_defaults(func=filter.run)
 


### PR DESCRIPTION
Addresses some of issue [179](https://github.com/nextstrain/augur/issues/179)

Introduces two new arguments:
`--exclude-where` and `--include-where`

which can be used like:
`--exclude-where host=laboratoryderived country=canada`
`--include-where host=watersample lab=sanger`
(these are processed individually - they'll be included if they have either, not only if they have both)
etc

Doesn't:
- preserve 'starts-with' behaviour
- address segment-filtering
- address unintuitive behaviour if dates are in the wrong format and use `group-by` etc

Also, the 'include-where' currently overrides any sequences that were excluded by a list in a file (`--exclude`) - this may be bad! Thoughts on whether anything in `--exclude` should be excluded no matter what (maybe bad sequences?) would be appreciated. Also, a little more testing with a variety of fields would be probably be good. 

