### PR TITLE
Standardize H3N2 reference sequences

### DIFF
--- a/builds/flu/metadata/h3n2_ha_outgroup.gb
+++ b/builds/flu/metadata/h3n2_ha_outgroup.gb
@@ -1,55 +1,39 @@
-LOCUS       CY113677                1732 bp    DNA              VRL 04-APR-2012
-DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) hemagglutinin (HA) gene,
+LOCUS       A/Beijing/32/1992               1701 bp    DNA              VRL 02-MAY-2006
+DEFINITION  Influenza A virus (A/Beijing/32/1992(H3N2)) hemagglutinin gene,
             complete cds.
-ACCESSION   CY113677
-VERSION     CY113677.1
+ACCESSION   U26830
+VERSION     U26830.1  GI:857407
 KEYWORDS    .
 SOURCE      Influenza A virus (A/Beijing/32/1992(H3N2))
   ORGANISM  Influenza A virus (A/Beijing/32/1992(H3N2))
             Viruses; ssRNA viruses; ssRNA negative-strand viruses;
             Orthomyxoviridae; Influenzavirus A.
-REFERENCE   1  (bases 1 to 1732)
-  AUTHORS   Wentworth,D.E., Dugan,V., Halpin,R., Lin,X., Bera,J., Ghedin,E.,
-            Fedorova,N., Overton,L., Tsitrin,T., Stockwell,T., Amedeo,P.,
-            Bishop,B., Chen,H., Edworthy,P., Gupta,N., Katzel,D., Li,K.,
-            Schobel,S., Shrivastava,S., Thovarai,V., Wang,S., Westgeest,K.B.,
-            van Beek,R., Bestebroer,T.M., de Jong,J.C., Rimmelzwaan,G.F.,
-            Osterhaus,A.D.M.E., Fouchier,R.A.M., Bao,Y., Sanders,R.,
-            Dernovoy,D., Kiryutin,B., Lipman,D.J. and Tatusova,T.
-  TITLE     The NIAID Influenza Genome Sequencing Project
-  JOURNAL   Unpublished
-REFERENCE   2  (bases 1 to 1732)
-  CONSRTM   The NIAID Influenza Genome Sequencing Consortium
+REFERENCE   1  (bases 1 to 1701)
+  AUTHORS   Muster,T., Ferko,B., Klima,A., Purtscher,M., Trkola,A., Schulz,P.,
+            Grassauer,A., Engelhardt,O.G., Garcia-Sastre,A., Palese,P. and
+            Katinger,H.
+  TITLE     Mucosal model of immunization against human immunodeficiency virus
+            type 1 with a chimeric influenza virus
+  JOURNAL   J. Virol. 69 (11), 6678-6686 (1995)
+   PUBMED   7474077
+REFERENCE   2  (bases 1 to 1701)
+  AUTHORS   Muster,T. and Klima,A.
   TITLE     Direct Submission
-  JOURNAL   Submitted (04-APR-2012) on behalf of JCVI/Erasmus Medical
-            College/NCBI, National Center for Biotechnology Information, NIH,
-            Bethesda, MD 20894, USA
-COMMENT     This work was supported by the National Institute of Allergy and
-            Infectious Diseases (NIAID), Genome Sequencing Centers for
-            Infectious Diseases (GSCID) program.
+  JOURNAL   Submitted (11-MAY-1995) Thomas Muster, Institute of Applied
+            Microbiology, Nussdorfer Laende 11, Vienna, A-1190, Austria
 FEATURES             Location/Qualifiers
-     source          1..1732
-                     /bio_material="CEIRS#CIP047BE3292#"
-                     /collection_date="1992"
-                     /country="China: Beijing"
+     source          1..1701
+                     /mol_type="genomic RNA"
+                     /lab_host="MDBK cells"
                      /db_xref="taxon:380950"
-                     /host="Homo sapiens"
-                     /lab_host="xtMK3 MDCK1 passage(s)"
-                     /mol_type="viral cRNA"
-                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
-                     /segment="4"
                      /serotype="H3N2"
                      /strain="A/Beijing/32/1992"
-     misc_feature    1..1732
-                     /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.HA"
-     gene            15..1715
-                     /gene="HA"
-     CDS             15..1715
-                     /codon_start=1
-                     /function="receptor binding and fusion protein"
-                     /gene="HA"
+                     /host="Homo sapiens"
+                     /organism="Influenza A virus (A/Beijing/32/1992(H3N2))"
+     CDS             1..1701
+                     /db_xref="GI:857408"
                      /product="hemagglutinin"
-                     /protein_id="AFG99677.1"
+                     /codon_start=1
                      /translation="MKTIIALSYILCLVFAQKLPGNDNSTATLCLGHHAVPNGTLVKTI
                      TNDQIEVTNATELVQSSSTGRICDSPHRILDGKNCTLIDALLGDPHCDGFQNKEWDLFV
                      ERSKAYSNCYPYDVPDYASLRSLVASSGTLEFINEDFNWTGVAQDGGSYACKRGSVNSF
