### PR TITLE
lat long demes are always lower case

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -223,32 +223,27 @@ def read_config(fname):
 
 def read_lat_longs(overrides=None, use_defaults=True):
     coordinates = {}
+    def add_line_to_coordinates(line):
+        if line.startswith('#'): 
+            return
+        fields = line.strip().split()
+        if len(fields) == 4:
+            geo_field, loc = fields[0].lower(), fields[1].lower()
+            lat, long = float(fields[2]), float(fields[3])
+            coordinates[(geo_field, loc)] = {
+                "latitude": lat,
+                "longitude": long
+            }
     if use_defaults:
         with resource_stream(__package__, "data/lat_longs.tsv") as stream:
             with TextIOWrapper(stream, "utf-8") as defaults:
                 for line in defaults:
-                    if line.startswith('#'): continue
-                    fields = line.strip().split()
-                    if len(fields) == 4:
-                        geo_field, loc = fields[0].lower(), fields[1].lower()
-                        lat, long = float(fields[2]), float(fields[3])
-                        coordinates[(geo_field, loc)] = {
-                            "latitude": lat,
-                            "longitude": long
-                        }
+                    add_line_to_coordinates(line)
     if overrides:
         if os.path.isfile(overrides):
             with open(overrides) as ifile:
                 for line in ifile:
-                    if line.startswith('#'): continue
-                    fields = line.strip().split()
-                    if len(fields) == 4:
-                        geo_field, loc = fields[0], fields[1]
-                        lat, long = float(fields[2]), float(fields[3])
-                        coordinates[(geo_field, loc)] = {
-                            "latitude": lat,
-                            "longitude": long
-                        }
+                    add_line_to_coordinates(line)
         else:
             print("WARNING: input lat/long file %s not found." % overrides)
     return coordinates


### PR DESCRIPTION
Prior to this PR the parsing of lat/long demes was inconsistent -- using the "default" lat/long file converted them to lowercase (https://github.com/nextstrain/augur/blame/master/augur/utils.py#L233), but a user provided file kept the case as it was given (https://github.com/nextstrain/augur/blame/master/augur/utils.py#L246). This PR changes this behavior so that all demes are in lower case.

Note that the matching of demes in the tree to those from this file is done in lower case -- https://github.com/nextstrain/augur/blob/master/augur/export.py#L179. 

This PR is required for WNV builds to work correctly. 