### PR TITLE
Optionally auto-scale the number of threads used for alignment and tree building 

### DIFF
--- a/augur/align.py
+++ b/augur/align.py
@@ -6,7 +6,7 @@ import os,sys,argparse
 from shutil import copyfile
 import numpy as np
 from Bio import AlignIO, SeqIO, Seq
-from .utils import run_shell_command
+from .utils import run_shell_command, nthreads_value
 
 def make_gaps_ambiguous(aln):
     '''
@@ -29,8 +29,8 @@ def make_gaps_ambiguous(aln):
 def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in fasta or VCF format")
     parser.add_argument('--output', '-o', help="output file")
-    parser.add_argument('--nthreads', type=int, default=2,
-                                help="number of threads used")
+    parser.add_argument('--nthreads', type=nthreads_value, default=1,
+                                help="number of threads to use; specifying the value 'auto' will cause the number of available CPU cores on your system, if determinable, to be used")
     parser.add_argument('--method', default='mafft', choices=["mafft"],
                                 help="alignment program to use")
     parser.add_argument('--reference-name', type=str, help="strip insertions relative to reference sequence; use if the reference is already in the input sequences")

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -97,8 +97,6 @@ def register_arguments(parser):
                                 help='branch length mode of treetime to use')
     parser.add_argument('--clock-filter-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
                                 'interquartile ranges from the root-to-tip vs time regression')
-    parser.add_argument('--nthreads', type=int, default=2,
-                                help="number of threads used")
     parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
     parser.add_argument('--year-bounds', type=int, nargs='+', help='specify min or max & min prediction bounds for samples with XX in year')
 

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -2,7 +2,7 @@
 Build a tree using a variety of methods.
 """
 
-import os, shutil, time
+import os, shutil, sys, time
 from Bio import Phylo
 from treetime.vcf_utils import read_vcf
 import numpy as np
@@ -290,8 +290,12 @@ def run(args):
         T = build_raxml(fasta, tree_fname, nthreads=args.nthreads)
     elif args.method=='iqtree':
         T = build_iqtree(fasta, tree_fname, args.substitution_model, nthreads=args.nthreads)
-    else: #use fasttree - if add more options, put another check here
+    elif args.method=='fasttree':
         T = build_fasttree(fasta, tree_fname)
+    else:
+        print("ERROR: unknown tree builder provided to --method: %s" % args.method, file = sys.stderr)
+        return 1
+
     end = time.time()
     print("Building original tree took {} seconds".format(str(end-start)))
 

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -6,7 +6,7 @@ import os, shutil, sys, time
 from Bio import Phylo
 from treetime.vcf_utils import read_vcf
 import numpy as np
-from .utils import run_shell_command
+from .utils import run_shell_command, nthreads_value
 
 def find_executable(names, default = None):
     """
@@ -26,7 +26,7 @@ def find_executable(names, default = None):
     return exe
 
 
-def build_raxml(aln_file, out_file, clean_up=True, nthreads=2):
+def build_raxml(aln_file, out_file, clean_up=True, nthreads=1):
     '''
     build tree using RAxML with parameters '-f d -m GTRCAT -c 25 -p 235813 -n tre"
     '''
@@ -110,7 +110,7 @@ def build_fasttree(aln_file, out_file, clean_up=True, nthreads=1):
     return T
 
 
-def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nthreads=2):
+def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nthreads=1):
     '''
     build tree using IQ-Tree with parameters "-fast"
     arguments:
@@ -258,8 +258,8 @@ def register_arguments(parser):
     parser.add_argument('--output', '-o', type=str, help='file name to write tree to')
     parser.add_argument('--substitution-model', default="GTR", choices=["HKY", "GTR", "HKY+G", "GTR+G"],
                                 help='substitution model to use. Specify \'none\' to run ModelTest. Currently, only available for IQTREE.')
-    parser.add_argument('--nthreads', type=int, default=2,
-                             help="number of threads used")
+    parser.add_argument('--nthreads', type=nthreads_value, default=1,
+                                help="number of threads to use; specifying the value 'auto' will cause the number of available CPU cores on your system, if determinable, to be used")
     parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
     parser.add_argument('--exclude-sites', type=str, help='file name of sites to exclude for raw tree building (VCF only)')
 

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -375,17 +375,25 @@ def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):
         run_shell_command(" ".join(call), raise_errors = True)
 
 
-def run_shell_command(cmd, raise_errors = False):
+def run_shell_command(cmd, raise_errors = False, extra_env = None):
     """
     Run the given command string via the shell with error checking.
 
     Returns True if the command exits normally.  Returns False if the command
     exits with failure and "raise_errors" is False (the default).  When
     "raise_errors" is True, exceptions are rethrown.
+
+    If an *extra_env* mapping is passed, the provided keys and values are
+    overlayed onto the default subprocess environment.
     """
+    env = os.environ.copy()
+
+    if extra_env:
+        env.update(extra_env)
+
     try:
         # Use check_call() instead of run() since the latter was added only in Python 3.5.
-        subprocess.check_call(cmd, shell = True)
+        subprocess.check_call(cmd, shell = True, env = env)
     except subprocess.CalledProcessError as error:
         print(
             "ERROR: {program} exited {returncode}, invoked as: {cmd}".format(


### PR DESCRIPTION
Uses all the available CPU cores by default instead of just 2.  It is still possible to limit the number of threads to a certain number using the `--nthreads` options to "align" and "tree".

Auto-scaling by default is particularly nice because it means the same command invocations in Snakefile can make the most of the system they're run on, whether that's a laptop or the cluster or a beefy AWS instance.

This PR builds off PR #217 (the `command-architecture` branch), so should wait to merge until that is merged.