@@ -60,40 +44,45 @@ FEATURES             Location/Qualifiers
                      LIEKTNEKFHQIEKEFSEVEGRIQDLEKYVEDTKIDLWSYNAELLVALENQHTIDLTDS
                      EMNKLFEKTRKQLRENAEDMGNGCFKIYHKCDNACIGSIRNGTYDHDVYRDEALNNRFQ
                      IKGVELKSGYKDWILWISFAISCFLLCVVLLGFIMWACQKGNIRCNICI"
-     sig_peptide     15..62
-                     /gene="HA"
-     mat_peptide     63..1049
+                     /protein_id="AAA87553.1"
+     CDS             1..48
+                     /product="Signal peptide"
+                     /gene="SigPep"
+     CDS             49..1035
+                     /product="HA1 protein"
                      /gene="HA1"
-     mat_peptide     1050..1712
+     CDS             1036..1698
+                     /product="HA2 protein"
                      /gene="HA2"
+
 ORIGIN
-        1 taattctatt aaccatgaag actatcattg ctttgagcta cattttatgt ctggttttcg
-       61 ctcaaaaact tcccggaaat gacaacagca cagcaacgct gtgcctggga catcatgcag
-      121 tgccaaacgg aacgctagtg aaaacaatca cgaatgatca aattgaagtg actaatgcta
-      181 ctgagctggt tcagagttcc tcaacaggta gaatatgcga cagtcctcac cgaatccttg
-      241 atggaaaaaa ctgcacactg atagatgctc tattgggaga ccctcattgt gatggcttcc
-      301 aaaataagga atgggacctt tttgttgaac gcagcaaagc ttacagcaac tgttaccctt
-      361 atgatgtacc ggattatgcc tcccttaggt cactagttgc ctcatcaggc accctggagt
-      421 ttatcaatga agacttcaat tggactggag tcgctcagga tgggggaagc tatgcttgca
-      481 aaaggggatc tgttaacagt ttctttagta gattgaattg gttgcacaaa tcagaataca
-      541 aatatccagc gctgaacgtg actatgccaa acaatggcaa atttgacaaa ttgtacattt
-      601 ggggggttca ccacccgagc acggacagag accaaaccag cctatatgtt cgagcatcag
-      661 ggagagtcac agtctctacc aaaagaagcc aacaaactgt aaccccgaat atcgggtcta
-      721 gaccctgggt aaggggtcag tccagtagaa taagcatcta ttggacaata gtaaaaccgg
-      781 gagacatact tttgattaat agcacaggga atctaattgc tcctcggggt tacttcaaaa
-      841 tacgaaatgg gaaaagctca ataatgaggt cagatgcacc cattggcacc tgcagttctg
-      901 aatgcatcac tccaaatgga agcattccca atgacaaacc ttttcaaaat gtaaacagga
-      961 tcacatatgg ggcctgcccc agatatgtta agcaaaacac tctgaaattg gcaacaggga
-     1021 tgcggaatgt accagagaaa caaactagag gcatattcgg cgcaatcgca ggtttcatag
-     1081 aaaatggttg ggagggaatg gtagacggtt ggtacggttt caggcatcaa aattctgagg
-     1141 gcacaggaca agcagcagat cttaaaagca ctcaagcagc aatcgaccaa atcaacggga
-     1201 aactgaatag gttaatcgag aaaacgaacg agaaattcca tcaaatcgaa aaagaattct
-     1261 cagaagtaga agggagaatt caggacctcg agaaatatgt tgaagacact aaaatagatc
-     1321 tctggtctta caacgcggag cttcttgttg ccctggagaa ccaacataca attgatctaa
-     1381 ctgactcaga aatgaacaaa ctgtttgaaa aaacaaggaa gcaactgagg gaaaatgctg
-     1441 aggacatggg caatggttgc ttcaaaatat accacaaatg tgacaatgcc tgcatagggt
-     1501 caatcagaaa tggaacttat gaccatgatg tatacagaga cgaagcatta aacaaccggt
-     1561 tccagatcaa aggtgttgag ctgaagtcag gatacaaaga ttggatccta tggatttcct
-     1621 ttgccatatc atgctttttg ctttgtgttg ttttgctggg gttcatcatg tgggcctgcc
-     1681 aaaaaggcaa cattaggtgc aacatttgca tttgagtgca ttaattaaaa ac
+        1 atgaagacta tcattgcttt gagctacatt ttatgtctgg ttttcgctca aaaacttccc
+       61 ggaaatgaca acagcacagc aacgctgtgc ctgggacatc atgcagtgcc aaacggaacg
+      121 ctagtgaaaa caatcacgaa tgatcaaatt gaagtgacta atgctactga gctggttcag
+      181 agttcctcaa caggtagaat atgcgacagt cctcaccgaa tccttgatgg aaaaaactgc
+      241 acactgatag atgctctatt gggagaccct cattgtgatg gcttccaaaa taaggaatgg
+      301 gacctttttg ttgaacgcag caaagcttac agcaactgtt acccttatga tgtaccggat
+      361 tatgcctccc ttaggtcact agttgcctca tcaggcaccc tggagtttat caatgaagac
+      421 ttcaattgga ctggagtcgc tcaggatggg ggaagctatg cttgcaaaag gggatctgtt
+      481 aacagtttct ttagtagatt gaattggttg cacaaatcag aatacaaata tccagcgctg
+      541 aacgtgacta tgccaaacaa tggcaaattt gacaaattgt acatttgggg ggttcaccac
+      601 ccgagcacgg acagagacca aaccagccta tatgttcgag catcagggag agtcacagtc
+      661 tctaccaaaa gaagccaaca aactgtaacc ccgaatatcg ggtctagacc ctgggtaagg
+      721 ggtcagtcca gtagaataag catctattgg acaatagtaa aaccgggaga catacttttg
+      781 attaatagca cagggaatct aattgctcct cggggttact tcaaaatacg aaatgggaaa
+      841 agctcaataa tgaggtcaga tgcacccatt ggcacctgca gttctgaatg catcactcca
+      901 aatggaagca ttcccaatga caaacctttt caaaatgtaa acaggatcac atatggggcc
+      961 tgccccagat atgttaagca aaacactctg aaattggcaa cagggatgcg gaatgtacca
+     1021 gagaaacaaa ctagaggcat attcggcgca atcgcaggtt tcatagaaaa tggttgggag
+     1081 ggaatggtag acggttggta cggtttcagg catcaaaatt ctgagggcac aggacaagca
+     1141 gcagatctta aaagcactca agcagcaatc gaccaaatca acgggaaact gaataggtta
+     1201 atcgagaaaa cgaacgagaa attccatcaa atcgaaaaag aattctcaga agtagaaggg
+     1261 agaattcagg acctcgagaa atatgttgaa gacactaaaa tagatctctg gtcttacaac
+     1321 gcggagcttc ttgttgccct ggagaaccaa catacaattg atcttactga ctcagaaatg
+     1381 aacaaactgt ttgaaaaaac aaggaagcaa ctgagggaaa atgctgagga catgggcaat
+     1441 ggttgcttca aaatatacca caaatgtgac aatgcctgca tagggtcaat cagaaatgga
+     1501 acttatgacc atgatgtata cagagacgaa gcattaaaca accggttcca gatcaaaggt
+     1561 gttgagctga agtcaggata caaagattgg atcctgtgga tttcctttgc catatcatgc
+     1621 tttttgcttt gtgttgtttt gctggggttc atcatgtggg cctgccaaaa aggcaacatt
+     1681 aggtgtaaca tttgcatttg a
 //

