### PR TITLE
Censor titers in fitness model

### DIFF
--- a/base/fitness_predictors.py
+++ b/base/fitness_predictors.py
@@ -387,8 +387,7 @@ class fitness_predictors(object):
         """
         # Filter titers by date from the root node to the current timepoint.
         node_lookup = {node.name: node for node in tree.get_terminals()}
-        date_range = [tree.root.numdate, timepoint]
-        filtered_titers = TiterCollection.subset_to_date(titers, node_lookup, date_range)
+        filtered_titers = TiterCollection.subset_to_date(titers, node_lookup, tree.root.numdate, timepoint)
 
         # Set titer model parameters.
         kwargs = {

--- a/base/fitness_predictors.py
+++ b/base/fitness_predictors.py
@@ -11,6 +11,7 @@ except ImportError:
     pass
 
 from .scores import calculate_LBI
+from .titer_model import SubstitutionModel, TiterCollection, TreeModel
 
 # all fitness predictors should be designed to give a positive sign, ie.
 # number of epitope mutations
@@ -60,8 +61,10 @@ class fitness_predictors(object):
             self.calc_random_predictor(tree)
         #if pred == 'dfreq':
             # do nothing
-        #if pred == 'cHI':
-            # do nothing
+        if pred == 'cTiter':
+            self.calc_titer_model("tree", tree, timepoint, **kwargs)
+        if pred == 'cTiterSub':
+            self.calc_titer_model("substitution", tree, timepoint, **kwargs)
 
     def setup_epitope_mask(self, epitope_masks_fname = 'metadata/ha_masks.tsv', epitope_mask_version = 'wolf', tolerance_mask_version = 'ha1'):
         sys.stderr.write("setup " + str(epitope_mask_version) + " epitope mask and " + str(tolerance_mask_version) + " tolerance mask\n")
@@ -377,3 +380,29 @@ class fitness_predictors(object):
         """
         for node in tree.find_clades():
             setattr(node, attr, np.random.random())
+
+    def calc_titer_model(self, model, tree, timepoint, titers, lam_avi, lam_pot, lam_drop, **kwargs):
+        """Calculates the requested titer model for the given tree using only titers
+        associated with strains sampled prior to the given timepoint.
+        """
+        # Filter titers by date from the root node to the current timepoint.
+        node_lookup = {node.name: node for node in tree.get_terminals()}
+        date_range = [tree.root.numdate, timepoint]
+        filtered_titers = TiterCollection.subset_to_date(titers, node_lookup, date_range)
+
+        # Set titer model parameters.
+        kwargs = {
+            "criterium": lambda node: hasattr(node, "aa_muts") and sum([len(node.aa_muts[protein]) for protein in node.aa_muts]) > 0,
+            "lam_avi": lam_avi,
+            "lam_pot": lam_pot,
+            "lam_drop": lam_drop
+        }
+
+        # Run the requested model and annotate results to nodes.
+        if model == "tree":
+            model = TreeModel(tree, filtered_titers, **kwargs)
+        elif model == "substitution":
+            model = SubstitutionModel(tree, filtered_titers, **kwargs)
+
+        model.prepare(**kwargs)
+        model.train(**kwargs)

--- a/base/process.py
+++ b/base/process.py
@@ -636,7 +636,7 @@ class process(object):
 
 
 
-    def annotate_fitness(self):
+    def annotate_fitness(self, predictor_kwargs=None):
         """Run the fitness prediction model and annotate the tree's nodes with fitness
         values. Returns the resulting fitness model instance.
         """
@@ -651,6 +651,9 @@ class process(object):
 
         if "predictors" in self.config:
             kwargs["predictor_input"] = self.config["predictors"]
+
+        if predictor_kwargs is not None:
+            kwargs["predictor_kwargs"] = predictor_kwargs
 
         if "epitope_mask" in self.config:
             kwargs["epitope_masks_fname"] = self.config["epitope_mask"]

--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -974,6 +974,19 @@ class SubstitutionModel(TiterModel):
         for mi, mut in enumerate(self.relevant_muts):
             self.substitution_effect[mut] = self.model_params[mi]
 
