### PR TITLE
Censor frequencies in fitness model

### DIFF
--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -722,9 +722,14 @@ class fitness_model(object):
 
         correlation_null, correlation_raw, correlation_rel = self.get_correlation()
 
+        # Do not try to export titer data if it was provided to the model.
+        predictor_kwargs = self.predictor_kwargs.copy()
+        if "titers" in predictor_kwargs:
+            del predictor_kwargs["titers"]
+
         data = {
             "params": params_df.to_dict(orient="records"),
-            "predictor_kwargs": self.predictor_kwargs,
+            "predictor_kwargs": predictor_kwargs,
             "data": self.pred_vs_true_df.to_dict(orient="records"),
             "accuracy": {
                 "clade_error": self.clade_fit(self.model_params),

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -141,7 +141,7 @@ class fitness_model(object):
             sys.stderr.write("Recalculating frequencies\n")
             frequency_params = self.frequencies.get_params()
             frequency_params["include_internal_nodes"] = True
-            self.frequencies = type(self.frequencies)(**frequency_params)
+            self.frequencies = KdeFrequencies(**frequency_params)
             self.frequencies.estimate(self.tree)
 
         # Pivots should be defined by frequencies.
@@ -254,7 +254,7 @@ class fitness_model(object):
                 # Censor frequencies by omitting all tips sampled after the current timepoint.
                 sys.stderr.write("Calculating censored frequencies for %s\n" % time)
                 frequency_parameters["max_date"] = time
-                frequency_estimator = type(self.frequencies)(**frequency_parameters)
+                frequency_estimator = KdeFrequencies(**frequency_parameters)
                 frequencies = frequency_estimator.estimate(self.tree)
 
                 # Determine the frequency of each tip at the given timepoint.
@@ -297,7 +297,7 @@ class fitness_model(object):
             frequency_parameters["start_date"] = time_interval[0]
             frequency_parameters["end_date"] = time_interval[1]
             frequency_parameters["max_date"] = time_interval[1]
-            frequency_estimator = type(self.frequencies)(**frequency_parameters)
+            frequency_estimator = KdeFrequencies(**frequency_parameters)
             frequencies = frequency_estimator.estimate(self.tree)
 
             # Annotate censored frequencies on nodes.

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -236,11 +236,11 @@ class fitness_model(object):
         for node in self.nodes:
             interpolation = interp1d(self.rootnode.pivots, node.freq[region], kind='linear', bounds_error=True)
             node.timepoint_freqs = {}
-            node.delta_freqs = {}
+            node.observed_final_freqs = {}
             for time in self.timepoints:
                 node.timepoint_freqs[time] = np.asscalar(interpolation(time))
             for time in self.timepoints[:-1]:
-                node.delta_freqs[time] = np.asscalar(interpolation(time + self.delta_time))
+                node.observed_final_freqs[time] = np.asscalar(interpolation(time + self.delta_time))
 
         # Estimate frequencies for tips at specific timepoints.
         # Censor future tips from estimations unless these data are explicitly allowed.
@@ -415,7 +415,7 @@ class fitness_model(object):
             tmp_pred_vs_true = []
             for clade in self.fit_clades[time]:
                 # The observed final frequency is calculated for each clade from all available data.
-                obs_final_freq = clade.delta_freqs[time]
+                obs_final_freq = clade.observed_final_freqs[time]
 
                 # The initial frequency is calculated from the sum of each clade's censored tip frequencies.
                 pred = self.predictor_arrays[time][clade.tips]

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -361,6 +361,11 @@ class fitness_model(object):
         for time in self.timepoints:
             values = self.predictor_arrays[time]
             weights = self.freq_arrays[time]
+
+            # Do not calculate weighted summary statistics when all frequencies at the current timepoint are zero.
+            if weights.sum() == 0:
+                weights = None
+
             means = np.average(values, weights=weights, axis=0)
             variances = np.average((values-means)**2, weights=weights, axis=0)
             sds = np.sqrt(variances)

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -392,11 +392,14 @@ class fitness_model(object):
         for time in self.timepoints[:-1]:
             self.fit_clades[time] = []
             for node in self.nodes:
+                # Only select clades for fitting if their censored frequencies are within the specified thresholds.
                 node_freq = self.freq_arrays[time][node.tips].sum(axis=0)
-                if (node_freq >= self.min_freq and
-                    node_freq <= self.max_freq and
-                    node_freq < self.node_parents[node].timepoint_freqs[time]):
-                    self.fit_clades[time].append(node)
+
+                if self.min_freq <= node_freq <= self.max_freq:
+                    # Exclude subclades whose frequency is identical to their parent clade.
+                    parent_node_freq = self.freq_arrays[time][self.node_parents[node].tips].sum(axis=0)
+                    if node_freq < parent_node_freq:
+                        self.fit_clades[time].append(node)
 
 
     def clade_fit(self, params):

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -235,8 +235,8 @@ class fitness_model(object):
 
         for node in self.nodes:
             interpolation = interp1d(self.rootnode.pivots, node.freq[region], kind='linear', bounds_error=True)
-            node.timepoint_freqs = defaultdict(float)
-            node.delta_freqs = defaultdict(float)
+            node.timepoint_freqs = {}
+            node.delta_freqs = {}
             for time in self.timepoints:
                 node.timepoint_freqs[time] = np.asscalar(interpolation(time))
             for time in self.timepoints[:-1]:

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -609,6 +609,26 @@ class KdeFrequencies(object):
         self.max_date = max_date
         self.include_internal_nodes = include_internal_nodes
 
+    def get_params(self):
+        """
+        Returns the parameters used to define the current instance.
+
+        Returns:
+            dict: parameters that define the current instance and that can be used to create a new instance
+        """
+        return {
+            "sigma_narrow": self.sigma_narrow,
+            "sigma_wide": self.sigma_wide,
+            "proportion_wide": self.proportion_wide,
+            "pivot_frequency": self.pivot_frequency,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "weights": self.weights,
+            "weights_attribute": self.weights_attribute,
+            "max_date": self.max_date,
+            "include_internal_nodes": self.include_internal_nodes
+        }
+
     @classmethod
     def from_json(cls, json_dict):
         """Returns an instance populated with parameters and data from the given JSON dictionary.
@@ -630,18 +650,7 @@ class KdeFrequencies(object):
         """Returns a dictionary for the current instance that can be serialized in a JSON file.
         """
         frequencies_json = {
-            "params": {
-                "sigma_narrow": self.sigma_narrow,
-                "sigma_wide": self.sigma_wide,
-                "proportion_wide": self.proportion_wide,
-                "pivot_frequency": self.pivot_frequency,
-                "start_date": self.start_date,
-                "end_date": self.end_date,
-                "weights": self.weights,
-                "weights_attribute": self.weights_attribute,
-                "max_date": self.max_date,
-                "include_internal_nodes": self.include_internal_nodes
-            }
+            "params": self.get_params()
         }
 
         # If frequencies have been estimated, export them along with the pivots as data.

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -697,11 +697,13 @@ class KdeFrequencies(object):
             pivot_start = start_date
             pivot_end = end_date
 
-        return np.arange(
+        pivots = np.arange(
             pivot_start,
             pivot_end,
             pivot_frequency
         )
+
+        return np.around(pivots, 2)
 
     @classmethod
     def get_density_for_observation(cls, mu, pivots, sigma_narrow=1/12.0, sigma_wide=3/12.0, proportion_wide=0.2):

--- a/base/process.py
+++ b/base/process.py
@@ -204,7 +204,8 @@ class process(object):
         # for name, msa in self.seqs.translations.iteritems():
         #     SeqIO.write(msa, self.output_path + "_aligned_" + name + ".mfa", "fasta")
 
-    def get_time_interval_as_floats(self):
+    @staticmethod
+    def get_time_interval_as_floats(time_interval):
         """
         Converts the current process's datetime interval to start and end floats.
 
@@ -214,15 +215,8 @@ class process(object):
             start_date (float): the start of the current process's time interval
             end_date (float): the end of the current process's time interval
         """
-        try:
-            time_interval = self.info["time_interval"]
-            start_date = time_interval[1].year + (time_interval[1].month - 1) / 12.0
-            end_date = time_interval[0].year + time_interval[0].month / 12.0
-        except KeyError:
-            self.log.fatal("Cannot space pivots without a time interval in the prepared JSON")
-            start_date = None
-            end_date = None
-
+        start_date = time_interval[1].year + (time_interval[1].month - 1) / 12.0
+        end_date = time_interval[0].year + time_interval[0].month / 12.0
         return start_date, end_date
 
     def get_pivots_via_spacing(self):
@@ -231,7 +225,13 @@ class process(object):
         except AssertionError:
             self.log.fatal("Cannot space pivots without providing \"pivot_spacing\" in the config")
 
-        start_date, end_date = self.get_time_interval_as_floats()
+        try:
+            time_interval = self.info["time_interval"]
+            start_date, end_date = self.get_time_interval_as_floats(time_interval)
+        except KeyError:
+            self.log.fatal("Cannot space pivots without a time interval in the prepared JSON")
+            start_date = end_date = None
+
         return np.arange(start_date,
                          end_date,
                          self.config["pivot_spacing"])

--- a/base/process.py
+++ b/base/process.py
@@ -640,15 +640,14 @@ class process(object):
         """Run the fitness prediction model and annotate the tree's nodes with fitness
         values. Returns the resulting fitness model instance.
         """
-        if not hasattr(self, "tree_frequencies"):
-            self.log.warn("Could not find tree frequencies.")
+        if not hasattr(self, "kde_frequencies"):
+            self.log.warn("Could not find KDE frequencies.")
             return
 
         kwargs = {
             "tree": self.tree.tree,
-            "frequencies": self.tree_frequencies,
-            "time_interval": self.info["time_interval"],
-            "pivots": np.around(self.pivots, 2)
+            "frequencies": self.kde_frequencies,
+            "time_interval": self.info["time_interval"]
         }
 
         if "predictors" in self.config:

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -542,7 +542,7 @@ if __name__=="__main__":
 
         # estimate KDE tip frequencies
         if runner.config["estimate_kde_frequencies"]:
-            start_date, end_date = runner.get_time_interval_as_floats()
+            start_date, end_date = runner.get_time_interval_as_floats(runner.info["time_interval"])
 
             kde_frequencies = KdeFrequencies(
                 pivot_frequency=runner.config["pivot_spacing"],

--- a/tests/test_fitness_model.py
+++ b/tests/test_fitness_model.py
@@ -15,6 +15,7 @@ except ImportError:
 
 from base.fitness_model import fitness_model
 from base.frequencies import KdeFrequencies
+from base.process import process
 
 #
 # Fixtures
@@ -87,38 +88,44 @@ def real_tree(multiple_sequence_alignment):
 
 @pytest.fixture
 def simple_fitness_model(simple_tree):
+    time_interval = (
+        datetime.date(2015, 1, 1),
+        datetime.date(2012, 1, 1)
+    )
+    start_date, end_date = process.get_time_interval_as_floats(time_interval)
+
     return fitness_model(
         tree=simple_tree,
         frequencies=KdeFrequencies(
-            start_date=2012.0,
-            end_date=2015.0,
+            start_date=start_date,
+            end_date=end_date,
             include_internal_nodes=True
         ),
         predictor_input=["random"],
         pivot_spacing=1.0 / 12,
-        time_interval=(
-            datetime.date(2015, 1, 1),
-            datetime.date(2012, 1, 1)
-        ),
+        time_interval=time_interval,
         epitope_masks_fname="builds/flu/metadata/ha_masks.tsv",
         epitope_mask_version="wolf"
     )
 
 @pytest.fixture
 def real_fitness_model(real_tree, multiple_sequence_alignment):
+    time_interval = (
+        datetime.date(2017, 6, 1),
+        datetime.date(2014, 6, 1)
+    )
+    start_date, end_date = process.get_time_interval_as_floats(time_interval)
+
     model = fitness_model(
         tree=real_tree,
         frequencies=KdeFrequencies(
-            start_date=2014.5,
-            end_date=2017.5,
+            start_date=start_date,
+            end_date=end_date,
             include_internal_nodes=True
         ),
         predictor_input=["random"],
         pivot_spacing=1.0 / 12,
-        time_interval=(
-            datetime.date(2017, 6, 1),
-            datetime.date(2014, 6, 1)
-        ),
+        time_interval=time_interval,
         epitope_masks_fname="builds/flu/metadata/ha_masks.tsv",
         epitope_mask_version="wolf"
     )
@@ -132,19 +139,22 @@ def precalculated_fitness_model(simple_tree):
     """Provides a simple fitness model with precalculated model parameters such that
     the model skips learning new parameters.
     """
+    time_interval = (
+        datetime.date(2015, 1, 1),
+        datetime.date(2012, 1, 1)
+    )
+    start_date, end_date = process.get_time_interval_as_floats(time_interval)
+
     return fitness_model(
         tree=simple_tree,
         frequencies=KdeFrequencies(
-            start_date=2012.0,
-            end_date=2015.0,
+            start_date=start_date,
+            end_date=end_date,
             include_internal_nodes=True
         ),
         predictor_input={"random": MODEL_PARAMS},
         pivot_spacing=1.0 / 12,
-        time_interval=(
-            datetime.date(2015, 1, 1),
-            datetime.date(2012, 1, 1)
-        ),
+        time_interval=time_interval,
         epitope_masks_fname="builds/flu/metadata/ha_masks.tsv",
         epitope_mask_version="wolf"
     )

--- a/tests/test_fitness_model.py
+++ b/tests/test_fitness_model.py
@@ -14,6 +14,7 @@ except ImportError:
     from io import StringIO
 
 from base.fitness_model import fitness_model
+from base.frequencies import KdeFrequencies
 
 #
 # Fixtures
@@ -42,6 +43,7 @@ def simple_tree():
     dates = (2012.5, 2013.25, 2014.8)
     index = 0
     for node in tree.find_clades(order="preorder"):
+        node.clade = index
         node.aa = sequences[index]
         node.attr = {"num_date": dates[index]}
         index += 1
@@ -61,6 +63,7 @@ def real_tree(multiple_sequence_alignment):
                   for alignment in multiple_sequence_alignment])
 
     # Assign sequences to the tree.
+    index = 0
     for node in tree.find_clades():
         if node.name is not None:
             node.sequence = np.fromstring(sequences_by_name[node.name], "S1")
@@ -77,13 +80,20 @@ def real_tree(multiple_sequence_alignment):
             node.sequence = np.fromstring(str(summary.dumb_consensus(threshold=0.5, ambiguous="N")), "S1")
             node.attr = {"num_date": 2014.8}
 
+        node.clade = index
+        index += 1
+
     return tree
 
 @pytest.fixture
 def simple_fitness_model(simple_tree):
     return fitness_model(
         tree=simple_tree,
-        frequencies={},
+        frequencies=KdeFrequencies(
+            start_date=2012.0,
+            end_date=2015.0,
+            include_internal_nodes=True
+        ),
         predictor_input=["random"],
         pivot_spacing=1.0 / 12,
         time_interval=(
@@ -98,7 +108,11 @@ def simple_fitness_model(simple_tree):
 def real_fitness_model(real_tree, multiple_sequence_alignment):
     model = fitness_model(
         tree=real_tree,
-        frequencies={},
+        frequencies=KdeFrequencies(
+            start_date=2014.5,
+            end_date=2017.5,
+            include_internal_nodes=True
+        ),
         predictor_input=["random"],
         pivot_spacing=1.0 / 12,
         time_interval=(
@@ -120,7 +134,11 @@ def precalculated_fitness_model(simple_tree):
     """
     return fitness_model(
         tree=simple_tree,
-        frequencies={},
+        frequencies=KdeFrequencies(
+            start_date=2012.0,
+            end_date=2015.0,
+            include_internal_nodes=True
+        ),
         predictor_input={"random": MODEL_PARAMS},
         pivot_spacing=1.0 / 12,
         time_interval=(

--- a/tests/test_frequencies.py
+++ b/tests/test_frequencies.py
@@ -244,3 +244,19 @@ class TestKdeFrequencies(object):
 
         assert kde_frequencies.pivot_frequency == new_kde_frequencies.pivot_frequency
         assert not hasattr(new_kde_frequencies, "frequencies")
+
+    def test_get_params(self, tree):
+        """Test export of parameters used to create an instance.
+        """
+        initial_params = {
+            "max_date": 2017.0,
+            "start_date": 2015.5,
+            "end_date": 2018.5
+        }
+        kde_frequencies = KdeFrequencies(**initial_params)
+        frequencies = kde_frequencies.estimate(tree)
+
+        # Confirm that the exported parameters match the input.
+        params = kde_frequencies.get_params()
+        for param in initial_params:
+            assert params[param] == initial_params[param]


### PR DESCRIPTION
This PR is part one of two splitting out logic from #125 into more understandable and testable requests.

This PR modifies the fitness model to censor future data from frequency calculations model fitting. It includes the following major changes:

* The fitness model expects frequencies to be an instance of the `KdeFrequencies` class
* The `KdeFrequencies` class provides a `get_params` method that allows a new instance to be created easily from an existing instance
* If the frequencies instance does not have frequencies estimated yet (or internal node frequencies), the fitness model will estimate them
* Frequency censoring is parameterized in the fitness model by a `censor_frequencies` attribute that defaults to `True`
* Observed final clade frequencies are always estimated from all available data
* Initial and predicted clade frequencies are calculated from the sum of each clade’s tip frequencies (which may or may not be censored)

- [x] Tests pass
- [x] Flu builds work on rhino with `run_flu.py` for all subtypes at 2y resolution
