### PR TITLE
Remove all JSON indentation by default if AUGUR_MINIFY_JSON is set

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -96,7 +96,7 @@ def run(args):
     else:
         anc_seqs_fname = '.'.join(args.alignment.split('.')[:-1]) + '.anc_seqs.json'
 
-    anc_seqs_success = write_json(anc_seqs, anc_seqs_fname)
+    write_json(anc_seqs, anc_seqs_fname)
     print("ancestral sequences written to",anc_seqs_fname, file=sys.stdout)
 
     # If VCF, output VCF including new ancestral seqs
@@ -108,7 +108,4 @@ def run(args):
         write_vcf(tt.get_tree_dict(keep_var_ambigs=True), vcf_fname)
         print("ancestral sequences as vcf-file written to",vcf_fname, file=sys.stdout)
 
-    if anc_seqs_success:
-        return 0
-    else:
-        return 1
+    return 0

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -142,7 +142,7 @@ import sys
 
 from .frequency_estimators import timestamp_to_float
 from .reconstruct_sequences import load_alignments
-from .utils import annotate_parents_for_tree, read_node_data
+from .utils import annotate_parents_for_tree, read_node_data, write_json
 
 
 def read_distance_map(map_file):
@@ -566,5 +566,4 @@ def run(args):
     }
 
     # Export distances to JSON.
-    with open(args.output, "w") as oh:
-        json.dump({"params": params, "nodes": final_distances_by_node}, oh, indent=1, sort_keys=True)
+    write_json({"params": params, "nodes": final_distances_by_node}, args.output)

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -165,7 +165,7 @@ def run(args):
                     "frequencies": format_frequencies(frequencies[node_name])
                 }
 
-        json_success = write_json(frequency_dict, args.output)
+        write_json(frequency_dict, args.output)
         print("tree frequencies written to", args.output, file=sys.stdout)
     elif args.alignments:
         if args.method == "kde":
@@ -192,5 +192,5 @@ def run(args):
             frequencies["%s:counts" % gene] = [int(observations_per_pivot)
                                                for observations_per_pivot in freqs.counts]
 
-        json_success = write_json(frequencies, args.output)
+        write_json(frequencies, args.output)
         print("mutation frequencies written to", args.output, file=sys.stdout)

--- a/augur/lbi.py
+++ b/augur/lbi.py
@@ -5,6 +5,7 @@ import Bio.Phylo
 from collections import defaultdict
 import json
 import numpy as np
+from .utils import write_json
 
 
 def select_nodes_in_season(tree, timepoint, time_window=0.6, **kwargs):
@@ -120,5 +121,4 @@ def run(args):
             lbi_by_node[node.name][attribute_name] = node.attr[attribute_name]
 
     # Export LBI to JSON.
-    with open(args.output, "w") as oh:
-        json.dump({"nodes": lbi_by_node}, oh, indent=1, sort_keys=True)
+    write_json({"nodes": lbi_by_node}, args.output)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -208,7 +208,7 @@ def run(args):
     else:
         node_data_fname = '.'.join(args.alignment.split('.')[:-1]) + '.node_data.json'
 
-    json_success = write_json(node_data, node_data_fname)
+    write_json(node_data, node_data_fname)
     print("node attributes written to",node_data_fname, file=sys.stdout)
 
-    return 0 if (tree_success and json_success) else 1
+    return 0 if tree_success else 1

--- a/augur/sequence_traits.py
+++ b/augur/sequence_traits.py
@@ -5,7 +5,7 @@ Annotate sequences based on amino-acid or nucleotide signatures.
 import numpy as np
 from treetime.vcf_utils import read_vcf
 from collections import defaultdict
-import json
+from .utils import write_json
 
 def read_in_translate_vcf(vcf_file, ref_file):
     """
@@ -319,5 +319,4 @@ def run(args):
     seq_features = attach_features(annotations, args.label, args.count)
 
     #write out json
-    with open(args.output, 'w') as results:
-        json.dump({"nodes":seq_features}, results, indent=1, sort_keys = True)
+    write_json({"nodes":seq_features}, args.output)

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -4,9 +4,9 @@ Infer ancestral traits based on a tree.
 
 import numpy as np
 from collections import defaultdict
-import json, os, sys
+import os, sys
 import pandas as pd
-from .utils import read_metadata
+from .utils import read_metadata, write_json
 TINY = 1e-12
 
 def mugration_inference(tree=None, seq_meta=None, field='country', confidence=True,
@@ -190,8 +190,7 @@ def run(args):
 
                 ofile.write(str(gtr))
 
-    with open(args.output, 'w') as results:
-        json.dump({"nodes":mugration_states}, results, indent=1, sort_keys = True)
+    write_json({"nodes":mugration_states}, args.output)
 
     print("\nInferred ancestral states of discrete character using TreeTime:"
           "\n\tSagulenko et al. TreeTime: Maximum-likelihood phylodynamic analysis"

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -134,10 +134,13 @@ def read_node_data(fnames, tree=None):
 
 
 def write_json(data, file_name, indent=1):
-    import json, os
-    success = False
+    """
+    Write *data* as JSON to the given *file_name*, creating parent directories
+    if necessary.
 
-    #in case auspice folder does not exist yet
+    By default, an *indent* of 1 is passed to :func:`json.dumps`.
+    """
+    #in case parent folder does not exist yet
     parent_directory = os.path.dirname(file_name)
     if parent_directory and not os.path.exists(parent_directory):
         try:
@@ -146,16 +149,8 @@ def write_json(data, file_name, indent=1):
             if not os.path.isdir(parent_directory):
                 raise
 
-    try:
-        handle = open(file_name, 'w')
-    except IOError:
-        raise
-    else:
+    with open(file_name, 'w') as handle:
         json.dump(data, handle, indent=indent, sort_keys = True)
-        handle.close()
-        success=True
-
-    return success
 
 
 def load_features(reference, feature_names=None):

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -133,12 +133,14 @@ def read_node_data(fnames, tree=None):
     return node_data
 
 
-def write_json(data, file_name, indent=1):
+def write_json(data, file_name, indent=(None if os.environ.get("AUGUR_MINIFY_JSON") else 1)):
     """
     Write *data* as JSON to the given *file_name*, creating parent directories
     if necessary.
 
-    By default, an *indent* of 1 is passed to :func:`json.dumps`.
+    By default, an *indent* of 1 is passed to :func:`json.dumps`.  If the
+    environment variable ``AUGUR_MINIFY_JSON`` is defined with a truthy value,
+    the default *indent* is instead ``None``.
     """
     #in case parent folder does not exist yet
     parent_directory = os.path.dirname(file_name)


### PR DESCRIPTION
This is comparable to export's `--minify-json` flag, but applies to all
commands and is easily toggled pipeline-wide for dev vs. production.

For parity with John's choice with `--minify-json`, spaces are left
between and within key/value pairs.  A future enhancement might strip
those too.

It is possible we should also add `--minify-json` flags to all commands
for consistency with export, but it seems like export is the most useful
command to have the flag.  The files export produces are generally
expected to be longer-lived than the files produced by other commands at
intermediate steps.

Another future enhancement might be to automatically gzip JSON output
(and gunzip JSON input, which would require some more refactoring).