### PR TITLE
Modifications to v2 schema

### DIFF
--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -209,7 +209,7 @@
                 },
                 "color_by": {
                     "description": "Default color by",
-                    "$comment": "The value here must be present in the color_options object (see above)",
+                    "$comment": "The value here must be present in the colorings object (see above)",
                     "type": "string"
                 },
                 "distance_measure": {
@@ -222,6 +222,13 @@
                     "type": "boolean"
                 }
             }
+        },
+        "tree_name" : {
+          "description": "The name of the tree (e.g. segment name), if applicable",
+          "$comment": "This is required if you want to view two trees side-by-side",
+          "$comment": "It should match a field in the JSON filename after splitting on '_'",
+          "$comment": "e.g. `flu_h3n2_ha_3y` has a tree name of `ha`",
+          "type": "string"
         },
         "tree": {
             "type" : "object",

--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -404,6 +404,13 @@
                                 }
                             }
                         }
+                    },
+                    "not": {
+                        "required": [
+                            "authors",
+                            "num_date",
+                            "div"
+                        ]
                     }
                 },
                 "children": {

--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -55,6 +55,10 @@
                             "description": "Publication title",
                             "type": "string"
                         },
+                        "year": {
+                            "description": "Publication year",
+                            "type": "number"
+                        },
                         "journal": {
                             "description": "Journal title",
                             "type": "string"

--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -174,38 +174,19 @@
                             "type": "string",
                             "enum": ["continuous", "ordinal", "categorical", "boolean"]
                         },
-                        "domain": {
-                            "description": "Color scale domain",
-                            "$comment": "if type is continuous, this defines the domain of the color scale. If numItems > 2, then this also defines the legend entries",
-                            "$comment": "if type is ordinal / categorical, this defines the ordering (to be displayed in the legend, and to which a color scale will be applied)",
-                            "$comment": "not available for boolean types",
-                            "type": "array",
-                            "minItems": 2
-                        },
                         "scale": {
-                            "description": "Used to calculate the colour scale",
-                            "oneOf": [
-                                {
-                                    "description": "Provided mapping between trait values & hex values",
-                                    "$comment": "If type is continuous or ordinal, values between those provided here are interpolated",
-                                    "$comment": "If type is categorical, values not present here are grey",
-                                    "$comment": "If type is boolean, use \"1\" (true) and \"0\" (false) as properties",
-                                    "type": "object",
-                                    "patternProperties": {
-                                        "^.+$": {
-                                            "description": "color hex value",
-                                            "type": "string",
-                                            "pattern": "^#[0-9A-Fa-f]{6}$"
-                                        }
-                                    }
-                                },
-                                {
-                                    "description": "Name of a color scale to use",
-                                    "$comment": "Not yet implemented in Auspice",
-                                    "type": "string"
+                            "description": "Provided mapping between trait values & hex values",
+                            "$comment": "If type is continuous or ordinal, values between those provided here are interpolated",
+                            "$comment": "If type is categorical, values not present here are grey",
+                            "$comment": "If type is boolean, use \"1\" (true) and \"0\" (false) as properties",
+                            "type": "object",
+                            "patternProperties": {
+                                "^.+$": {
+                                    "description": "color hex value",
+                                    "type": "string",
+                                    "pattern": "^#[0-9A-Fa-f]{6}$"
                                 }
-                            ]
-
+                            }
                         }
                     }
                 }

--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -364,7 +364,7 @@
                     "$comment": "Obviously only for terminal nodes",
                     "$comment": "If not known/available, don't include this as a property of the node",
                     "type": "string",
-                    "pattern": "^[0-9A-Za-z-]+$"
+                    "pattern": "^[0-9A-Za-z-_]+$"
                 },
                 "traits": {
                     "description": "Inferred Attributes / traits decorations on the nodes",

--- a/augur/export.py
+++ b/augur/export.py
@@ -526,7 +526,7 @@ def run(args):
     unified = {}
 
     unified['title'] = args.title
-    unified['maintainers'] = [{'name': name, 'href':url} for name, url in zip(args.maintainers, args.maintainer_urls)]
+    unified['maintainers'] = [{'name': name, 'url':url} for name, url in zip(args.maintainers, args.maintainer_urls)]
     unified["version"] = "2.0"
 
     # get traits to colour by etc - do here before node_data is modified below

--- a/augur/export.py
+++ b/augur/export.py
@@ -2,7 +2,7 @@
 Export JSON files suitable for visualization with auspice.
 """
 
-import os
+import os, sys
 import re
 import time
 import numpy as np
@@ -524,6 +524,12 @@ def run(args):
 
     ## SCHEMA v2.0 ##
     unified = {}
+
+    if args.auspice_config:
+        print("ERROR: Version 2 JSONs do not use the auspice config JSON")
+        print("you must supply all configuration as command line arguments")
+        sys.exit(2)
+
 
     unified['title'] = args.title
     unified['maintainers'] = [{'name': name, 'url':url} for name, url in zip(args.maintainers, args.maintainer_urls)]

--- a/augur/export.py
+++ b/augur/export.py
@@ -452,6 +452,7 @@ def register_arguments(parser):
     parser.add_argument('--geography-traits', nargs='+', help="What location traits are used to plot on map")
     parser.add_argument('--extra-traits', nargs='+', help="Metadata columns not run through 'traits' to be added to tree")
     parser.add_argument('--panels', default=['tree', 'map', 'entropy'], nargs='+', help="What panels to display in auspice. Options are : xxx")
+    parser.add_argument('--tree-name', default=False, help="Tree name (needed for tangle tree functionality)")
     parser.add_argument('--minify-json', action="store_true", help="export JSONs without indentation or line returns")
 
 
@@ -558,5 +559,11 @@ def run(args):
     unified["updated"] = time.strftime('%Y-%m-%d')
     unified["genome_annotations"] = process_annotations(node_data)
     unified["panels"] = process_panels(args.panels, unified)
+
+    if args.tree_name:
+        if not re.search("(^|_|/){}(_|.json)".format(args.tree_name), str(args.output_main)):
+            print("Error: tree name {} must be found as part of the output string".format(args.tree_name))
+            sys.exit(2)
+        unified["tree_name"] = args.tree_name
 
     write_json(unified, args.output_main, indent=json_indent)


### PR DESCRIPTION
This PR introduces a few (minor) changes to the v2 schema discovered during implementation in auspice, as well as a few tweaks to `augur export`

## Removed:
Domain and (string) scales from `colorings` - These features would be great to have in the future but are currently unsupported by auspice. They are easy to add in later (with a corresponding JSON version bump).

## Added
* Author info was missing `year`
* Added (optional) `tree_name` property which is needed for tangle trees to work correctly and a corresponding command line option

## Questions about how `augur export` is run
For v2 JSONs augur export now uses exclusively command arguments (instead of the `auspice_config.json`. This means one less config file (hooray!), but i'm unsure how we're going to specify everything -- e.g. how can we specify the type of the color traits (ordinal vs discrete), how do you specify the `title` of the colors etc. I also couldn't work out how to add `authors` as a coloring without adding them as a trait, which will then add `node.trait.authors` which isn't allowed. We haven't really used this functionality of `augur export` so to be expected that there are lots of little things!

## To consider
We may want to consider changing the `distance_measure` values:
* `div` -> `divergence`
* `num_date` -> `temporal`

We may also want to add a `footer` field to define the footer content here. You can put markdown into JSONs but you need a library (e.g. [this one](https://www.npmjs.com/package/markdown-json)), so this could be build into `augur export`. This has the advantage of storing it as HTML which we can render, and the disadvantages that come with rendering user-provided HTML.