### PR TITLE
Check that nodes have a pre-assigned name

### DIFF
--- a/augur/titers.py
+++ b/augur/titers.py
@@ -20,6 +20,7 @@ def register_arguments(parser):
 def run(args):
     T = Phylo.read(args.tree, 'newick')
 
+    assert all([n.name is not None for n in T.find_clades()]), 'Oops: each tree node must have a pre-assigned name'
     TM_tree, TM_subs = None, None
     if args.titer_model == "tree":
         from .titer_model import TreeModel


### PR DESCRIPTION
The current titer module implementation relies on pre-assigned node names to index the output `cTiter` and `dTiter` values. If passing in an externally-generated tree, nodes are not necessarily pre-named.

I added an assertion for now as a stop-gap. I think we have a few options that warrant discussion. 

Currently we export only a JSON file mapping node names to `cTiter` and `dTiter` values.

We have two decision points:
1 - Always require pre-assigned node names in the input phylogeny vs assign any missing node names
2 - Only export the JSON mapping node names to titer values vs also export a copy of the tree, annotated with names, `cTiter` and `dTiter` values. 

Note that if we do opt to assign missing node names, we should also export a tree with at least the assigned names annotated.