### PR TITLE
translate: Nucleotide ("nuc") annotation starts at 0, not 1

### DIFF
--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -80,11 +80,11 @@
                     "$comment": "I imagine this can get more complex at some point",
                     "properties": {
                         "start": {
-                            "description": "Gene start position (one-based)",
+                            "description": "Gene start position (zero-based, i.e. BED format)",
                             "type": "number"
                         },
                         "end": {
-                            "description": "Gene end position (one-based)",
+                            "description": "Gene end position (one-based, i.e. zero-based exclusive or BED format)",
                             "type": "number"
                         },
                         "strand": {

--- a/augur/data/schema_meta.json
+++ b/augur/data/schema_meta.json
@@ -64,11 +64,11 @@
                     "type": "object",
                     "properties": {
                         "start": {
-                            "description": "Gene start position (one-based)",
+                            "description": "Gene start position (zero-based, i.e. BED format)",
                             "type": "number"
                         },
                         "end": {
-                            "description": "Gene end position (one-based)",
+                            "description": "Gene end position (one-based, i.e. zero-based exclusive or BED format)",
                             "type": "number"
                         },
                         "strand": {

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -300,10 +300,12 @@ def run(args):
         print("{} genes had no mutations and so have been be excluded.".format(len(deleted)))
 
     ## glob the annotations for later auspice export
+    #
+    # Note that both our JSON schema and BioPython FeatureLocations use
+    # "Pythonic" coordinates: [zero-origin, half-open).
     annotations = {}
     for fname, feat in features.items():
-        increment = 0 if feat.type != 'source' else 1 #'nuc' goes to 0, unsure why - make 1
-        annotations[fname] = {'start':int(feat.location.start)+increment,
+        annotations[fname] = {'start':int(feat.location.start),
                               'end':int(feat.location.end),
                               'strand': feat.location.strand}
     if is_vcf: #need to add our own nuc


### PR DESCRIPTION
Reverts to the existing behaviour before "Export functional for Fasta and VCF" (c6000aa), which inexplicably introduced this off-by-one change.  The bug affected only the "nuc" annotation of non-bacterial (VCF) builds, causing them to start at 1 instead of 0.  The impact seems very minor, as auspice hardcodes 0 in many places.

The numbering for "nuc" now (again) matches that used by the gene annotations in the same data structure.
