### PR TITLE
Allow Legend Order to be Set by User

### DIFF
--- a/augur/export.py
+++ b/augur/export.py
@@ -507,7 +507,7 @@ def run(args):
 
         # Export the metadata JSON
         lat_long_mapping = read_lat_longs(args.lat_longs)
-        color_mapping = read_colors(args.colors)
+        color_mapping = read_colors(args.colors, use_defaults=False)
         meta_json["updated"] = time.strftime("%d %b %Y")
         meta_json["virus_count"] = len(list(T.get_terminals()))
         meta_json["author_info"] = construct_author_info_nexflu(meta_tsv, T, nodes)

--- a/augur/export.py
+++ b/augur/export.py
@@ -507,7 +507,7 @@ def run(args):
 
         # Export the metadata JSON
         lat_long_mapping = read_lat_longs(args.lat_longs)
-        color_mapping = read_colors(args.colors, use_defaults=False)
+        color_mapping = read_colors(args.colors)
         meta_json["updated"] = time.strftime("%d %b %Y")
         meta_json["virus_count"] = len(list(T.get_terminals()))
         meta_json["author_info"] = construct_author_info_nexflu(meta_tsv, T, nodes)

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -264,6 +264,10 @@ def read_colors(overrides=None, use_defaults=True):
         if not hex_code.startswith("#") or len(hex_code) != 7:
             print("WARNING: Color map file contained this invalid hex code: ", hex_code)
             return
+        # If was already added, delete entirely so order can change to order in user-specified file
+        # (even though dicts shouldn't be relied on to have order)
+        if (trait, trait_value) in colors:
+            del colors[(trait, trait_value)]
         colors[(trait, trait_value)] = hex_code
 
 
@@ -283,6 +287,7 @@ def read_colors(overrides=None, use_defaults=True):
     color_map = defaultdict(list)
     for (trait, trait_value), hex_code in colors.items():
         color_map[trait].append((trait_value, hex_code))
+
     return color_map
 
 def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):


### PR DESCRIPTION
Currently, for most traits where a colour is specified in a `colors.tsv` file during export, the order of the colours/traits in the legend will be the order they are specified in the file. This makes it easy for users to re-order legends.

However, for `regions` trait this did not work, as there are default region colours in `/augur/augur/data/colors.tsv`, which are read in by default by `read_colors` in `utils.py`. Even though the colours are later overridden if the user has specified a `colors.tsv` file, the order in which they are added from the default file persists (even though dicts don't have order technically).

It was decided that even if the users specify a `colors.tsv`, if that doesn't contain `region` but they have a region colorby, the defaults should be used instead. (And in theory, this could be extended to other things added to the default color file.) 

As the default file is read before the user file, I found the easiest way to achieve this is simply to delete a key if it already exists in the dict, and re-add it. 

Before this change:
![image](https://user-images.githubusercontent.com/14290674/57469719-922bb480-7287-11e9-9eb8-dddb030706d1.png)


After this change:
![image](https://user-images.githubusercontent.com/14290674/57469667-71635f00-7287-11e9-93ac-3ba58d6952a9.png)




