### PR TITLE
Check all shell command invocations for failure

### DIFF
--- a/augur/align.py
+++ b/augur/align.py
@@ -7,7 +7,13 @@ from .utils import run_shell_command
 def make_gaps_ambiguous(aln):
     '''
     replace all gaps by 'N' in all sequences in the alignment. TreeTime will treat them
-    as fully ambiguous and replace then with the most likely state
+    as fully ambiguous and replace then with the most likely state. This modifies the
+    alignment in place.
+
+    Parameters
+    ----------
+    aln : MultipleSeqAlign
+        Biopython Alignment
     '''
     for seq in aln:
         seq_array = np.array(seq)
@@ -64,7 +70,8 @@ def run(args):
         print('ERROR: alignment method not implemented')
         return -1
 
-    if not run_shell_command(cmd):
+    success = run_shell_command(cmd)
+    if not success: # return error if aligner errored
         return -1
 
     # after aligning, make a copy of the data that the aligner produced (useful for debugging)
@@ -91,6 +98,21 @@ def strip_non_reference(alignment_fname, reference, keep_reference=False):
     '''
     return sequences that have all insertions relative to the reference
     removed. The alignment is read from file and returned as list of sequences.
+
+    Parameters
+    ----------
+    alignment_fname : str
+        alignment file name, file needs to be fasta format
+    reference : str
+        name of reference sequence, assumed to be part of the alignment
+    keep_reference : bool, optional
+        by default, the reference sequence is removed after stripping
+        non-reference sequence. To keep the reference, use keep_reference=True
+
+    Returns
+    -------
+    list
+        list of trimmed sequences, effectively a multiple alignment
     '''
     aln = AlignIO.read(alignment_fname, 'fasta')
     seqs = {s.name:s for s in aln}

--- a/augur/align.py
+++ b/augur/align.py
@@ -2,6 +2,7 @@ import os,sys,argparse
 import numpy as np
 from Bio import AlignIO, SeqIO, Seq
 from shutil import copyfile
+from .utils import run_shell_command
 
 def make_gaps_ambiguous(aln):
     '''
@@ -56,12 +57,14 @@ def run(args):
     # align
     if args.method=='mafft':
         cmd = "mafft --reorder --anysymbol --thread %d %s 1> %s 2> %s.log"%(args.nthreads, seq_fname, output, output)
-        os.system(cmd)
         print("\nusing mafft to align via:\n\t" + cmd +
               " \n\n\tKatoh et al, Nucleic Acid Research, vol 30, issue 14"
               "\n\thttps://doi.org/10.1093%2Fnar%2Fgkf436\n")
     else:
         print('ERROR: alignment method not implemented')
+        return -1
+
+    if not run_shell_command(cmd):
         return -1
 
     # after aligning, make a copy of the data that the aligner produced (useful for debugging)

--- a/augur/align.py
+++ b/augur/align.py
@@ -1,7 +1,7 @@
 import os,sys,argparse
+from shutil import copyfile
 import numpy as np
 from Bio import AlignIO, SeqIO, Seq
-from shutil import copyfile
 from .utils import run_shell_command
 
 def make_gaps_ambiguous(aln):
@@ -23,6 +23,17 @@ def make_gaps_ambiguous(aln):
 
 
 def run(args):
+    '''
+    Parameters
+    ----------
+    args : namespace
+        arguments passed in via the command-line from augur
+
+    Returns
+    -------
+    int
+        returns 0 for success, 1 for general error
+    '''
     seq_fname = args.sequences
     ref_name = args.reference_name
     ref_fname = args.reference_sequence
@@ -35,7 +46,7 @@ def run(args):
         seqs = {s.id:s for s in SeqIO.parse(seq_fname, 'fasta')}
     except:
         print("Cannot read sequences -- make sure the file %s exists and contains sequences in fasta format"%seq_fname)
-        return -1
+        return 1
 
     if ref_name and (ref_name not in seqs):
         print("Specified reference name %s is not in the sequence sample. Will not trim."%ref_name)
@@ -68,11 +79,11 @@ def run(args):
               "\n\thttps://doi.org/10.1093%2Fnar%2Fgkf436\n")
     else:
         print('ERROR: alignment method not implemented')
-        return -1
+        return 1
 
     success = run_shell_command(cmd)
     if not success: # return error if aligner errored
-        return -1
+        return 1
 
     # after aligning, make a copy of the data that the aligner produced (useful for debugging)
     copyfile(output, output+".post_aligner.fasta")

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -3,7 +3,7 @@ import pandas as pd
 from collections import defaultdict
 import random,os
 import numpy as np
-from .utils import read_metadata, get_numerical_dates
+from .utils import read_metadata, get_numerical_dates, run_shell_command
 
 comment_char = '#'
 
@@ -30,7 +30,7 @@ def write_vcf(compressed, input_file, output_file, dropped_samps):
 
     print("Filtering samples using VCFTools with the call:")
     print(" ".join(call))
-    os.system(" ".join(call))
+    run_shell_command(" ".join(call), raise_errors = True)
     # remove vcftools log file
     try:
         os.remove('out.log')

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -2,6 +2,7 @@ from Bio import SeqIO
 import pandas as pd
 import os
 import numpy as np
+from .utils import run_shell_command
 
 def get_mask_sites(vcf_file, mask_file):
     '''
