### PR TITLE
Add exception catch for empty titers files.

### DIFF
--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -11,6 +11,9 @@ from .utils import myopen
 
 TITER_ROUND=4
 
+class InsufficientDataException(Exception):
+    pass
+
 class TiterCollection(object):
     """
     Container for raw titer values and methods for analyzing these values.
@@ -425,8 +428,7 @@ class TiterModel(object):
         self.lam_avi = lam_avi
         self.lam_drop = lam_drop
         if len(self.train_titers)==0:
-            print('no titers to train')
-            self.model_params = np.zeros(self.genetic_params+len(self.sera)+len(self.test_strains))
+            raise InsufficientDataException("Error: No titers in training set.")
         else:
             if method=='l1reg':  # l1 regularized fit, no constraint on sign of effect
                 self.model_params = self.fit_l1reg()
@@ -774,7 +776,7 @@ class TreeModel(TiterModel):
         if len(self.train_titers)>1:
             self.make_treegraph()
         else:
-            print("TreeModel: no titers in training set")
+            raise InsufficientDataException("TreeModel: Not enough titers in training set, found {}".format(len(self.train_titers)))
 
     def get_path_no_terminals(self, v1, v2):
         '''
@@ -959,7 +961,7 @@ class SubstitutionModel(TiterModel):
         if len(self.train_titers)>1:
             self.make_seqgraph()
         else:
-            print('substitution model: no titers to train')
+            raise InsufficientDataException("SubstitutionModel: Not enough titers in training set, found {}".format(len(self.train_titers)))
 
 
     def get_mutations(self, strain1, strain2):

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -80,15 +80,24 @@ class infer_tree_model():
         T = Phylo.read(args.tree, 'newick')
         TM_tree = TreeModel(T, args.titers)
         TM_tree.prepare()
-        TM_tree.train()
+        try:
+            TM_tree.train()
+            tree_model = {'titers':TM_tree.compile_titers(),
+                          'potency':TM_tree.compile_potencies(),
+                          'avidity':TM_tree.compile_virus_effects(),
+                          'nodes':{n.name:{"dTiter": n.dTiter, "cTiter":n.cTiter}
+                                      for n in T.find_clades()}}
+        except:
+            print("Unable to train tree model.")
+            tree_model = {'titers':TM_tree.compile_titers(),
+                          'potency':{},
+                          'avidity':{},
+                          'nodes':{n.name:{"dTiter": n.dTiter, "cTiter":n.cTiter}
+                                      for n in T.find_clades()}}
+            pass
 
-        # export the tree model
-        tree_model = {'titers':TM_tree.compile_titers(),
-                      'potency':TM_tree.compile_potencies(),
-                      'avidity':TM_tree.compile_virus_effects(),
-                      'nodes':{n.name:{"dTiter": n.dTiter, "cTiter":n.cTiter}
-                                  for n in T.find_clades()}}
-        write_json(tree_model, args.output)
+            # export the tree model
+            write_json(tree_model, args.output)
         print("\nInferred titer model of type 'TreeModel' using augur:"
               "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic phenotypes of seasonal influenza viruses."
               "\n\tPNAS, vol 113, 10.1073/pnas.1525578113\n")

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from Bio import Phylo
 
 from .reconstruct_sequences import load_alignments
+from .titer_model import InsufficientDataException
 from .utils import read_metadata, read_node_data, write_json
 
 
@@ -20,6 +21,7 @@ def register_arguments(parser):
     tree_model = subparsers.add_parser('tree', help='tree model')
     tree_model.add_argument('--titers', nargs='+', type=str, required=True, help="file with titer measurements")
     tree_model.add_argument('--tree', '-t', type=str, required=True, help="tree to perform fit titer model to")
+    tree_model.add_argument('--allow-empty-model', action="store_true", help="allow model to be empty")
     tree_model.add_argument('--output', '-o', type=str, required=True, help='JSON file to save titer model')
     tree_model.set_defaults(
         __command__ = infer_tree_model
@@ -30,6 +32,7 @@ def register_arguments(parser):
     sub_model.add_argument('--alignment', nargs='+', type=str, required=True, help="sequence to be used in the substitution model, supplied as fasta files")
     sub_model.add_argument('--gene-names', nargs='+', type=str, required=True, help="names of the sequences in the alignment, same order assumed")
     sub_model.add_argument('--tree', '-t', type=str, help="optional tree to annotate fit titer model to")
+    sub_model.add_argument('--allow-empty-model', action="store_true", help="allow model to be empty")
     sub_model.add_argument('--output', '-o', type=str, required=True, help='JSON file to save titer model')
     sub_model.set_defaults(
         __command__ = infer_substitution_model
@@ -42,13 +45,26 @@ class infer_substitution_model():
         alignments = load_alignments(args.alignment, args.gene_names)
 
         TM_subs = SubstitutionModel(alignments, args.titers)
-        TM_subs.prepare()
-        TM_subs.train()
+        try:
 
-        subs_model = {'titers':TM_subs.compile_titers(),
+            TM_subs.prepare()
+            TM_subs.train()
+
+            subs_model = {'titers':TM_subs.compile_titers(),
                       'potency':TM_subs.compile_potencies(),
                       'avidity':TM_subs.compile_virus_effects(),
                       'substitution':TM_subs.compile_substitution_effects()}
+        except InsufficientDataException:
+            print("Unable to train substitution model.", file=sys.stderr)
+            if args.allow_empty_model:
+                subs_model = {'titers':TM_subs.compile_titers(),
+                          'potency':{},
+                          'avidity':{},
+                          'substitution':{}}
+                print("Writing empty model.", file=sys.stderr)
+            else:
+                print("Exiting", file=sys.stderr)
+                sys.exit(1)
 
         # Annotate nodes with inferred titer drops, if a tree is given.
         if args.tree:
@@ -79,22 +95,26 @@ class infer_tree_model():
         from .titer_model import TreeModel
         T = Phylo.read(args.tree, 'newick')
         TM_tree = TreeModel(T, args.titers)
-        TM_tree.prepare()
         try:
+            TM_tree.prepare()
             TM_tree.train()
             tree_model = {'titers':TM_tree.compile_titers(),
                           'potency':TM_tree.compile_potencies(),
                           'avidity':TM_tree.compile_virus_effects(),
                           'nodes':{n.name:{"dTiter": n.dTiter, "cTiter":n.cTiter}
                                       for n in T.find_clades()}}
-        except:
-            print("Unable to train tree model.")
-            tree_model = {'titers':TM_tree.compile_titers(),
-                          'potency':{},
-                          'avidity':{},
-                          'nodes':{n.name:{"dTiter": n.dTiter, "cTiter":n.cTiter}
-                                      for n in T.find_clades()}}
-            pass
+        except InsufficientDataException:
+            print("Unable to train tree model.", file=sys.stderr)
+            if args.allow_empty_model:
+                print("Writing empty model.", file=sys.stderr)
+                tree_model = {'titers':TM_tree.compile_titers(),
+                              'potency':{},
+                              'avidity':{},
+                              'nodes':{n.name:{"dTiter": n.dTiter, "cTiter":n.cTiter}
+                                          for n in T.find_clades()}}
+            else:
+                print("Exiting.")
+                sys.exit(1)
 
             # export the tree model
             write_json(tree_model, args.output)


### PR DESCRIPTION
This PR addresses https://github.com/nextstrain/augur/issues/279. It adds a try/except clause before the tree model is trained in `augur titers` that replaces the expected `potency` and `avidity` outputs with empty dictionary. This prevents builds from crashing if they fail to find any titers, as is the case with NIID 2y HI H3N2 builds.

I have tested this with both the above titer-less build that was previously failing and with a similar build that was working before this change, both ran without error.