### PR TITLE
Emit one-based coordinates for KDE-based mutation frequencies

### DIFF
--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -1197,7 +1197,7 @@ class AlignmentKdeFrequencies(KdeFrequencies):
                 for sample, base in enumerate(alignment[:, position]):
                     # Estimate frequencies by current position and base/residue
                     # at the position for each sample.
-                    key = "%s:%s" % (position, base.upper())
+                    key = "%s:%s" % (position + 1, base.upper())
                     if key not in frequencies:
                         frequencies[key] = np.zeros_like(self.pivots)
 


### PR DESCRIPTION
Previously KDE mutation frequencies were being emitted with with zero-based
positions while the diffusion-based frequencies used the standard one-based
output.

Closes #269.