### PR TITLE
Run pytest in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 install:
   - pip3 install -e .[dev]
 script:
+  - (pytest -c pytest.python3.ini)
   - (cd tests/builds/zika/; snakemake)
   - (cd tests/builds/tb/; snakemake)
 after_success:


### PR DESCRIPTION
This PR adds a line to Travis config to run pytest with the Python 3 configuration which runs all unit tests and doctests in modular augur. Since the Travis build for this commit passed, this seems to be working.
