### PR TITLE
Use frequency time intervals for fitness model

### DIFF
--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -100,7 +100,7 @@ def sum_of_squared_errors(observed_freq, predicted_freq):
 
 class fitness_model(object):
 
-    def __init__(self, tree, frequencies, time_interval, predictor_input, censor_frequencies=True,
+    def __init__(self, tree, frequencies, predictor_input, censor_frequencies=True,
                  pivot_spacing=1.0 / 12, verbose=0, enforce_positive_predictors=True, predictor_kwargs=None,
                  cost_function=sum_of_squared_errors, **kwargs):
         """
@@ -108,7 +108,6 @@ class fitness_model(object):
         Args:
             tree (Bio.Phylo): an annotated tree for which a fitness model is to be determined
             frequencies (KdeFrequencies): a frequency estimator and its parameters
-            time_interval:
             predictor_input: a list of predictors to fit or dict of predictors to coefficients / std deviations
             censor_frequencies (bool): whether frequencies should censor future data or not
             pivot_spacing:
@@ -136,13 +135,6 @@ class fitness_model(object):
 
         self.time_window = kwargs.get("time_window", 6.0 / 12.0)
 
-        # Convert datetime date interval to floating point interval from
-        # earliest to latest.
-        self.time_interval = (
-            time_interval[1].year + (time_interval[1].month) / 12.0,
-            time_interval[0].year + (time_interval[0].month - 1) / 12.0
-        )
-
         if isinstance(predictor_input, dict):
             predictor_names = predictor_input.keys()
             self.estimate_coefficients = False
@@ -164,6 +156,7 @@ class fitness_model(object):
         self.pivots = self.frequencies.pivots
 
         # final timepoint is end of interval and is only projected forward, not tested
+        self.time_interval = (self.frequencies.start_date, self.frequencies.end_date)
         self.timepoint_step_size = 0.5      # amount of time between timepoints chosen for fitting
         self.delta_time = 1.0               # amount of time projected forward to do fitting
         self.timepoints = np.around(

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -699,7 +699,7 @@ class KdeFrequencies(object):
 
         pivots = np.arange(
             pivot_start,
-            pivot_end,
+            pivot_end + 0.0001,
             pivot_frequency
         )
 

--- a/base/process.py
+++ b/base/process.py
@@ -646,8 +646,7 @@ class process(object):
 
         kwargs = {
             "tree": self.tree.tree,
-            "frequencies": self.kde_frequencies,
-            "time_interval": self.info["time_interval"]
+            "frequencies": self.kde_frequencies
         }
 
         if "predictors" in self.config:

--- a/tests/test_frequencies.py
+++ b/tests/test_frequencies.py
@@ -60,7 +60,7 @@ class TestKdeFrequencies(object):
         assert isinstance(pivots, np.ndarray)
         assert pivots[1] - pivots[0] == pivot_frequency
         assert pivots[0] == start_date
-        assert pivots[-1] != end_date
+        assert pivots[-1] == end_date
         assert pivots[-1] >= end_date - pivot_frequency
 
     def test_estimate(self, tree):


### PR DESCRIPTION
This PR replaces the fitness model's custom time interval calculation with the existing time interval provided by `KdeFrequencies`.
This modification revealed an issue with the calculation of pivots by KdeFrequencies where the last date in the pivot range was not included.

These types of bugs would be easier to avoid if date intervals were calculated with datetime data types instead of floating point values. For example, the [pandas date_range function](https://pandas.pydata.org/pandas-docs/stable/timeseries.html#generating-ranges-of-timestamps) could be a useful replacement for the numpy `arange` or `linspace` logic currently used in augur.