@@ -69,7 +70,7 @@ def run(args):
     call = ["vcftools", "--exclude-positions", tempMaskFile, inCall, in_file, "--recode --stdout", outCall, ">", out_file]
     print("Removing masked sites from VCF file using vcftools... this may take some time. Call:")
     print(" ".join(call))
-    os.system(" ".join(call))
+    run_shell_command(" ".join(call), raise_errors = True)
     os.remove(tempMaskFile) #remove masking file
     # remove vcftools log file
     try:

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -2,6 +2,7 @@ import os, shutil, time
 from Bio import Phylo
 from treetime.vcf_utils import read_vcf
 import numpy as np
+from .utils import run_shell_command
 
 def find_executable(names, default = None):
     """
@@ -48,8 +49,8 @@ def build_raxml(aln_file, out_file, clean_up=True, nthreads=2):
     print("Building a tree via:\n\t" + cmd +
           "\n\tStamatakis, A: RAxML Version 8: A tool for Phylogenetic Analysis and Post-Analysis of Large Phylogenies."
           "\n\tIn Bioinformatics, 2014\n")
-    os.system(cmd)
     try:
+        run_shell_command(cmd, raise_errors = True)
         shutil.copy('RAxML_bestTree.tre', out_file)
         T = Phylo.read(out_file, 'newick')
         if clean_up:
@@ -82,8 +83,8 @@ def build_fasttree(aln_file, out_file, clean_up=True):
     print("Building a tree via:\n\t" + cmd +
           "\n\tPrice et al: FastTree 2 - Approximately Maximum-Likelihood Trees for Large Alignments." +
           "\n\tPLoS ONE 5(3): e9490. https://doi.org/10.1371/journal.pone.0009490\n")
-    os.system(cmd)
     try:
+        run_shell_command(cmd, raise_errors = True)
         T = Phylo.read(out_file, 'newick')
         if clean_up:
             os.remove(log_file)
@@ -140,10 +141,10 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
           "\n\tMol. Biol. Evol., 32:268-274. https://doi.org/10.1093/molbev/msu300\n")
     if substitution_model.lower() == "none":
         print("Conducting a model test... see iqtree.log for the result. You can specify this with --substitution-model in future runs.")
-    os.system(cmd)
 
     # Check result
     try:
+        run_shell_command(cmd, raise_errors = True)
         T = Phylo.read(aln_file+".treefile", 'newick')
         shutil.copyfile(aln_file+".treefile", out_file)
         #this allows the user to check intermediate output, as tree.nwk will be

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -1,5 +1,6 @@
 import os, json, sys
 import pandas as pd
+import subprocess
 from treetime.utils import numeric_date
 from collections import defaultdict
 from pkg_resources import resource_stream
@@ -371,4 +372,32 @@ def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):
         #must temporarily remove .gz ending, or gzip won't zip it!
         os.rename(vcf_file_name, vcf_file_name[:-3])
         call = ["gzip", vcf_file_name[:-3]]
-        os.system(" ".join(call))
+        run_shell_command(" ".join(call), raise_errors = True)
+
+
+def run_shell_command(cmd, raise_errors = False):
+    """
+    Run the given command string via the shell with error checking.
+
+    Returns True if the command exits normally.  Returns False if the command
+    exits with failure and "raise_errors" is False (the default).  When
+    "raise_errors" is True, exceptions are rethrown.
+    """
+    try:
+        # Use check_call() instead of run() since the latter was added only in Python 3.5.
+        subprocess.check_call(cmd, shell = True)
+    except subprocess.CalledProcessError as error:
+        print(
+            "ERROR: {program} exited {returncode}, invoked as: {cmd}".format(
+                program    = cmd.split()[0],
+                returncode = error.returncode,
+                cmd        = cmd,
+            ),
+            file = sys.stderr
+        )
+        if raise_errors:
+            raise
+        else:
+            return False
+    else:
+        return True


### PR DESCRIPTION
Replaces os.system() calls with a small utility function,
run_shell_command(), which prints an error message if the command exits
with failure and returns or raises an exception appropriately.  This is
a thin wrapper around subprocess.check_call(), which does most of the
heavy-lifting.  subprocess is Python's modern collection of functions
for running external commands.

It is better to catch command failure early, immediately after it
happens, than to proceed on the assumption that everything worked and
discover failure later via proxies like missing or empty files.  Doing
so makes what failed and why more clear.

This only changes modular augur.