### PR TITLE
Fix syntax error for Python versions <3.6

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -349,7 +349,7 @@ def mask_sites_in_multiple_sequence_alignment(alignment_file, excluded_sites_fil
 
     # Write out the new alignment FASTA to disk.
     alignment_file_path = Path(alignment_file)
-    masked_alignment_file = str(alignment_file_path.parent / f"masked_{alignment_file_path.name}")
+    masked_alignment_file = str(alignment_file_path.parent / ("masked_%s" % alignment_file_path.name))
     with open(masked_alignment_file, "w") as oh:
         Bio.AlignIO.write(final_alignment, oh, "fasta")
 


### PR DESCRIPTION
The original code used the formatted string literals syntax that was introduced
in Python 3.6 [1] resulting in a syntax error for any users with Python versions
<3.6.

Closes #257.

[1] https://docs.python.org/3/reference/lexical_analysis.html#f-strings