### PR TITLE
augur/clades.py: change clade assignment from mutations to sequences …

### DIFF
--- a/augur/clades.py
+++ b/augur/clades.py
@@ -32,51 +32,28 @@ def read_in_clade_definitions(clade_file):
 
     return clades
 
-def get_node_alleles(node_name, muts, parents):
-    '''
-    Retrieve the set of mutations leading to a node
-    This includes node-specific mutations as well as mutations
-    along its full line of descent
-    '''
-    node_alleles = []
-    sites_encountered = set()
-    focal_node = node_name
-    while focal_node is not None:
-        if 'aa_muts' in muts[focal_node]:
-            for gene in muts[focal_node]['aa_muts']:
-                for mut in muts[focal_node]['aa_muts'][gene]:
-                    site = (gene, int(mut[1:-1]))
-                    if site not in sites_encountered:
-                        sites_encountered.add(site)
-                        allele = (gene, int(mut[1:-1]), mut[-1])
-                        node_alleles.append(allele)
-        if 'muts' in muts[focal_node]:
-            for mut in muts[focal_node]['muts']:
-                site = (gene, int(mut[1:-1]))
-                if site not in sites_encountered:
-                    sites_encountered.add(site)
-                    allele = ('nuc', int(mut[1:-1]), mut[-1])
-                    node_alleles.append(allele)
 
-        focal_node = parents.get(focal_node)
-
-    return node_alleles
-
-def is_node_in_clade(clade_alleles, node):
+def is_node_in_clade(clade_alleles, node, ref):
     '''
     Determines whether a node contains all mutations that define a clade
     '''
     # mutations are stored on nodes in format 'R927H' matching the clade definitions
     # if all of the clade-defining mutations are in the node mutations, it's part of this clade
     conditions = []
-    for gene, pos, state in clade_alleles:
-        if gene=='nuc':
-            conditions.append(node.sequence[pos]==state)
+    for gene, pos, clade_state in clade_alleles:
+        if gene in node.sequences and pos in node.sequences[gene]:
+            state = node.sequences[gene][pos]
+        elif ref and gene in ref:
+            state = ref[gene][pos]
         else:
-            conditions.append(node.aa_sequences[gene][pos]==state)
+            state = ''
+
+        conditions.append(state==clade_state)
+
     return all(conditions)
 