+        # Annotate branch-specific and cumulative antigenic evolution scores.
+        for node in self.tree.find_clades():
+            dTiterSub = 0
+            if hasattr(node, "aa_muts"):
+                for gene, mutations in node.aa_muts.iteritems():
+                    for mutation in mutations:
+                        dTiterSub += self.substitution_effect.get((gene, mutation), 0)
+
+            node.dTiterSub = dTiterSub
+            if node.up is not None:
+                node.cTiterSub = node.up.cTiterSub + dTiterSub
+            else:
+                node.cTiterSub = 0
 
     def predict_titer(self, virus, serum, cutoff=0.0):
         muts= self.get_mutations(serum[0], virus)

--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -151,7 +151,7 @@ class TiterCollection(object):
                 if key[0] in strains and key[1][0] in strains}
 
     @classmethod
-    def subset_to_date(cls, titers, node_lookup, date_range):
+    def subset_to_date(cls, titers, node_lookup, start_date, end_date):
         """Subset the given titers to the given date range based on the dates annotated
         on each node.
         """
@@ -160,12 +160,12 @@ class TiterCollection(object):
         filtered_strains = set([
             node_name
             for node_name, node in node_lookup.items()
-            if node.numdate <= date_range[1] and node.numdate >= date_range[0]
+            if start_date <= node.numdate < end_date
         ])
         filtered_titers = cls.filter_strains(titers, filtered_strains)
         original_counts = sum(cls.count_strains(titers).values())
         filtered_counts = sum(cls.count_strains(filtered_titers).values())
-        sys.stderr.write("Filtered from %i to %i titers between %s and %s\n" % (original_counts, filtered_counts, date_range[0], date_range[1]))
+        sys.stderr.write("Filtered from %i to %i titers between %s and %s\n" % (original_counts, filtered_counts, start_date, end_date))
 
         return filtered_titers
 

