### PR TITLE
Fixes a Few Validate Bugs

### DIFF
--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -318,6 +318,7 @@
                     "$comment": "same numbering scheme as used by the meta.JSON -> annotations",
                     "$comment": "combining nuc + AAs parallels the metadata -> annotations structure",
                     "type": "object",
+                    "additionalProperties": false,
                     "properties":  {
                         "nuc": {
                             "description": "nucelotide mutations",
@@ -332,7 +333,7 @@
                         }
                     },
                     "patternProperties": {
-                        "^[a-zA-Z0-9]+$": {
+                        "^[a-zA-Z0-9_]+$": {
                             "description": "Amino acid mutations for this gene (or annotated region)",
                             "$comment": "properties must exist in the meta.JSON -> annotation object",
                             "type": "array",

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -166,7 +166,7 @@ def verifyMetaAndOrTreeJSONsAreInternallyConsistent(meta, tree):
     mj = meta["json"]
 
     if "panels" in mj and "entropy" in mj["panels"] and "annotations" not in mj:
-        error("\tERROR: The entropy panel has been specified but annotations don't exist.", file=sys.stderr)
+        error("\tERROR: The entropy panel has been specified but annotations don't exist.")
 
     if not tree:
         return return_status
@@ -320,13 +320,13 @@ def verifyMainJSONIsInternallyConsistent(main):
                 if author not in data["author_info"]:
                     error("Author \"{}\" defined on a tree node but not in \"author_info\".".format(author))
 
-    genes_with_mutations = collectMutationGenes(data)
+    genes_with_mutations = collectMutationGenes(data['tree'])
     if len(genes_with_mutations):
-        if "annotations" not in data:
-            error("The tree defined mutations on genes {}, but annotations aren't defined in the meta JSON.".format(", ".join(genes_with_aa_muts)))
+        if "genome_annotations" not in data:
+            error("The tree defined mutations on genes {}, but annotations aren't defined in the meta JSON.".format(", ".join(genes_with_mutations)))
         else:
             for gene in genes_with_mutations:
-                if gene not in data["annotations"]:
+                if gene not in data["genome_annotations"]:
                     error("The tree defined mutations on gene {} which doesn't appear in the metadata annotations object.".format(gene))
 
     return return_status


### PR DESCRIPTION
Minor changes to `validate` and `schema` to fix a few bugs.

This validation now consistently allows `_` in gene names (currently `export` does but `exportv2` doesn't, but it isn't being checked properly).
This allows `tests/builds/tb` to validate without errors. However, trying to then colorBy genes with `_` in auspice doesn't work (nothing happens). How to handle this is being discussed in PR [220](https://github.com/nextstrain/augur/pull/220). 

James, I'm less familiar with `validate` and the schema so if you wouldn't mind just casting eyes on this to ensure it's sensible, I'd appreciate :) Then it can be merged.