--- a/builds/flu/metadata/h3n2_na_outgroup.gb
+++ b/builds/flu/metadata/h3n2_na_outgroup.gb
@@ -44,7 +44,7 @@ FEATURES             Location/Qualifiers
                      /db_xref="IRD:NIGSP_CEIRS_CIP047_RFH3_00116.NA"
      gene            4..1413
                      /gene="NA"
-     CDS             4..1413
+     CDS             4..1410
                      /codon_start=1
                      /gene="NA"
                      /product="neuraminidase"


### PR DESCRIPTION
This PR standardizes H3N2 reference sequences with the following changes:

  - Replace an older, unused HA reference sequence for H3N2 (`metadata/h3n2_ha_outgroup.gb`) with the HA reference sequence actually used by live flu builds (`metadata/h3n2_outgroup.gb`). This consistent naming scheme enables wildcard rules in Snakemake for a modular augur flu build.

  - Correct overlapping and overhanging CDS coordinates for HA regions from the original reference. Specifically resolves overlap between SigPep and HA1 coordinates and unnecessary inclusion of an extra nucleotide in the CDS coordinates for HA2. These fixes eliminate annoying BioPython warnings.

  - Consistently omit stop codons from translations. The original manually curated CDS coordinates for HA2 appear to have intentionally omitted the protein's stop codon from translation by omitting the last two nucleotides of the CDS. The CDS coordinates for NA had not been similarly curated previously, so translations of NA produced a stop codon residue "*". Since the standard in augur seems to be to omit stop codons, I've updated NA's CDS coordinates accordingly.

This PR does not update the original H3N2 HA reference file (`metadata/h3n2_outgroup.gb`) because the issues described above primarily affect modular augur flu builds and not the existing live flu builds.