--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -857,114 +857,15 @@ class SubstitutionModel(TiterModel):
         '''
         muts = []
 
-        # If proteins information is available and node translations are
-        # annotated, use those to find pairwise amino acid mutations.
-        # Otherwise, use the annotated amino acid mutations per branch to
-        # reconstruct what the pairwise mutations are between the two nodes.
-        if hasattr(self, "proteins"):
-            for prot in self.proteins:
-                seq1 = node1.translations[prot]
-                seq2 = node2.translations[prot]
-                muts.extend([(prot, aa1+str(pos+1)+aa2) for pos, (aa1, aa2)
-                            in enumerate(izip(seq1, seq2)) if aa1!=aa2])
-        else:
-            # Find the last common ancestor of the two nodes.
-            mrca = self.tree.common_ancestor([node1, node2])
-
-            # Find the most recent unreverted mutation at each gene position
-            # in both nodes.
-            muts1 = self.find_mutations_to_mrca(node1, mrca)
-            muts2 = self.find_mutations_to_mrca(node2, mrca)
-
-            # Find all mutated positions from both nodes to their MRCA that
-            # were:
-            #
-            # a) only mutated in one node. The initial to final amino
-            # acids in each of these records should reflect the pairwise
-            # difference between the node that mutated and the ancestral
-            # sequence in the unmutated node.
-            #
-            # OR
-            #
-            # b) mutated in both nodes with different final amino acids.
-            # In this case, the different amino acids reflect the pairwise
-            # amino acid difference we would find between complete sequences.
-            mutations = []
-            for key in muts1:
-                # Test for mutations at each site only in one node.
-                if not key in muts2:
-                    # Report the first node's final as the first mutation and the
-                    # ancestral amino acid as the second node's value.
-                    muts.append((key[0], muts1[key]["final"] + str(key[1]) + muts1[key]["initial"]))
-                # Test for different mutations at the same site in the two nodes.
-                elif key in muts2:
-                    if muts1[key]["final"] != muts2[key]["final"]:
-                        # Store the mutation and then remove it from the second node's mutations.
-                        muts.append((key[0], muts1[key]["final"] + str(key[1]) + muts2[key]["final"]))
-
-                    # Delete the shared mutation from the second node. If the two
-                    # nodes ended with different mutations, we have just stored
-                    # that differences and if they have the same final mutations,
-                    # we don't want to count that as a difference.
-                    del muts2[key]
-
-            # Add all of the second node's remaining mutations to the set.
-            # We know these must not be shared with the first node now.
-            for key in muts2:
-                muts.append((key[0], muts2[key]["initial"] + str(key[1]) + muts2[key]["final"]))
+        # Use available information about proteins and amino acid translations
+        # on nodes to find pairwise amino acid mutations.
+        for prot in self.proteins:
+            seq1 = node1.translations[prot]
+            seq2 = node2.translations[prot]
+            muts.extend([(prot, aa1+str(pos+1)+aa2) for pos, (aa1, aa2)
+                        in enumerate(zip(seq1, seq2)) if aa1!=aa2])
 
         return muts
-
-
-    def find_mutations_to_mrca(self, node, mrca):
-        """Find all pairwise amino acid mutations between the given node
-        and one of its ancestors.
-        >>>
-        """
-        current_node = node
-        muts_node = {}
-
-        while current_node != mrca and current_node.up is not None:
-            for gene, muts in current_node.aa_muts.items():
-                for mut in muts:
-                    initial_aa = mut[0]
-                    final_aa = mut[-1]
-                    position = int(mut[1:-1])
-                    key = (gene, position)
-
-                    if not key in muts_node:
-                        # If we haven't seen a mutation at this gene position,
-                        # track the initial and final amino acids.
-                        muts_node[key] = {
-                            "initial": initial_aa,
-                            "final": final_aa
-                        }
-                    else:
-                        # If we have already seen a mutation at this position,
-                        # check whether the current mutation reverts the current
-                        # final amino acid. For example, the following sequence
-                        # from first to last in time reverts the amino acid at
-                        # a given position:
-                        #
-                        # 1. G -> K
-                        # 2. K -> L
-                        # 3. L -> G
-                        #
-                        # As we walk backward in time to the MRCA, if we find
-                        # an initial "G" that resulted in the final "G", we
-                        # collapse the reversion by removing the gene position
-                        # from the tracked mutations.
-                        if initial_aa == muts_node[key]["final"]:
-                             # If it is a reversion, remove the stored mutation and continue.
-                            del muts_node[key]
-                        else:
-                            # If the next mutation is not a reversion, update the initial
-                            # amino acid to track the ancestral state in the MRCA.
-                            muts_node[key]["initial"] = initial_aa
-
-            current_node = current_node.up
-
-        return muts_node
 
 
     def determine_relevant_mutations(self, min_count=10):

--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -830,7 +830,8 @@ class SubstitutionModel(TiterModel):
     """
     def __init__(self, *args, **kwargs):
         super(SubstitutionModel, self).__init__(*args, **kwargs)
-        self.proteins = self.tree.root.translations.keys()
+        if hasattr(self.tree.root, "translations"):
+            self.proteins = self.tree.root.translations.keys()
 
     def prepare(self, **kwargs):
         self.make_training_set(**kwargs)
@@ -855,12 +856,115 @@ class SubstitutionModel(TiterModel):
         between as tuples (protein, mutation) e.g. (HA1, 159F)
         '''
         muts = []