-def assign_clades(clade_designations, all_muts, tree):
+
+def assign_clades(clade_designations, all_muts, tree, ref=None):
     '''
     Ensures all nodes have an entry (or auspice doesn't display nicely), tests each node
     to see if it's the first member of a clade (assigns 'clade_annotation'), and sets
@@ -91,37 +68,30 @@ def assign_clades(clade_designations, all_muts, tree):
     for node in tree.find_clades(order = 'preorder'):
         clade_membership[node.name] = {'clade_membership': 'unassigned'}
 
-
     # count leaves
     for node in tree.find_clades(order = 'postorder'):
         node.leaf_count = 1 if node.is_terminal() else np.sum([c.leaf_count for c in node])
 
-    # attach sequences to root
-    try:
-        tree.root.sequence = list(all_muts[tree.root.name]["sequence"])
-    except:
-        raise TypeError("augur.clades requires nucleotide mutation files with full sequences for the root node.")
+    for node in tree.get_nonterminals():
+        for c in node:
+            c.up=node
+    tree.root.up = None
+    tree.root.sequences = {'nuc':{}}
+    tree.root.sequences.update({gene:{} for gene in all_muts[tree.root.name]['aa_muts']})
 
-    if "aa_muts" in all_muts[tree.root.name]:
-        try:
-            tree.root.aa_sequences = {gene:list(seq) for gene, seq in all_muts[tree.root.name]["aa_sequences"].items()}
-        except:
-            raise TypeError("augur.clades requires amino acid mutation files with full sequences for the root node.")
 
     # attach sequences to all nodes
-    for node in tree.get_nonterminals(order='preorder'):
-        for c in node:
-            c.sequence = node.sequence.copy()
-            for mut in all_muts[c.name]['muts']:
-                a, pos, d = mut[0], int(mut[1:-1])-1, mut[-1]
-                c.sequence[pos] = d
-            if hasattr(node, 'aa_sequences'):
-                c.aa_sequences = {}
-                for gene in node.aa_sequences:
-                    c.aa_sequences[gene] = node.aa_sequences[gene].copy()
-                    for mut in all_muts[c.name]['aa_muts'][gene]:
-                        a, pos, d = mut[0], int(mut[1:-1])-1, mut[-1]
-                        c.aa_sequences[gene][pos] = d
+    for node in tree.find_clades(order='preorder'):
+        if node.up:
+            node.sequences = {gene:muts.copy() for gene, muts in node.up.sequences.items()}
+        for mut in all_muts[node.name]['muts']:
+            a, pos, d = mut[0], int(mut[1:-1])-1, mut[-1]
+            node.sequences['nuc'][pos] = d
+        if hasattr(node, 'aa_sequences'):
+            for gene in all_muts[node.name]['aa_muts'][gene]:
+                for mut in all_muts[node.name]['aa_muts'][gene]:
+                    a, pos, d = mut[0], int(mut[1:-1])-1, mut[-1]
+                    node.sequences[gene][pos] = d
 
 
     # second pass to assign 'clade_annotation' to basal nodes within each clade
@@ -130,7 +100,7 @@ def assign_clades(clade_designations, all_muts, tree):
     for clade_name, clade_alleles in clade_designations.items():
         node_counts = []
         for node in tree.find_clades(order = 'preorder'):
-            if is_node_in_clade(clade_alleles, node):
+            if is_node_in_clade(clade_alleles, node, ref):
                 node_counts.append(node)
         sorted_nodes = sorted(node_counts, key=lambda x: x.leaf_count, reverse=True)
         print(clade_name, clade_alleles, len(sorted_nodes))
@@ -149,9 +119,28 @@ def assign_clades(clade_designations, all_muts, tree):
     return clade_membership
 
 
+def get_reference_sequence_from_root_node(all_muts, root_name):
+    # attach sequences to root
+    ref = {}
+    try:
+        ref['nuc'] = list(all_muts[root_name]["sequence"])
+    except:
+        print("augur.clades: nucleotide mutation json does not contain full sequences for the root node.")
+
+    if "aa_muts" in all_muts[root_name]:
+        try:
+            ref.update({gene:list(seq) for gene, seq in all_muts[root_name]["aa_sequences"].items()})
+        except:
+            print("augur.clades: amino acid mutation json does not contain full sequences for the root node.")
+
+    return ref
+
+
+
 def register_arguments(parser):
     parser.add_argument('--tree', help="prebuilt Newick -- no tree will be built if provided")
     parser.add_argument('--mutations', nargs='+', help='JSON(s) containing ancestral and tip nucleotide and/or amino-acid mutations ')
+    parser.add_argument('--reference', nargs='+', help='fasta files containing reference and tip nucleotide and/or amino-acid sequences ')
     parser.add_argument('--clades', type=str, help='TSV file containing clade definitions by amino-acid')
     parser.add_argument('--output', type=str, help="name of JSON files for clades")
 
@@ -165,9 +154,14 @@ def run(args):
         return 1
     all_muts = node_data['nodes']
 
+    if args.reference:
+        pass
+    else:
+        ref = get_reference_sequence_from_root_node(all_muts, tree.root.name)
+
     clade_designations = read_in_clade_definitions(args.clades)
 
-    clade_membership = assign_clades(clade_designations, all_muts, tree)
+    clade_membership = assign_clades(clade_designations, all_muts, tree, ref)
 
     write_json({'nodes': clade_membership}, args.output)
     print("clades written to", args.output, file=sys.stdout)

--- a/augur/clades.py
+++ b/augur/clades.py
@@ -5,6 +5,7 @@ Assign clades to nodes in a tree based on amino-acid or nucleotide signatures.
 import sys
 from Bio import Phylo
 import pandas as pd
+import numpy as np
 from .utils import get_parent_name_by_child_name_for_tree, read_node_data, write_json
 
 def read_in_clade_definitions(clade_file):
@@ -23,7 +24,7 @@ def read_in_clade_definitions(clade_file):
 
     df = pd.read_csv(clade_file, sep='\t' if clade_file.endswith('.tsv') else ',')
     for index, row in df.iterrows():
-        allele = (row.gene, row.site, row.alt)
+        allele = (row.gene, row.site-1, row.alt)
         if row.clade in clades:
             clades[row.clade].append(allele)
         else:
@@ -61,16 +62,19 @@ def get_node_alleles(node_name, muts, parents):
 
     return node_alleles
 
-def is_node_in_clade(clade_alleles, node_alleles):
+def is_node_in_clade(clade_alleles, node):
     '''
     Determines whether a node contains all mutations that define a clade
     '''
-    is_clade = False
     # mutations are stored on nodes in format 'R927H' matching the clade definitions
     # if all of the clade-defining mutations are in the node mutations, it's part of this clade
-    if all([ clade_allele in node_alleles for clade_allele in clade_alleles ]):
-        is_clade = True
-    return is_clade
+    conditions = []
+    for gene, pos, state in clade_alleles:
+        if gene=='nuc':
+            conditions.append(node.sequence[pos]==state)
+        else:
+            conditions.append(node.aa_sequences[gene][pos]==state)
+    return all(conditions)
 
 def assign_clades(clade_designations, all_muts, tree):
     '''
