### PR TITLE
Emit JSON with sorted keys

### DIFF
--- a/augur/sequence_traits.py
+++ b/augur/sequence_traits.py
@@ -320,4 +320,4 @@ def run(args):
 
     #write out json
     with open(args.output, 'w') as results:
-        json.dump({"nodes":seq_features}, results, indent=1)
+        json.dump({"nodes":seq_features}, results, indent=1, sort_keys = True)

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -172,7 +172,7 @@ def run(args):
                 ofile.write(str(gtr))
 
     with open(args.output, 'w') as results:
-        json.dump({"nodes":mugration_states}, results, indent=1)
+        json.dump({"nodes":mugration_states}, results, indent=1, sort_keys = True)
 
     print("\nInferred ancestral states of discrete character using TreeTime:"
           "\n\tSagulenko et al. TreeTime: Maximum-likelihood phylodynamic analysis"

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -147,7 +147,7 @@ def write_json(data, file_name, indent=1):
     except IOError:
         raise
     else:
-        json.dump(data, handle, indent=indent)
+        json.dump(data, handle, indent=indent, sort_keys = True)
         handle.close()
         success=True
 


### PR DESCRIPTION
Sorting the JSON output makes it easier to diff and run other textual
comparisons against.