-        for prot in self.proteins:
-            seq1 = node1.translations[prot]
-            seq2 = node2.translations[prot]
-            muts.extend([(prot, aa1+str(pos+1)+aa2) for pos, (aa1, aa2)
-                        in enumerate(zip(seq1, seq2)) if aa1!=aa2])
+
+        # If proteins information is available and node translations are
+        # annotated, use those to find pairwise amino acid mutations.
+        # Otherwise, use the annotated amino acid mutations per branch to
+        # reconstruct what the pairwise mutations are between the two nodes.
+        if hasattr(self, "proteins"):
+            for prot in self.proteins:
+                seq1 = node1.translations[prot]
+                seq2 = node2.translations[prot]
+                muts.extend([(prot, aa1+str(pos+1)+aa2) for pos, (aa1, aa2)
+                            in enumerate(izip(seq1, seq2)) if aa1!=aa2])
+        else:
+            # Find the last common ancestor of the two nodes.
+            mrca = self.tree.common_ancestor([node1, node2])
+
+            # Find the most recent unreverted mutation at each gene position
+            # in both nodes.
+            muts1 = self.find_mutations_to_mrca(node1, mrca)
+            muts2 = self.find_mutations_to_mrca(node2, mrca)
+
+            # Find all mutated positions from both nodes to their MRCA that
+            # were:
+            #
+            # a) only mutated in one node. The initial to final amino
+            # acids in each of these records should reflect the pairwise
+            # difference between the node that mutated and the ancestral
+            # sequence in the unmutated node.
+            #
+            # OR
+            #
+            # b) mutated in both nodes with different final amino acids.
+            # In this case, the different amino acids reflect the pairwise
+            # amino acid difference we would find between complete sequences.
+            mutations = []
+            for key in muts1:
+                # Test for mutations at each site only in one node.
+                if not key in muts2:
+                    # Report the first node's final as the first mutation and the
+                    # ancestral amino acid as the second node's value.
+                    muts.append((key[0], muts1[key]["final"] + str(key[1]) + muts1[key]["initial"]))
+                # Test for different mutations at the same site in the two nodes.
+                elif key in muts2:
+                    if muts1[key]["final"] != muts2[key]["final"]:
+                        # Store the mutation and then remove it from the second node's mutations.
+                        muts.append((key[0], muts1[key]["final"] + str(key[1]) + muts2[key]["final"]))
+
+                    # Delete the shared mutation from the second node. If the two
+                    # nodes ended with different mutations, we have just stored
+                    # that differences and if they have the same final mutations,
+                    # we don't want to count that as a difference.
+                    del muts2[key]
+
+            # Add all of the second node's remaining mutations to the set.
+            # We know these must not be shared with the first node now.
+            for key in muts2:
+                muts.append((key[0], muts2[key]["initial"] + str(key[1]) + muts2[key]["final"]))
+
         return muts
+
+
+    def find_mutations_to_mrca(self, node, mrca):
+        """Find all pairwise amino acid mutations between the given node
+        and one of its ancestors.
+        >>>
+        """
+        current_node = node
+        muts_node = {}
+
+        while current_node != mrca and current_node.up is not None:
+            for gene, muts in current_node.aa_muts.items():
+                for mut in muts:
+                    initial_aa = mut[0]
+                    final_aa = mut[-1]
+                    position = int(mut[1:-1])
+                    key = (gene, position)
+
+                    if not key in muts_node:
+                        # If we haven't seen a mutation at this gene position,
+                        # track the initial and final amino acids.
+                        muts_node[key] = {
+                            "initial": initial_aa,
+                            "final": final_aa
+                        }
+                    else:
+                        # If we have already seen a mutation at this position,
+                        # check whether the current mutation reverts the current
+                        # final amino acid. For example, the following sequence
+                        # from first to last in time reverts the amino acid at
+                        # a given position:
+                        #
+                        # 1. G -> K
+                        # 2. K -> L
+                        # 3. L -> G
+                        #
+                        # As we walk backward in time to the MRCA, if we find
+                        # an initial "G" that resulted in the final "G", we
+                        # collapse the reversion by removing the gene position
+                        # from the tracked mutations.
+                        if initial_aa == muts_node[key]["final"]:
+                             # If it is a reversion, remove the stored mutation and continue.
+                            del muts_node[key]
+                        else:
+                            # If the next mutation is not a reversion, update the initial
+                            # amino acid to track the ancestral state in the MRCA.
+                            muts_node[key]["initial"] = initial_aa
+
+            current_node = current_node.up
+
+        return muts_node
 
 
     def determine_relevant_mutations(self, min_count=10):

--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from .io_util import myopen
 import pandas as pd
 from pprint import pprint
+import sys
 
 try:
     import itertools.izip as zip