@@ -87,19 +91,53 @@ def assign_clades(clade_designations, all_muts, tree):
     for node in tree.find_clades(order = 'preorder'):
         clade_membership[node.name] = {'clade_membership': 'unassigned'}
 
+
+    # count leaves
+    for node in tree.find_clades(order = 'postorder'):
+        node.leaf_count = 1 if node.is_terminal() else np.sum([c.leaf_count for c in node])
+
+    # attach sequences to root
+    try:
+        tree.root.sequence = list(all_muts[tree.root.name]["sequence"])
+    except:
+        raise TypeError("augur.clades requires nucleotide mutation files with full sequences for the root node.")
+
+    if "aa_muts" in all_muts[tree.root.name]:
+        try:
+            tree.root.aa_sequences = {gene:list(seq) for gene, seq in all_muts[tree.root.name]["aa_sequences"].items()}
+        except:
+            raise TypeError("augur.clades requires amino acid mutation files with full sequences for the root node.")
+
+    # attach sequences to all nodes
+    for node in tree.get_nonterminals(order='preorder'):
+        for c in node:
+            c.sequence = node.sequence.copy()
+            for mut in all_muts[c.name]['muts']:
+                a, pos, d = mut[0], int(mut[1:-1])-1, mut[-1]
+                c.sequence[pos] = d
+            if hasattr(node, 'aa_sequences'):
+                c.aa_sequences = {}
+                for gene in node.aa_sequences:
+                    c.aa_sequences[gene] = node.aa_sequences[gene].copy()
+                    for mut in all_muts[c.name]['aa_muts'][gene]:
+                        a, pos, d = mut[0], int(mut[1:-1])-1, mut[-1]
+                        c.aa_sequences[gene][pos] = d
+
+
     # second pass to assign 'clade_annotation' to basal nodes within each clade
     # if multiple nodes match, assign annotation to largest
     # otherwise occasional unwanted cousin nodes get assigned the annotation
     for clade_name, clade_alleles in clade_designations.items():
-        node_counts = {}
+        node_counts = []
         for node in tree.find_clades(order = 'preorder'):
