### PR TITLE
Schema gene names can now contain hyphens and underscores

### DIFF
--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -97,7 +97,7 @@
                 }
             },
             "patternProperties": {
-                "^[a-zA-Z0-9_*]+$": {"$ref": "#/properties/genome_annotations/properties/nuc"}
+                "^[a-zA-Z0-9_]+$": {"$ref": "#/properties/genome_annotations/properties/nuc"}
             }
         },
         "filters": {

--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -97,7 +97,7 @@
                 }
             },
             "patternProperties": {
-                "^[a-zA-Z0-9_]+$": {"$ref": "#/properties/genome_annotations/properties/nuc"}
+                "^[a-zA-Z0-9_-]+$": {"$ref": "#/properties/genome_annotations/properties/nuc"}
             }
         },
         "filters": {
@@ -333,7 +333,7 @@
                         }
                     },
                     "patternProperties": {
-                        "^[a-zA-Z0-9_]+$": {
+                        "^[a-zA-Z0-9_-]+$": {
                             "description": "Amino acid mutations for this gene (or annotated region)",
                             "$comment": "properties must exist in the meta.JSON -> annotation object",
                             "type": "array",

--- a/augur/data/schema_meta.json
+++ b/augur/data/schema_meta.json
@@ -80,7 +80,7 @@
                 }
             },
             "patternProperties": {
-                "^[a-zA-Z0-9_]+$": {"$ref": "#/properties/annotations/properties/nuc"}
+                "^[a-zA-Z0-9_-]+$": {"$ref": "#/properties/annotations/properties/nuc"}
             }
         },
         "maintainer": {

--- a/augur/data/schema_meta.json
+++ b/augur/data/schema_meta.json
@@ -80,7 +80,7 @@
                 }
             },
             "patternProperties": {
-                "^[a-zA-Z0-9_*]+$": {"$ref": "#/properties/annotations/properties/nuc"}
+                "^[a-zA-Z0-9_]+$": {"$ref": "#/properties/annotations/properties/nuc"}
             }
         },
         "maintainer": {

--- a/augur/data/schema_tree.json
+++ b/augur/data/schema_tree.json
@@ -146,7 +146,7 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
-                "^[a-zA-Z0-9_]+$": {
+                "^[a-zA-Z0-9_-]+$": {
                     "description": "Mutations for this gene (or annotated region)",
                     "type": "array",
                     "items": {

--- a/augur/data/schema_tree.json
+++ b/augur/data/schema_tree.json
@@ -146,7 +146,7 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
-                "^[a-zA-Z0-9]+$": {
+                "^[a-zA-Z0-9_]+$": {
                     "description": "Mutations for this gene (or annotated region)",
                     "type": "array",
                     "items": {


### PR DESCRIPTION
See commit messages for more info. Related to recent work in auspice.