@@ -148,6 +149,25 @@ class TiterCollection(object):
         """
         return {key: value for key, value in titers.iteritems()
                 if key[0] in strains and key[1][0] in strains}
+
+    @classmethod
+    def subset_to_date(cls, titers, node_lookup, date_range):
+        """Subset the given titers to the given date range based on the dates annotated
+        on each node.
+        """
+        # Filter titers from the future by keeping titers associated with
+        # strains from the given timepoint or earlier.
+        filtered_strains = set([
+            node_name
+            for node_name, node in node_lookup.items()
+            if node.numdate <= date_range[1] and node.numdate >= date_range[0]
+        ])
+        filtered_titers = cls.filter_strains(titers, filtered_strains)
+        original_counts = sum(cls.count_strains(titers).values())
+        filtered_counts = sum(cls.count_strains(filtered_titers).values())
+        sys.stderr.write("Filtered from %i to %i titers between %s and %s\n" % (original_counts, filtered_counts, date_range[0], date_range[1]))
+
+        return filtered_titers
 
     def __init__(self, titers, **kwargs):
         """Accepts the name of a file containing titers to load or a preloaded titers
@@ -338,21 +358,6 @@ class TiterModel(object):
         for node in self.tree.get_nonterminals():
             for c in node.clades:
                 c.up = node
-
-
-    def subset_to_date(self, date_range):
-        # if data is to censored by date, subset the data set and
-        # reassign sera, reference strains, and test viruses
-        self.train_titers = {key:val for key,val in self.train_titers.iteritems()
-                            if self.node_lookup[key[0]].num_date>=date_range[0] and
-                               self.node_lookup[key[1][0]].num_date>=date_range[0] and
-                               self.node_lookup[key[0]].num_date<date_range[1] and
-                               self.node_lookup[key[1][0]].num_date<date_range[1]}
-
-        self.sera, self.ref_strains, self.test_strains = self.titers.strain_census(self.train_titers)
-
-        print("Reduced training data to date range", date_range)
-        self.titer_stats()
 
 
     def make_training_set(self, training_fraction=1.0, subset_strains=False, **kwargs):

--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -398,10 +398,7 @@ class TiterModel(object):
         self.lam_pot = lam_pot
         self.lam_avi = lam_avi
         self.lam_drop = lam_drop
-        if len(self.train_titers)==0:
-            print('no titers to train')
-            self.model_params = np.zeros(self.genetic_params+len(self.sera)+len(self.test_strains))
-        else:
+        if len(self.train_titers) > 1:
             if method=='l1reg':  # l1 regularized fit, no constraint on sign of effect
                 self.model_params = self.fit_l1reg()
             elif method=='nnls':  # non-negative least square, not regularized
@@ -412,6 +409,9 @@ class TiterModel(object):
                 self.model_params = self.fit_nnl1reg()
 
             print('rms deviation on training set=',np.sqrt(self.fit_func()))
+        else:
+            print('no titers to train')
+            self.model_params = np.zeros(self.genetic_params+len(self.sera)+len(self.test_strains))
 
         # extract and save the potencies and virus effects. The genetic parameters
         # are subclass specific and need to be process by the subclass

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -35,6 +35,7 @@ def parse_args():
     parser.add_argument('--epitope_mask_version', help="name of the epitope mask that defines epitope mutations")
     parser.add_argument('--tolerance_mask_version', help="name of the tolerance mask that defines non-epitope mutations")
     parser.add_argument('--glyc_mask_version', help="name of the mask that defines putative glycosylation sites")
+    parser.add_argument('--export_translations', action='store_true', help="export amino acid translations as node attributes in the auspice tree JSON")
 
     parser.set_defaults(
         json="prepared/flu.json"
@@ -50,7 +51,7 @@ def make_config(prepared_json, args):
         args.predictors_sds
     )
 
-    return {
+    config = {
         "dir": "flu",
         "in": prepared_json,
         "geo_inference": ['region'],
@@ -94,6 +95,12 @@ def make_config(prepared_json, args):
             "method": args.tree_method
         }
     }
