### PR TITLE
Python 2/3 compatibility fixes

### DIFF
--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -225,7 +225,7 @@ class TiterCollection(object):
                 self.measurements_per_serum[ref]+=1
             else:
                 pass
-                #print "no homologous titer found:", ref
+                #print("no homologous titer found:", ref)
 
     def strain_census(self, titers):
         """
@@ -729,8 +729,8 @@ class TreeModel(TiterModel):
                 node.titer_branch_index=None
 
         self.genetic_params = self.titer_split_count
-        print ("# of reference strains:",len(self.sera))
-        print ("# of eligible branches with titer constraints", self.titer_split_count)
+        print("# of reference strains:",len(self.sera))
+        print("# of eligible branches with titer constraints", self.titer_split_count)
 
 
     def make_treegraph(self):
@@ -774,7 +774,7 @@ class TreeModel(TiterModel):
         self.titer_dist =  np.array(titer_dist)*self.weights
         self.design_matrix = (np.array(tree_graph).T*self.weights).T
         self.TgT = np.dot(self.design_matrix.T, self.design_matrix)
-        print ("Found", self.design_matrix.shape, "measurements x parameters")
+        print("Found", self.design_matrix.shape, "measurements x parameters")
 
     def train(self,**kwargs):
         self._train(**kwargs)
@@ -919,7 +919,7 @@ class SubstitutionModel(TiterModel):
         if colin_thres is not None and self.genetic_params > 0:
             self.collapse_colinear_mutations(colin_thres)
         self.TgT = np.dot(self.design_matrix.T, self.design_matrix)
-        print ("Found", self.design_matrix.shape, "measurements x parameters")
+        print("Found", self.design_matrix.shape, "measurements x parameters")
 
 
     def collapse_colinear_mutations(self, colin_thres):

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -353,7 +353,7 @@ def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):
             #Now convert these calls to #/# (VCF format)
             calls = [ j+"/"+j if j!='.' else '.' for j in pattern ]
             if len(uniques)==0:
-                print ("UNEXPECTED ERROR WHILE CONVERTING TO VCF AT POSITION {}".format(str(pi)))
+                print("UNEXPECTED ERROR WHILE CONVERTING TO VCF AT POSITION {}".format(str(pi)))
                 break
 
             #put it all together and write it out

--- a/base/fetch_outgroups.py
+++ b/base/fetch_outgroups.py
@@ -47,7 +47,7 @@ outgroups = {#'H3N2':'U26830',
              }
 
 if __name__ == "__main__":
-    for virus, genbank_id in outgroups.iteritems():
+    for virus, genbank_id in outgroups.items():
         handle = Entrez.efetch(db="nucleotide", id=genbank_id, rettype="gb")
         seq= SeqIO.read(StringIO(handle.read()), format = 'genbank')
         SeqIO.write(seq, 'flu/metadata/'+virus+'_outgroup.gb', format='genbank')

--- a/base/fitness_model.py
+++ b/base/fitness_model.py
@@ -6,6 +6,7 @@ import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.stats import linregress, pearsonr
 import sys
+from builtins import range
 
 from .io_util import write_json
 from .scores import select_nodes_in_season
@@ -585,7 +586,7 @@ class fitness_model(object):
         minimize_error()
         params_stack.append((self.last_fit, self.model_params))
 
-        for ii in xrange(niter):
+        for ii in range(niter):
             if self.verbose:
                 print("iteration:", ii+1)
             self.model_params = np.random.rand(len(self.predictors)) #0*np.ones(len(self.predictors))  # initial values

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -259,18 +259,16 @@ class nested_frequencies(object):
         self.kwargs = kwargs
 
     def calc_freqs(self):
-        sorted_obs = sorted(list(self.obs.items()), key=lambda x:x[1].sum(), reverse=True)
+        sorted_obs = sorted(self.obs.items(), key=lambda x: np.array(list(x[1])).sum(), reverse=True)
         self.remaining_freq = np.ones_like(self.pivots)
 
         self.frequencies = {}
         valid_tps = np.ones_like(self.tps, dtype=bool)
         for mut, obs in sorted_obs[:-1]:
-            # print(mut,'...')
             fe = freq_est_clipped(self.tps[valid_tps], obs[valid_tps], self.pivots, **self.kwargs)
             if fe.valid==False:
                 self.frequencies[mut] = np.zeros_like(self.remaining_freq)
                 break
-
             fe.learn()
             self.frequencies[mut] = self.remaining_freq * fe.pivot_freq
             self.remaining_freq *= (1.0-fe.pivot_freq)
@@ -363,7 +361,7 @@ class tree_frequencies(object):
                     if len(small_clades)==1:
                         obs_to_estimate.update(remainder)
                     else:
-                        obs_to_estimate['other'] = np.any(remainder.values(), axis=0)
+                        obs_to_estimate['other'] = np.any(np.array(list(remainder.values())), axis=0)
 
                 ne = nested_frequencies(node_tps, obs_to_estimate, self.pivots, pc=self.pc, **self.kwargs)
                 freq_est = ne.calc_freqs()

--- a/base/frequencies.py
+++ b/base/frequencies.py
@@ -173,7 +173,7 @@ class frequency_estimator(object):
         # instantiate an interpolation object based on the optimal frequency pivots
         self.frequency_estimate = interp1d(self.pivots, self.pivot_freq, kind=self.interpolation_type, bounds_error=False)
 
-        if self.verbose: print ("neg logLH using",len(self.pivots),"pivots:", self.logLH(self.pivot_freq))
+        if self.verbose: print("neg logLH using",len(self.pivots),"pivots:", self.logLH(self.pivot_freq))
 
 
 class freq_est_clipped(object):
@@ -259,7 +259,7 @@ class nested_frequencies(object):
         self.kwargs = kwargs
 
     def calc_freqs(self):
-        sorted_obs = sorted(self.obs.items(), key=lambda x:x[1].sum(), reverse=True)
+        sorted_obs = sorted(list(self.obs.items()), key=lambda x:x[1].sum(), reverse=True)
         self.remaining_freq = np.ones_like(self.pivots)
 
         self.frequencies = {}
@@ -367,7 +367,7 @@ class tree_frequencies(object):
 
                 ne = nested_frequencies(node_tps, obs_to_estimate, self.pivots, pc=self.pc, **self.kwargs)
                 freq_est = ne.calc_freqs()
-                for clade, tmp_freq in freq_est.iteritems():
+                for clade, tmp_freq in freq_est.items():
                     if clade != "other":
                         self.frequencies[clade] = self.frequencies[node.clade] * tmp_freq
 
@@ -404,7 +404,7 @@ class tree_frequencies(object):
         useful approximation in most cases
         '''
         self.confidence = {}
-        for key, freq in self.frequencies.iteritems():
+        for key, freq in self.frequencies.items():
             # add a pseudo count 1/(n+1) and normalize to n+1
             self.confidence[key] = np.sqrt((1.0/(1+self.counts)+freq*(1-freq))/(1.0+self.counts))
         return self.confidence
@@ -489,8 +489,7 @@ class alignment_frequencies(object):
             if len(obs)==0:
                 obs[(pos, muts[0])] = column==muts[0]
             elif len(obs)!=len(nis):
-                tmp = ~np.any(obs.values(), axis=0) # pull out sequences not yet assigned
-
+                tmp = ~np.any(list(obs.values()), axis=0) # pull out sequences not yet assigned
                 if any(tmp):
                     if len(obs)==len(nis)-1: # if only category left, assign it
                         obs[(pos, muts[-1])] = tmp
@@ -499,7 +498,7 @@ class alignment_frequencies(object):
 
             print("Estimating frequencies of position: {}".format(pos), end="\r")
             sys.stdout.flush()
-            # print("Variants found at frequency:", [(k,o.mean()) for k,o in obs.iteritems()])
+            # print("Variants found at frequency:", [(k,o.mean()) for k,o in obs.items()])
 
             # calculate frequencies, which will be added to the frequencies dict with (pos, mut) as key
             ne = nested_frequencies(tps, obs, self.pivots, **self.kwargs)
@@ -508,7 +507,7 @@ class alignment_frequencies(object):
 
     def calc_confidence(self):
         self.confidence = {}
-        for key, freq in self.frequencies.iteritems():
+        for key, freq in self.frequencies.items():
             # add a pseudo count 1/(n+1) and normalize to n+1
             self.confidence[key] = np.sqrt((1.0/(1+self.counts)+freq*(1-freq))/(1.0+self.counts))
 
@@ -564,7 +563,7 @@ def test_nested_estimator():
 
     if plot:
         plt.figure()
-        for k,o in obs.iteritems():
+        for k,o in obs.items():
             plt.plot(tps, o, 'o')
             plt.plot(fe.pivots,fe.frequencies[k], 'o')
 

--- a/base/prediction.py
+++ b/base/prediction.py
@@ -3,8 +3,12 @@ import numpy as np
 import time
 from collections import defaultdict
 from .io_util import myopen
-from itertools import izip
 import pandas as pd
+
+try:
+    import itertools.izip as zip
+except ImportError:
+    pass
 
 def LBI(tree, tau=0.001, attr='lbi'):
     '''
@@ -111,4 +115,3 @@ class tree_predictor(object):
             LBI(self.tree, tau=tau, attr='lbi')
             for node in self.tree.find_clades():
                 node.LBI[tint] = node.lbi/tau
-

--- a/base/process.py
+++ b/base/process.py
@@ -615,7 +615,7 @@ class process(object):
         ## NOTE clades_to_nodes is used in the (full) frequencies export
         self.clades_to_nodes = {}
         for clade_name, genotype in clades.items():
-            matching_nodes = filter(lambda x:match(x,genotype), self.tree.tree.get_nonterminals())
+            matching_nodes = list(filter(lambda x:match(x,genotype), self.tree.tree.get_nonterminals()))
             matching_nodes.sort(key=lambda x:x.numdate if hasattr(x,'numdate') else x.dist2root)
             if len(matching_nodes):
                 self.clades_to_nodes[clade_name] = matching_nodes[0]
@@ -623,7 +623,7 @@ class process(object):
             else:
                 print('matchClades: no match found for ', clade_name, genotype)
                 for allele in genotype:
-                    partial_matches = filter(lambda x:match(x,[allele]), self.tree.tree.get_nonterminals())
+                    partial_matches = list(filter(lambda x:match(x,[allele]), self.tree.tree.get_nonterminals()))
                     print('Found %d partial matches for allele '%len(partial_matches), allele)
 
         ## Now preorder traverse the tree with state replacement to set the clade_membership via clade_annotation

--- a/base/scores.py
+++ b/base/scores.py
@@ -28,7 +28,7 @@ def calculate_metadata_scores(tree):
 
     for node in tree.get_terminals():
         node.tip_count=1.0
-        if ('age' in node.attr) and type(node.attr['age']) in [str, unicode]:
+        if ('age' in node.attr) and type(node.attr['age']) in [str]:
             tmp_age = node.attr['age']
             if tmp_age[-1] in ['y', 'm']:
                 node.attr['age'] = int(tmp_age[:-1])
@@ -86,7 +86,7 @@ def calculate_metadata_scores(tree):
     # gender seems not to be a relevant quantity as of now...
     for node in tree.get_terminals():
         node.tip_count=1.0
-        if ('gender' in node.attr) and type(node.attr['gender']) in [str, unicode]:
+        if ('gender' in node.attr) and type(node.attr['gender']) in [str]:
             g = node.attr["gender"]
             node.attr["num_gender"] = -1 if g=='male' else (1 if g=='female' else 0)
         else:

--- a/base/titer_model.py
+++ b/base/titer_model.py
@@ -110,7 +110,7 @@ class TiterCollection(object):
         2
         """
         counts = defaultdict(int)
