### PR TITLE
Don't filter by group if groups not found

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -167,6 +167,17 @@ def run(args):
                 print("Note that using 'year' or 'year month' requires a column called 'date'.")
             print("\n")
         else:
+            # Check to see if some categories are missing to warn the user
+            group_by = set([cat if cat not in ['year','month'] else 'date' for cat in args.group_by])
+            missing_cats = [cat for cat in group_by if cat not in meta_columns]
+            if missing_cats:
+                print("WARNING:")
+                if any([cat != 'date' for cat in missing_cats]):
+                    print("\tSome of the specified group-by categories couldn't be found: %s"%[cat for cat in missing_cats if cat != 'date'])
+                if any([cat == 'date' for cat in missing_cats]):
+                    print("\tA 'date' column could not be found to group-by year or month.")
+                print("\tFiltering by group may behave differently than expected!\n")
+
             if args.priority: # read priorities
                 priorities = read_priority_scores(args.priority)
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -160,20 +160,27 @@ def run(args):
                     group.append('unknown')
             seq_names_by_group[tuple(group)].append(seq_name)
 
-        if args.priority: # read priorities
-            priorities = read_priority_scores(args.priority)
+        #If didnt find any categories specified, all seqs will be in 'unknown' - but don't sample this!
+        if (len(seq_names_by_group) == 1 and 'unknown' in list(seq_names_by_group.keys())[0]):
+            print("WARNING: The specified group-by categories (%s) were not found. No sequences-per-group sampling will be done."%args.group_by)
+            if any([x in args.group_by for x in ['year','month']]):
+                print("Note that using 'year' or 'year month' requires a column called 'date'.")
+            print("\n")
+        else:
+            if args.priority: # read priorities
+                priorities = read_priority_scores(args.priority)
 
-        # subsample each groups, either by taking the spg highest priority strains or
-        # sampling at random from the sequences in the group
-        seq_subsample = []
-        for group, sequences_in_group in seq_names_by_group.items():
-            if args.priority: #sort descending by priority
-                seq_subsample.extend(sorted(sequences_in_group, key=lambda x:priorities[x], reverse=True)[:spg])
-            else:
-                seq_subsample.extend(sequences_in_group if len(sequences_in_group)<=spg
-                                     else random.sample(sequences_in_group, spg))
+            # subsample each groups, either by taking the spg highest priority strains or
+            # sampling at random from the sequences in the group
+            seq_subsample = []
+            for group, sequences_in_group in seq_names_by_group.items():
+                if args.priority: #sort descending by priority
+                    seq_subsample.extend(sorted(sequences_in_group, key=lambda x:priorities[x], reverse=True)[:spg])
+                else:
+                    seq_subsample.extend(sequences_in_group if len(sequences_in_group)<=spg
+                                         else random.sample(sequences_in_group, spg))
 
-        seq_keep = seq_subsample
+            seq_keep = seq_subsample
 
     # force include sequences specified in file.
     # Note that this might re-add previously excluded sequences

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -162,19 +162,22 @@ def run(args):
             seq_names_by_group[tuple(group)].append(seq_name)
 
         #If didnt find any categories specified, all seqs will be in 'unknown' - but don't sample this!
-        if (len(seq_names_by_group) == 1 and 'unknown' in list(seq_names_by_group.keys())[0]):
-            print("WARNING: The specified group-by categories (%s) were not found. No sequences-per-group sampling will be done."%args.group_by)
+        if len(seq_names_by_group)==1 and 'unknown' in seq_names_by_group:
+            print("WARNING: The specified group-by categories (%s) were not found."%args.group_by,
+                  "No sequences-per-group sampling will be done.")
             if any([x in args.group_by for x in ['year','month']]):
                 print("Note that using 'year' or 'year month' requires a column called 'date'.")
             print("\n")
         else:
             # Check to see if some categories are missing to warn the user
-            group_by = set([cat if cat not in ['year','month'] else 'date' for cat in args.group_by])
+            group_by = set(['date' if cat in ['year','month'] else cat
+                            for cat in args.group_by])
             missing_cats = [cat for cat in group_by if cat not in meta_columns]
             if missing_cats:
                 print("WARNING:")
                 if any([cat != 'date' for cat in missing_cats]):
-                    print("\tSome of the specified group-by categories couldn't be found: %s"%[cat for cat in missing_cats if cat != 'date'])
+                    print("\tSome of the specified group-by categories couldn't be found: ",
+                          ", ".join([str(cat) for cat in missing_cats if cat != 'date']))
                 if any([cat == 'date' for cat in missing_cats]):
                     print("\tA 'date' column could not be found to group-by year or month.")
                 print("\tFiltering by group may behave differently than expected!\n")


### PR DESCRIPTION
Currently, if the user specifies `group-by` categories that don't exist ('veg potato') all sequences end up in the group ('unknown', 'unknown') (or variations thereof) which is then sampled at the specified `sequences-per-group` level - almost certainly not what the user intended. 

Now, if this happens (all sequences end up in 'unknown'), a warning is issued and no sequences-per-group sampling is performed. _Should this be an error?_

If only some of the specified `group-by` categories are not found, a warning is displayed to say that filtering may not behave as expected (but group-by filtering still proceeds). 