+
+    # Export amino acid translations.
+    if args.export_translations:
+        config["auspice"]["extra_attr"].append("translations")
+
+    return config
 
 # set defaults when command line parameter is None based on lineage, segment and resolution
 def set_config_defaults(runner):

--- a/builds/flu/flu.process.py
+++ b/builds/flu/flu.process.py
@@ -676,40 +676,6 @@ if __name__=="__main__":
             #     "key": "glyc"
             # }
 
-        # titers
-        if hasattr(runner, "titers") and runner.info["segment"] == "ha":
-            HI_model(runner)
-
-            if runner.config["auspice"]["titers_export"]:
-                HI_export(runner)
-                vaccine_distance_json = vaccine_distance(titer_tree = runner.tree.tree,
-                                                         vaccine_strains = vaccine_choices[runner.info['lineage']],
-                                                         attributes=['dTiter', 'dTiterSub'])
-                write_json(vaccine_distance_json, os.path.join(runner.config["output"]["auspice"], runner.info["prefix"])+'_vaccine_dist.json')
-
-                if runner.info["segment"]=='ha':
-                    plot_titers(runner.HI_subs, runner.HI_subs.titers.titers,
-                                fname='processed/%s_raw_titers.png'%runner.info["prefix"],
-                                title = runner.info["prefix"], mean='geometric')
-                    plot_titers(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
-                                fname='processed/%s_normalized_titers.png'%runner.info["prefix"],
-                                title = runner.info["prefix"], mean='arithmetric')
-                    plot_titer_matrix(runner.HI_subs, runner.HI_subs.titers.titers,
-                                fname='processed/%s_raw_titer_matrix.png'%runner.info["prefix"],
-                                title = runner.info["prefix"], mean='geometric', clades=clades, normalized=False, potency=False)
-                    plot_titer_matrix(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
-                                fname='processed/%s_normalized_titer_matrix.png'%runner.info["prefix"],
-                                title = runner.info["prefix"], mean='arithmetric', clades=clades, normalized=True, potency=False)
-                    plot_titer_matrix(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
-                                fname='processed/%s_normalized_with_potency_titer_matrix.png'%runner.info["prefix"],
-                                title = runner.info["prefix"], mean='arithmetric', clades=clades, normalized=True, potency=True)
-                    plot_titer_matrix_grouped(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
-                                fname='processed/%s_grouped_titer_matrix.png'%runner.info["prefix"],
-                                title = runner.info["prefix"], virus_clades=virus_clades, serum_clades=serum_clades, potency=False)
-                    plot_titer_matrix_grouped(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
-                                fname='processed/%s_grouped_with_potency_titer_matrix.png'%runner.info["prefix"],
-                                title = runner.info["prefix"], virus_clades=virus_clades, serum_clades=serum_clades, potency=True)
-
     if runner.info["segment"] == "na":
         import json
         ha_tree_json_fname = os.path.join(runner.config["output"]["auspice"], runner.info["prefix"]) + "_tree.json"
@@ -728,7 +694,17 @@ if __name__=="__main__":
     # Predict fitness for HA after all other scores and annotations have completed
     # Only predict 2y resolution due to coefficient match
     if runner.info["segment"] == 'ha' and runner.info["resolution"] == "2y" and runner.config["annotate_fitness"]:
-        fitness_model = runner.annotate_fitness()
+        if hasattr(runner, "titers"):
+            predictor_kwargs = {
+                "lam_avi": runner.config["titers"]["lam_avi"],
+                "lam_pot": runner.config["titers"]["lam_pot"],
+                "lam_drop": runner.config["titers"]["lam_drop"],
+                "titers": runner.titers
+            }
+        else:
+            predictor_kwargs = {}
+
+        fitness_model = runner.annotate_fitness(predictor_kwargs=predictor_kwargs)
         if fitness_model is not None:
             print("Fitness model parameters: %s" % str(zip(fitness_model.predictors, fitness_model.model_params)))
             print("Fitness model deviations: %s" % str(zip(fitness_model.predictors, fitness_model.global_sds)))
