### PR TITLE
Errors and warnings for trees without internal node names

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -70,6 +70,16 @@ def run(args):
         print("ERROR: reading tree from %s failed."%args.tree)
         return 1
 
+    import numpy as np
+    missing_internal_node_names = [n.name is None for n in T.get_nonterminals()]
+    if np.all(missing_internal_node_names):
+        print("\n*** WARNING: Tree has no internal node names!")
+        print("*** Without internal node names, ancestral sequences can't be linked up to the correct node later.")
+        print("*** If you want to use 'augur export' or `augur translate` later, re-run this command with the output of 'augur refine'.")
+        print("*** If you haven't run 'augur refine', you can add node names to your tree by running:")
+        print("*** augur refine --tree %s --output-tree <filename>.nwk"%(args.tree) )
+        print("*** And use <filename>.nwk as the tree when running 'ancestral', 'translate', and 'traits'")
+
     if any([args.alignment.lower().endswith(x) for x in ['.vcf', '.vcf.gz']]):
         if not args.vcf_reference:
             print("ERROR: a reference Fasta is required with VCF-format alignments")

--- a/augur/export.py
+++ b/augur/export.py
@@ -53,6 +53,8 @@ def convert_tree_to_json_structure(node, metadata, div=0, nextflu_schema=False, 
                 cdiv = div + metadata[child.name]['mutation_length']
             elif 'branch_length' in metadata[child.name]:
                 cdiv = div + metadata[child.name]['branch_length']
+            else:
+                print("ERROR: Cannot find branch length information for %s"%(child.name))
             node_struct["children"].append(convert_tree_to_json_structure(child, metadata, div=cdiv, nextflu_schema=nextflu_schema, strains=strains)[0])
 
     return (node_struct, strains)
@@ -77,7 +79,7 @@ def recursively_decorate_tree_json_nextflu_schema(node, node_metadata, decoratio
         metadata = node_metadata[node["strain"]]
         metadata["strain"] = node["strain"]
     except KeyError:
-        raise Exception("ERROR: node %s is not found in the node metadata."%n.name)
+        raise Exception("ERROR: node %s is not found in the node metadata."%node.name)
 
     for data in decorations:
         val = None

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -128,6 +128,7 @@ def run(args):
     attributes = ['branch_length']
 
     # check if tree is provided an can be read
+    T = None #otherwise get 'referenced before assignment' error if reading fails
     for fmt in ["newick", "nexus"]:
         try:
             T = Phylo.read(args.tree, fmt)
@@ -165,8 +166,10 @@ def run(args):
     # if not specified, construct default output file name with suffix _tt.nwk
     if args.output_tree:
         tree_fname = args.output_tree
-    else:
+    elif args.alignment:
         tree_fname = '.'.join(args.alignment.split('.')[:-1]) + '_tt.nwk'
+    else:
+        tree_fname = '.'.join(args.tree.split('.')[:-1]) + '_tt.nwk'
 
     if args.timetree:
         # load meta data and covert dates to numeric
@@ -215,10 +218,13 @@ def run(args):
     import json
     tree_success = Phylo.write(T, tree_fname, 'newick', format_branch_length='%1.8f')
     print("updated tree written to",tree_fname, file=sys.stdout)
+
     if args.output_node_data:
         node_data_fname = args.output_node_data
-    else:
+    elif args.alignment:
         node_data_fname = '.'.join(args.alignment.split('.')[:-1]) + '.node_data.json'
+    else:
+        node_data_fname = '.'.join(args.tree.split('.')[:-1]) + '.node_data.json'
 
     write_json(node_data, node_data_fname)
     print("node attributes written to",node_data_fname, file=sys.stdout)

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -165,6 +165,17 @@ def run(args):
     tree_fname = args.tree
     traits, columns = read_metadata(args.metadata)
 
+    from Bio import Phylo
+    T = Phylo.read(tree_fname, 'newick')
+    missing_internal_node_names = [n.name is None for n in T.get_nonterminals()]
+    if np.all(missing_internal_node_names):
+        print("\n*** WARNING: Tree has no internal node names!")
+        print("*** Without internal node names, ancestral traits can't be linked up to the correct node later.")
+        print("*** If you want to use 'augur export' later, re-run this command with the output of 'augur refine'.")
+        print("*** If you haven't run 'augur refine', you can add node names to your tree by running:")
+        print("*** augur refine --tree %s --output-tree <filename>.nwk"%(tree_fname) )
+        print("*** And use <filename>.nwk as the tree when running 'ancestral', 'translate', and 'traits'")
+
     mugration_states = defaultdict(dict)
     for column in args.columns:
         T, gtr, alphabet = mugration_inference(tree=tree_fname, seq_meta=traits,


### PR DESCRIPTION
These are changes designed to detect cases where `refine` hasn't been run in order to give internal node names, and other functions that could or do rely on node-names are called. Some give warnings, others give errors and fail. 

The warnings/errors I implemented are quite wordy. If there's a better way to clearly convey the problem/solution to users, please modify :)

**1. Make adding node labels easier in `refine`**

Currently just to add node labels you must provide `--tree`, `--output-tree`, `--alignment`, and, if VCF, `--vcf-reference` (because this is checked if you've provided a VCF alignment). The alignment isn't actually used - the code is there for a fake alignment to be made if only renaming nodes.... but if you haven't provided `--output-node-data` (why would you when just naming nodes) then it tries to make the filename from `args.alignment`...

Node-data is necessary (it seems) even if it only contains branch lengths, because `export` looks for branch lengths in metadata read in from such files. However, I played around and `export` can quite easily be modified to look for branch lengths in the Newick if it doesn't find it in the metadata. @jameshadfield , is there any other reason we couldn't move to this?

For the moment, I've modified this so that if `args.alignment` isn't present, it makes the node-data filename from `args.tree`. So, you can run just name nodes with: 
`augur refine --tree results/tree_raw.nwk --output-tree results/tree.nwk`

Similarly, `--output-tree` is also not a required argument but looks to `args.alignment` to create the output file name, so I also modified this so that if `args.alignment` is missing, it'll use `args.tree` (required). (so you can actually now just run:
`augur refine --tree results/tree_raw.nwk` )


**2. Added errors with likely problem and solution to `translate`**

a) If some/all node names are missing, advises user to check they are using the tree output by `refine`. If `refine` hasn't been run, gives the run command above.

b) If a node in the tree can't be found in the alignment, advises user to ensure they've used the same tree as input for `ancestral` and `translate`, or to re-run `ancestral` with the tree they provided here, then run `translate` with the new alignment output.

This doesn't detect situations where the order/topology of the tree has changed since running `ancestral` but all the node names are the same. (But I'm not sure we could detect this?)

