### PR TITLE
Root no timetree

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -208,8 +208,8 @@ def run(args):
         from treetime import TreeAnc
         # instantiate treetime for the sole reason to name internal nodes
         if args.root:
-        	if args.root in ['best', 'least-squares', 'min_dev', 'oldest']:
-        		raise TypeError("The rooting option '%s' is only available when inferring a timetree. Please specify an explicit outgroup."%args.root)
+            if args.root in ['best', 'least-squares', 'min_dev', 'oldest']:
+                raise TypeError("The rooting option '%s' is only available when inferring a timetree. Please specify an explicit outgroup."%args.root)
 
             T.root_with_outgroup(args.root)
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -168,6 +168,11 @@ def run(args):
     else:
         tree_fname = '.'.join(args.alignment.split('.')[:-1]) + '_tt.nwk'
 
+    if args.root and len(args.root) == 1: #if anything but a list of seqs, don't send as a list
+        args.root = args.root[0]
+    if args.keep_root:  # This flag overrides anything specified by 'root'
+        args.root = None
+
     if args.timetree:
         # load meta data and covert dates to numeric
         if args.metadata is None:
@@ -184,10 +189,7 @@ def run(args):
             if n.name in metadata and 'date' in metadata[n.name]:
                 n.raw_date = metadata[n.name]['date']
 
-        if args.root and len(args.root) == 1: #if anything but a list of seqs, don't send as a list
-            args.root = args.root[0]
-        if args.keep_root:  # This flag overrides anything specified by 'root'
-            args.root = None
+        
 
         tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
                     reroot=args.root, # or 'best', # We now have a default in param spec - this just adds confusion.
@@ -207,6 +209,8 @@ def run(args):
     else:
         from treetime import TreeAnc
         # instantiate treetime for the sole reason to name internal nodes
+        if args.root:
+            T.root_with_outgroup(args.root)
         tt = TreeAnc(tree=T, aln=aln, ref=ref, gtr='JC69', verbose=1)
 
     node_data['nodes'] = collect_node_data(T, attributes)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -189,8 +189,6 @@ def run(args):
             if n.name in metadata and 'date' in metadata[n.name]:
                 n.raw_date = metadata[n.name]['date']
 
-        
-
         tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
                     reroot=args.root, # or 'best', # We now have a default in param spec - this just adds confusion.
                     Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
@@ -210,7 +208,11 @@ def run(args):
         from treetime import TreeAnc
         # instantiate treetime for the sole reason to name internal nodes
         if args.root:
+        	if args.root in ['best', 'least-squares', 'min_dev', 'oldest']:
+        		raise TypeError("The rooting option '%s' is only available when inferring a timetree. Please specify an explicit outgroup."%args.root)
+
             T.root_with_outgroup(args.root)
+
         tt = TreeAnc(tree=T, aln=aln, ref=ref, gtr='JC69', verbose=1)
 
     node_data['nodes'] = collect_node_data(T, attributes)


### PR DESCRIPTION
Previously, the `--root` argument was silently ignored when no timetree was inferred. Re-rooting was an outgroup is sensible even without a timetree. This PR implements this by using Biopython.Phylo's rerooting function. 