@@ -748,5 +724,39 @@ if __name__=="__main__":
             #     "legendTitle": "Predicted frequency",
             #     "key": "predicted_freq"
             # }
+
+    # titers
+    if hasattr(runner, "titers") and runner.info["segment"] == "ha":
+        HI_model(runner)
+
+        if runner.config["auspice"]["titers_export"]:
+            HI_export(runner)
+            vaccine_distance_json = vaccine_distance(titer_tree = runner.tree.tree,
+                                                     vaccine_strains = vaccine_choices[runner.info['lineage']],
+                                                     attributes=['dTiter', 'dTiterSub'])
+            write_json(vaccine_distance_json, os.path.join(runner.config["output"]["auspice"], runner.info["prefix"])+'_vaccine_dist.json')
+
+            if runner.info["segment"]=='ha':
+                plot_titers(runner.HI_subs, runner.HI_subs.titers.titers,
+                            fname='processed/%s_raw_titers.png'%runner.info["prefix"],
+                            title = runner.info["prefix"], mean='geometric')
+                plot_titers(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
+                            fname='processed/%s_normalized_titers.png'%runner.info["prefix"],
+                            title = runner.info["prefix"], mean='arithmetric')
+                plot_titer_matrix(runner.HI_subs, runner.HI_subs.titers.titers,
+                            fname='processed/%s_raw_titer_matrix.png'%runner.info["prefix"],
+                            title = runner.info["prefix"], mean='geometric', clades=clades, normalized=False, potency=False)
+                plot_titer_matrix(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
+                            fname='processed/%s_normalized_titer_matrix.png'%runner.info["prefix"],
+                            title = runner.info["prefix"], mean='arithmetric', clades=clades, normalized=True, potency=False)
+                plot_titer_matrix(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
+                            fname='processed/%s_normalized_with_potency_titer_matrix.png'%runner.info["prefix"],
+                            title = runner.info["prefix"], mean='arithmetric', clades=clades, normalized=True, potency=True)
+                plot_titer_matrix_grouped(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
+                            fname='processed/%s_grouped_titer_matrix.png'%runner.info["prefix"],
+                            title = runner.info["prefix"], virus_clades=virus_clades, serum_clades=serum_clades, potency=False)
+                plot_titer_matrix_grouped(runner.HI_subs, runner.HI_subs.titers.titers_normalized,
+                            fname='processed/%s_grouped_with_potency_titer_matrix.png'%runner.info["prefix"],
+                            title = runner.info["prefix"], virus_clades=virus_clades, serum_clades=serum_clades, potency=True)
 
     runner.auspice_export()

--- a/builds/flu/flu_titers.py
+++ b/builds/flu/flu_titers.py
@@ -31,20 +31,6 @@ def HI_model(process):
     process.HI_subs.train(**kwargs)
 
     for node in process.tree.tree.find_clades():
-        dTiterSub = 0
-
-        if hasattr(node, "aa_muts"):
-            for gene, mutations in node.aa_muts.iteritems():
-                for mutation in mutations:
-                    dTiterSub += process.HI_subs.substitution_effect.get((gene, mutation), 0)
-
-        node.dTiterSub = dTiterSub
-
-        if node.up is not None:
-            node.cTiterSub = node.up.cTiterSub + dTiterSub
-        else:
-            node.cTiterSub = 0
-
         node.attr["cTiterSub"] = node.cTiterSub
         node.attr["dTiterSub"] = node.dTiterSub
 


### PR DESCRIPTION
This PR is part two of two replacing #125 and ensures that the fitness model does not use titer data sampled from dates after the current prediction timepoint.
The new fitness predictor method `calc_titer_model` handles this logic by subsetting all titers to the current timepoint and re-running either the tree or substitution model with the new titer subset.

The current implementation of the fitness model uses pre-generated auspice JSON files as input.
These files do not usually have amino acid translations annotated to each node in the tree that the titer substitution model needs to run.
For this reason, this PR also introduces an `--export_translations` flag to the `flu.process.py` command that can optionally include those amino acid translations in auspice JSON trees.