For Fasta-input, there is a message if nodes can't be found in the translation: "no sequence pair for nodes `node1`-`node2`", but even if this message displays for every or almost every pair, it doesn't give an error and creates the output files anyway. I don't think that's necessarily obvious that something's gone wrong!
I added an extra catch that if it can't find both nodes in the alignment, it breaks and gives the same error as b) above. However, this allows some nodes to be missing, unlike with VCF (where any missing cause an error). We could be more strict here with Fasta-input as well - unsure if there is a reason for it allowing lots of missing nodes?

For Fasta-input, if the root node doesn't have a match in the alignment, it won't have the full translated sequence(s) in the resulting JSON. This doesn't seem to affect how it views in `auspice` - could this cause errors elsewhere? (If so, easy to add an extra check here.)

I used some return strings here to separate out the errors. I don't know if that's good Python practice - feel free to edit if there's a better way! (I wanted to be able to include the filename args in the error messages.)

**3. Added warnings to `traits` and `ancestral`**

If it's detected that the tree has no internal node names, a warning is displayed that tells the user if they'd like to use `export` or `translate` later, they should either use the tree from `refine` as input, or run `refine` to add node names (and gives the simple command)


**4. Fixed and added error messages in `export` (minor)**
Minor fixes


I've tested all of the above with Fasta and VCF, but probably not exhaustively, so other eyes would be appreciated.