### PR TITLE
Don't Export Empty Traits

### DIFF
--- a/augur/export.py
+++ b/augur/export.py
@@ -216,7 +216,7 @@ def add_tsv_metadata_to_nodes(nodes, meta_tsv, meta_json, extra_fields=['authors
         if strain not in meta_tsv:
             continue
         for field in fields:
-            if field not in node and field in meta_tsv[strain]:
+            if field not in node and field in meta_tsv[strain] and meta_tsv[strain][field]:
                 node[field] = meta_tsv[strain][field]
 
 
@@ -347,7 +347,7 @@ def transfer_metadata_to_strains(strains, raw_strain_info, traits):
 
         # TRANSFER TRAITS (INCLUDING CONFIDENCE & ENTROPY) #
         for trait in traits:
-            if trait in raw_data:
+            if trait in raw_data and raw_data[trait]:
                 node["traits"][trait] = {"value": raw_data[trait]}
                 if trait+"_confidence" in raw_data:
                     node["traits"][trait]["confidence"] = raw_data[trait+"_confidence"]
@@ -429,6 +429,8 @@ def run(args):
     # get traits to colour by etc - do here before node_data is modified below
     # this ensures we get traits even if they are not on every node
     traits = get_traits(node_data)
+    if args.extra_traits:
+        traits.extend(args.extra_traits)
 
     raw_strain_info = collect_strain_info(node_data, args.metadata)
     unified["tree"], strains = convert_tree_to_json_structure(T.root, raw_strain_info)


### PR DESCRIPTION
First - I realised that I deleted the functionality of exportv2 argument `extra-traits` somewhere along the way - this is back in now. 

In a scenario where a trait is added at export (but hasn't been run through `traits`) from the meta.tsv, and has values set to `NA`, these are currently read in by `utils.py` `read_metadata` as empty strings (''). In both versions of `export` these empty strings are written out to the JSONs. However, `auspice` doesn't handle these very well - they aren't undefined but don't get counted as a 'legitimate' value (don't show up in legend). This means they seem to map to some random colour.

Below, this trait 'label' only has a value for 7 tips, but as you can see, all tips are coloured:
![image](https://user-images.githubusercontent.com/14290674/44404531-59ac4500-a557-11e8-9994-51a0ba535d64.png)

I changed both versions of `export` so that it now doesn't export a value to the JSON if it's empty. This leads to `auspice` displaying this correctly:
![image](https://user-images.githubusercontent.com/14290674/44404584-79dc0400-a557-11e8-9f1b-6989c830d3b7.png)