-        for key in titers.iterkeys():
+        for key in titers.keys():
             measurements = len(titers[key])
             counts[key[0]] += measurements
 

--- a/builds/avian/changeColorsInJson.py
+++ b/builds/avian/changeColorsInJson.py
@@ -2,6 +2,7 @@ import json
 from pprint import pprint
 import pdb
 import os
+from builtins import range
 
 metaFiles = ['build/flu_H7N9_HA_meta.json', 'build/flu_H7N9_NA_meta.json'];
 for metaFile in metaFiles:
@@ -13,8 +14,8 @@ for metaFile in metaFiles:
     # print what we've got so far...
     for key in data["color_options"]:
         if "color_map" in data["color_options"][key]:
-            print key
-            print "\t" + "\n\t".join([x[0] for x in data["color_options"][key]["color_map"]])
+            print(key)
+            print("\t" + "\n\t".join([x[0] for x in data["color_options"][key]["color_map"]]))
 
     cmap = {
         "country": {
@@ -60,8 +61,8 @@ for metaFile in metaFiles:
 
     for key in data["color_options"]:
         if "color_map" in data["color_options"][key] and key in cmap:
-            print "changing color for " + key
-            for idx in xrange(0, len(data["color_options"][key]["color_map"])):
+            print("changing color for " + key)
+            for idx in range(0, len(data["color_options"][key]["color_map"])):
                 if (data["color_options"][key]["color_map"][idx][0] in cmap[key]):
                     data["color_options"][key]["color_map"][idx][1] = cmap[key][data["color_options"][key]["color_map"][idx][0]]
 

--- a/builds/dengue/dengue.process.py
+++ b/builds/dengue/dengue.process.py
@@ -157,7 +157,7 @@ genotypes = {
  }
 
 for i in ['denv1', 'denv2', 'denv3', 'denv4']:
-    for k,v in genotypes[i].iteritems():
+    for k,v in genotypes[i].items():
         genotypes['all'][i.upper()+'_'+k] = v
 
 # Label named clades based on mutations/genotypes at defining sites

--- a/builds/dengue/dengue.process.wrapper.py
+++ b/builds/dengue/dengue.process.wrapper.py
@@ -19,6 +19,6 @@ while True:
 
 		while len(running) < 2:
 			proc = subprocess.Popen(cmds[job_id].split())
-			print 'STARTING JOB ID %d'%job_id
+			print('STARTING JOB ID %d'%job_id)
 			job_id += 1
 			running.append(proc)

--- a/builds/dengue/dengue_titers.py
+++ b/builds/dengue/dengue_titers.py
@@ -1,3 +1,5 @@
+from builtins import range
+
 def tree_additivity_symmetry(titer_model):
     '''
     The titer model makes two major assumptions:
@@ -68,7 +70,7 @@ def tree_additivity_symmetry(titer_model):
     n_quartets = 1000
     for clique in C:
         if len(clique)>8:
-            for i in xrange(n_quartets):
+            for i in range(n_quartets):
                 Q = sample(clique, 4)
                 dists = []
                 for (a,b) in [((0,1), (2,3)),((0,2), (1,3)), ((0,3), (1,2))]:

--- a/scripts/json_tree_to_nexus.py
+++ b/scripts/json_tree_to_nexus.py
@@ -22,7 +22,7 @@ def resolve_polytomies(tree):
 
     def assign_attrs(node, source):
         # Assign all non-children attributes.
-        for attr, value in source.__dict__.iteritems():
+        for attr, value in source.__dict__.items():
             if attr != "children":
                 setattr(node, attr, value)
         # node.xvalue = 0

--- a/scripts/traits_from_json.py
+++ b/scripts/traits_from_json.py
@@ -40,5 +40,5 @@ if __name__=="__main__":
     except KeyError:
         pass
 
-    for seq, val in data["sequences"].iteritems():
+    for seq, val in data["sequences"].items():
         print("{}\t{}".format(seq, get_trait(val["attributes"], params.trait, params.date_format)))

--- a/scripts/tree_to_JSON.py
+++ b/scripts/tree_to_JSON.py
@@ -296,7 +296,7 @@ if __name__=="__main__":
             if node.name in meta:
                 if not hasattr(node, "attr"): # confusing!
                     setattr(node, "attr", {})
-                for key, value in meta[node.name].iteritems():
+                for key, value in meta[node.name].items():
                     if value == "":
                         continue
                     node.attr[key] = value


### PR DESCRIPTION
More Python 2/3 compatibility fixes. Nothing too shocking here. This is mostly changing `.iteritems` to `.items`.