### PR TITLE
Allow Recovery of Ambiguous Sites for Fasta-input

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -9,9 +9,34 @@ from treetime.vcf_utils import read_vcf, write_vcf
 from collections import defaultdict
 
 def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
-                                 marginal=False):
+                                 marginal=False, fill_overhangs=True):
+    """infer ancestral sequences using TreeTime
+
+    Parameters
+    ----------
+    tree : Bio.Phylo tree or str
+        tree or filename of tree
+    aln : Bio.Align.MultipleSeqAlignment or str
+        alignment or filename of alignment
+    infer_gtr : bool, optional
+        Description
+    marginal : bool, optional
+        Description
+    fill_overhangs : bool
+       In some cases, the missing data on both ends of the alignment is
+       filled with the gap character ('-'). If set to True, these end-gaps are
+       converted to "ambiguous" characters ('N' for nucleotides, 'X' for
+       aminoacids). Otherwise, the alignment is treated as-is
+
+    Returns
+    -------
+    TreeAnc
+        treetime.TreeAnc instance
+    """
+
     from treetime import TreeAnc
-    tt = TreeAnc(tree=tree, aln=aln, ref=ref, gtr='JC69', verbose=1)
+    tt = TreeAnc(tree=tree, aln=aln, ref=ref, gtr='JC69',
+                 fill_overhangs=fill_overhangs, verbose=1)
 
     # convert marginal (from args.inference) from 'joint' or 'marginal' to True or False
     bool_marginal = (marginal == "marginal")
@@ -26,6 +51,21 @@ def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
     return tt
 
 def collect_sequences_and_mutations(T, is_vcf=False):
+    """iterates of the tree and produces dictionaries with
+    mutations and sequences for each node.
+
+    Parameters
+    ----------
+    T : Bio.Phylo.Tree
+        Phylogenetic tree decorated with sequences and mutations as output by treetime.
+    is_vcf : bool, optional
+        specifies whether input alignment was vcf type (implying long genomes)
+
+    Returns
+    -------
+    dict
+        dictionary of mutations and sequences
+    """
     data = defaultdict(dict)
     inc = 1 # convert python numbering to start-at-1
     for n in T.find_clades():
@@ -52,8 +92,8 @@ def register_arguments(parser):
                                     help="calculate joint or marginal maximum likelihood ancestral sequence states")
     parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
     parser.add_argument('--output-vcf', type=str, help='name of output VCF file which will include ancestral seqs')
-    parser.add_argument('--keep-ambiguous', action="store_true", default=False, 
-                                help='do not infer nucleotides at N sites on tip sequences (leave as N). Always true for VCF input.')
+    parser.add_argument('--keep-ambiguous', action="store_true", default=False,
+                                help='do not infer nucleotides at ambiguous (N) sites on tip sequences (leave as N). Always true for VCF input.')
 
 def run(args):
     # check alignment type, set flags, read in if VCF
@@ -93,7 +133,8 @@ def run(args):
                 "\nUpdate TreeTime or run without the --keep-ambiguous flag.")
         return 1
 
-    tt = ancestral_sequence_inference(tree=T, aln=aln, ref=ref, marginal=args.inference)
+    tt = ancestral_sequence_inference(tree=T, aln=aln, ref=ref, marginal=args.inference,
+                                      fill_overhangs = True)
 
     if is_vcf or args.keep_ambiguous:
         # TreeTime overwrites ambig sites on tips during ancestral reconst.


### PR DESCRIPTION
Using `ancestral` with VCF-input includes a call to TreeTime's `recover_var_ambigs` function, which recalculates mutations on tip branches to restore ambiguous bases ('N's) at positions where they existed in the original sequence. 

TreeTime reconstructs bases at ambiguous sites (where it can), but recovering these back onto tip sequences allows users to accurately see what proportion of sequences actually have information at a given site, as reconstructions could be misleading. 

This PR updates the `ancestral` function with a new flag `--keep-ambiguous` which can be used to extend the same functionality to Fasta-input sequences. 

For example, at a site of interest in Enterovirus...
Without recovering ambiguous sites:
![image](https://user-images.githubusercontent.com/14290674/57225671-58e81000-700d-11e9-8982-a4dc3f8ff4b5.png)
This looks fairly straightforward, and one may be tempted to look and see if there are other associations with clusters where a mutation occurred.

With recovering ambiguous sites (note the colour change):
![image](https://user-images.githubusercontent.com/14290674/57225739-892fae80-700d-11e9-99cf-94ba956d6625.png)
It becomes clear that for most sequences we have no data at this site, and there are entire clusters without a sequence at this site which have coloured branches just because of ancestral reconstruction. One should be cautious interpreting mutations at this site. 

**This update includes a TreeTime version check**
This is because of a [bug](https://github.com/neherlab/treetime/pull/87) in older TreeTime versions that means using the `--keep_ambiguous` flag with Fasta-input returns nonsense. Thus, users are not allowed to use the flag if they are not running TreeTime 0.5.6 or newer. 

To make this update most useful, it would be great to implement standardised nucleotide/AA colouring in `auspice`! (Particularly so that -/N/X are always grey.)