-            node_alleles = get_node_alleles(node.name, all_muts, parents)
-            if is_node_in_clade(clade_alleles, node_alleles):
-                node_counts[node.name] = node.count_terminals()
-        sorted_nodes = list(sorted(node_counts.items(), key=lambda x: x[1], reverse=True))
+            if is_node_in_clade(clade_alleles, node):
+                node_counts.append(node)
+        sorted_nodes = sorted(node_counts, key=lambda x: x.leaf_count, reverse=True)
+        print(clade_name, clade_alleles, len(sorted_nodes))
         if len(sorted_nodes) > 0:
-            target_node = sorted_nodes[0][0]
-            clade_membership[target_node] = {'clade_annotation': clade_name, 'clade_membership': clade_name}
+            target_node = sorted_nodes[0]
+            print(target_node.name, clade_name)
+            clade_membership[target_node.name] = {'clade_annotation': clade_name, 'clade_membership': clade_name}
 
     # third pass to propagate 'clade_membership'
     # don't propagate if encountering 'clade_annotation'

--- a/augur/clades.py
+++ b/augur/clades.py
@@ -79,7 +79,6 @@ def assign_clades(clade_designations, all_muts, tree, ref=None):
     tree.root.sequences = {'nuc':{}}
     tree.root.sequences.update({gene:{} for gene in all_muts[tree.root.name]['aa_muts']})
 
-
     # attach sequences to all nodes
     for node in tree.find_clades(order='preorder'):
         if node.up:
@@ -87,10 +86,13 @@ def assign_clades(clade_designations, all_muts, tree, ref=None):
         for mut in all_muts[node.name]['muts']:
             a, pos, d = mut[0], int(mut[1:-1])-1, mut[-1]
             node.sequences['nuc'][pos] = d
-        if hasattr(node, 'aa_sequences'):
-            for gene in all_muts[node.name]['aa_muts'][gene]:
+        if 'aa_muts' in all_muts[node.name]:
+            for gene in all_muts[node.name]['aa_muts']:
                 for mut in all_muts[node.name]['aa_muts'][gene]:
                     a, pos, d = mut[0], int(mut[1:-1])-1, mut[-1]
+
+                    if gene not in node.sequences:
+                        node.sequences[gene]={}
                     node.sequences[gene][pos] = d
 
 
@@ -103,10 +105,8 @@ def assign_clades(clade_designations, all_muts, tree, ref=None):
             if is_node_in_clade(clade_alleles, node, ref):
                 node_counts.append(node)
         sorted_nodes = sorted(node_counts, key=lambda x: x.leaf_count, reverse=True)
-        print(clade_name, clade_alleles, len(sorted_nodes))
         if len(sorted_nodes) > 0:
             target_node = sorted_nodes[0]
-            print(target_node.name, clade_name)
             clade_membership[target_node.name] = {'clade_annotation': clade_name, 'clade_membership': clade_name}
 
     # third pass to propagate 'clade_membership'
@@ -136,7 +136,6 @@ def get_reference_sequence_from_root_node(all_muts, root_name):
     return ref
 
 
-
 def register_arguments(parser):
     parser.add_argument('--tree', help="prebuilt Newick -- no tree will be built if provided")
     parser.add_argument('--mutations', nargs='+', help='JSON(s) containing ancestral and tip nucleotide and/or amino-acid mutations ')
@@ -155,7 +154,8 @@ def run(args):
     all_muts = node_data['nodes']
 
     if args.reference:
-        pass
+        # PLACE HOLDER FOR vcf WORKFLOW.
+        ref = None
     else:
         ref = get_reference_sequence_from_root_node(all_muts, tree.root.name)
 


### PR DESCRIPTION
…to avoid unassigned nodes when reference sequence with respect to which mutations are defined is not part of the build. This still needs to be checked with vcf (cc @emmahodcroft ). there are also now obsolete parts that could be deleted (such as `get_node_alleles`)