### PR TITLE
Add dropped-kept numbers to filter

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -128,8 +128,12 @@ def run(args):
                     # strip whitespace and remove all text following comment character
                     exclude_name = line.split(comment_char)[0].strip()
                     to_exclude.add(exclude_name)
-        seq_keep = [seq_name for seq_name in seq_keep if seq_name not in to_exclude]
-        num_excluded_by_name = len(to_exclude)
+        tmp = [seq_name for seq_name in seq_keep if seq_name not in to_exclude]
+        num_excluded_by_name = len(seq_keep) - len(tmp)
+        seq_keep = tmp
+
+    elif not os.path.isfile(args.exclude):
+        raise FileNotFoundError("The list of dropped strains %s can not be opened"%s)
 
     # exclude strain my metadata field like 'host=camel'
     # match using lowercase

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -129,6 +129,7 @@ def run(args):
                     exclude_name = line.split(comment_char)[0].strip()
                     to_exclude.add(exclude_name)
         seq_keep = [seq_name for seq_name in seq_keep if seq_name not in to_exclude]
+        num_excluded_by_name = len(to_exclude)
 
     # exclude strain my metadata field like 'host=camel'
     # match using lowercase
@@ -295,3 +296,6 @@ def run(args):
             print("ERROR: All samples have been dropped! Check filter rules and metadata file format.")
             return 1
         SeqIO.write(seq_to_keep, args.output, 'fasta')
+
+    print("\n%i sequences were dropped during filtering. %i of these were dropped because they were in %s"%(len(all_seq)-len(seq_keep), num_excluded_by_name, args.exclude))
+    print("%i sequences have been written out to %s"%(len(seq_keep), args.output))


### PR DESCRIPTION
While I'm messing around in `augur`...

This PR just adds some output to let users know how many sequences were dropped and how many were written out. I've been caught out by datasets where I had a `filter` rule present that initially didn't do anything, but as the dataset grew, it started removing sequences, but I didn't notice for a while.

I think a little output just to tell users how much action (if any) `filter` has taken is useful, particularly if perhaps you've mis-specified something and it's removing (or not removing) many more sequences than you expect. 