### PR TITLE
Declare missing variable to enable --include-where with sequences

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -99,6 +99,7 @@ def run(args):
     else:
         seqs = {seq.id:seq for seq in SeqIO.parse(args.sequences, 'fasta')}
         seq_keep = list(seqs.keys())
+        all_seq = seq_keep.copy()
 
     meta_dict, meta_columns = read_metadata(args.metadata)
 


### PR DESCRIPTION
Adds an `all_seq` variable needed by the logic to include records by value. This
was previously working for VCF but threw an exception for sequences in FASTA
format.

This PR is related to issue #244 and may need to be revised to include additional code after discussion of that issue.