### PR TITLE
Export amino acid translations JSON

### DIFF
--- a/augur/translate.py
+++ b/augur/translate.py
@@ -322,6 +322,19 @@ def run(args):
                 fileEndings = -2
             vcf_out_ref = args.vcf_reference_output or '.'.join(args.alignment_output.split('.')[:fileEndings]) + '_reference.fasta'
             write_VCF_translation(translations, args.alignment_output, vcf_out_ref)
+        elif args.alignment_output.endswith(".json"):
+            # Translations are grouped by feature name and then by node name.
+            # For JSON output, they need to be grouped by node name, a
+            # descriptive name like "translations", and then by feature.
+            translations_json = {}
+            for feature_name, sequences in translations.items():
+                for sequence_name, sequence in sequences.items():
+                    if sequence_name not in translations_json:
+                        translations_json[sequence_name] = {"translations": {}}
+
+                    translations_json[sequence_name]["translations"][feature_name] = sequence
+
+            write_json({'annotations': annotations, 'nodes': translations_json}, args.alignment_output)
         else:
             ## write fasta-style output if requested
             if '%GENE' in args.alignment_output:

--- a/bin/augur
+++ b/bin/augur
@@ -121,8 +121,9 @@ if __name__=="__main__":
     translate_parser.add_argument('--genes', nargs='+', help="genes to translate (list or file containing list)")
     translate_parser.add_argument('--output', type=str, help="name of JSON files for aa mutations")
     translate_parser.add_argument('--alignment-output', type=str, help="write out translated gene alignments. "
-                                   "If a VCF-input, a .vcf or .vcf.gz will be output here (depending on file ending). If fasta-input, specify the file name "
-                                   "like so: 'my_alignment_%GENE.fasta', where '%GENE' will be replaced by the name of the gene")
+                                   "If a VCF-input, a .vcf or .vcf.gz will be output here (depending on file ending). "
+                                   "If fasta-input, specify the file name like so: 'my_alignment_%%GENE.fasta', where '%%GENE' will be replaced by the name of the gene. "
+                                   "If the alignment output file name ends with .json, the amino acid translations for all genes will be exported in a single node-data JSON file.")
     translate_parser.add_argument('--vcf-reference-output', type=str, help="fasta file where reference sequence translations for VCF input will be written")
     translate_parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
     translate_parser.set_defaults(func=translate.run)


### PR DESCRIPTION
This PR adds a JSON output format for the `augur translate` command's `--alignment-output` option such that full amino acid translations can be exported in a node-data-style JSON format and merged into an auspice tree JSON later as part of the `export` command.

Users can request this output format by specifying an alignment output with a JSON extension like so:

```bash
 augur translate \
            --tree {input.tree} \
            --ancestral-sequences {input.node_data} \
            --reference-sequence {input.reference} \
            --output {output.node_data} \
            --alignment-output translations.json
```

The full set of translations is needed for flu builds to calculate epitope mutation scores and run the titer substitution model, among other things.
This code should take us another step closer to running standard flu builds with modular augur.

The approach I took here is based on the existing interface for supporting VCF or FASTA alignment output based on the extension of the given output filename(s).