### PR TITLE
Rates and traits confidence v2

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -10,7 +10,7 @@ from treetime.vcf_utils import read_vcf, write_vcf
 def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='auto',
              confidence=False, resolve_polytomies=True, max_iter=2,
              infer_gtr=True, Tc=0.01, reroot=None, use_marginal=False, fixed_pi=None,
-             clock_rate=None, clock_filter_iqd=None, verbosity=1, **kwarks):
+             clock_rate=None, clock_std=None, clock_filter_iqd=None, verbosity=1, **kwarks):
     from treetime import TreeTime
 
     try: #Tc could be a number or  'opt' or 'skyline'. TreeTime expects a float or int if a number.
@@ -55,10 +55,16 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='a
     else:
         marginal = confidence
 
+    vary_rate = False
+    if clock_rate and clock_std:
+        vary_rate = clock_std
+    else:
+        vary_rate = True
+
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
            branch_length_mode=branch_length_inference, resolve_polytomies=resolve_polytomies,
            max_iter=max_iter, fixed_pi=fixed_pi, fixed_clock_rate=clock_rate,
-           **kwarks)
+           vary_rate=vary_rate, **kwarks)
 
     if confidence:
         for n in tt.tree.find_clades():
@@ -87,6 +93,7 @@ def register_arguments(parser):
     parser.add_argument('--timetree', action="store_true", help="produce timetree using treetime")
     parser.add_argument('--coalescent', help="coalescent time scale in units of inverse clock rate (float), optimize as scalar ('opt'), or skyline ('skyline')")
     parser.add_argument('--clock-rate', type=float, help="fixed clock rate")
+    parser.add_argument('--clock-std-dev', type=float, help="standard deviation of the fixed clock_rate estimate")
     parser.add_argument('--root', nargs="+", help="rooting mechanism ('best', 'residual', 'rsq', 'min_dev') "
                                 "OR node to root by OR two nodes indicating a monophyletic group to root by")
     parser.add_argument('--date-format', default="%Y-%m-%d", help="date format")
@@ -172,11 +179,12 @@ def run(args):
             args.root = args.root[0]
 
         tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
-                      reroot=args.root or 'best',
-                      Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
-                      use_marginal = args.date_inference == 'marginal',
-                      branch_length_inference = args.branch_length_inference or 'auto',
-                      clock_rate=args.clock_rate, clock_filter_iqd=args.clock_filter_iqd)
+                    reroot=args.root or 'best',
+                    Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
+                    use_marginal = args.date_inference == 'marginal',
+                    branch_length_inference = args.branch_length_inference or 'auto',
+                    clock_rate=args.clock_rate, clock_std=args.clock_std_dev,
+                    clock_filter_iqd=args.clock_filter_iqd)
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,
                               'intercept': tt.date2dist.intercept,

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
             "jsonschema ==3.0.0a1",
             "matplotlib >=2.0, ==2.*",
             "pandas >=0.17.1",
-            "phylo-treetime >=0.4.1, ==0.4.*",
+            "phylo-treetime >=0.5.1, ==0.5.*",
             "seaborn >=0.6.0, ==0.6.*",
             "snakemake >=5.1.5, ==5.*"
         ],

--- a/tests/builds/tb/Snakefile
+++ b/tests/builds/tb/Snakefile
@@ -79,12 +79,15 @@ rule refine:
         tree = "results/tree.nwk",
         node_data = "results/branch_lengths.json",
     params:
-        root = 'residual'
+        root = 'min_dev',
+        clock_rate = 1e-7,
+        clock_std = 3e-8
     shell:
         """
         augur refine --tree {input.tree} --alignment {input.aln} --metadata {input.metadata} \
             --output-tree {output.tree} --output-node-data {output.node_data} --vcf-reference {input.ref} \
-            --timetree --root {params.root} --coalescent 0.0001
+            --timetree --root {params.root} --coalescent 0.0001 \
+            --clock-rate {params.clock_rate} --clock-std-dev {params.clock_std}
         """
 
 rule ancestral:

--- a/tests/builds/tb_drm/Snakefile
+++ b/tests/builds/tb_drm/Snakefile
@@ -70,12 +70,15 @@ rule refine:
         tree = "results/tree.nwk",
         node_data = "results/branch_lengths.json",
     params:
-        root = 'residual'
+        root = 'min_dev',
+        clock_rate = 1e-7,
+        clock_std = 3e-8
     shell:
         """
         augur refine --tree {input.tree} --alignment {input.aln} --metadata {input.metadata} \
             --output-tree {output.tree} --output-node-data {output.node_data} --vcf-reference {input.ref} \
-            --timetree --root {params.root} --coalescent 0.0001
+            --timetree --root {params.root} --coalescent 0.0001 \
+            --clock-rate {params.clock_rate} --clock-std-dev {params.clock_std}
         """
 
 rule ancestral:
@@ -147,7 +150,7 @@ rule seqtraits:
             --features {input.drms} --output {output.drm_data} \
             --count {params.count} --label {params.label}
         """
-        
+
 rule export:
     message: "Exporting data files for for auspice using nextflu compatible schema"
     input:

--- a/tests/builds/zika/Snakefile
+++ b/tests/builds/zika/Snakefile
@@ -159,7 +159,8 @@ rule traits:
     output:
         node_data = "results/traits.json",
     params:
-        columns = "region country"
+        columns = "region country",
+        sampling_bias_correction = 3
     shell:
         """
         augur traits \
@@ -167,6 +168,7 @@ rule traits:
             --metadata {input.metadata} \
             --output {output.node_data} \
             --columns {params.columns} \
+            --sampling-bias-correction {params.sampling_bias_correction} \
             --confidence
         """
 


### PR DESCRIPTION
This is a more-or-less direct rebase of PR #213. It does three things:

1. Implements a `--sampling-bias-correction` flag in `augur traits` to add uncertainty to ancestral trait reconstruction.
2. Implements a `--clock-std-dev` flag in `augur refine` to allow inputting of standard deviation of "fixed" clock rate.
3. Adds both these options to the test builds.
4. Upgrades TreeTime to version 0.5.1.

----------------------

@rneher: My testing is showing no effect from the `--sampling-bias-correction` flag. I tested and it does modify `tt.gtr.mu` correctly. However, this seems to have no impact on resulting reconstructions. Can you take a look at this?