### PR TITLE
Bug Fixes & Feature Updates for Export V2

### DIFF
--- a/augur/export.py
+++ b/augur/export.py
@@ -542,7 +542,12 @@ def run(args):
     traits = get_traits(node_data)
     if args.extra_traits:
         traits.extend(args.extra_traits)
-    if "clade_annotation" in traits:
+    # Automatically add any specified geo traits - otherwise won't work!
+    if args.geography_traits:
+        traits.extend(args.geography_traits)
+        traits = list(set(traits)) #ensure no duplicates
+    # Clade annotation is label, not colorby!
+    if "clade_annotation" in traits: 
         traits.remove("clade_annotation")
 
     raw_strain_info = collect_strain_info(node_data, args.metadata)

--- a/augur/export.py
+++ b/augur/export.py
@@ -359,6 +359,11 @@ def transfer_metadata_to_strains(strains, raw_strain_info, traits):
             if "aa_muts" in raw_data:
                 aa = {gene:data for gene, data in raw_data["aa_muts"].items() if len(data)}
                 node["mutations"].update(aa)
+                #convert mutations into a label
+                if aa:
+                    aa_lab = '; '.join("{!s}: {!s}".format(key,', '.join(val)) for (key,val) in aa.items())
+                    node["labels"] = { "aa": aa_lab }
+
 
         # TRANSFER NODE DATES #
         if "numdate" in raw_data or "num_date" in raw_data: # it's ok not to have temporal information
@@ -372,9 +377,10 @@ def transfer_metadata_to_strains(strains, raw_strain_info, traits):
 
         # TRANSFER LABELS #
         if "clade_annotation" in raw_data:
-            node["labels"] = {
-                "clade": raw_data["clade_annotation"]
-            }
+            if 'labels' in node:
+                node['labels']['clade'] = raw_data["clade_annotation"]
+            else:
+                node["labels"] = { "clade": raw_data["clade_annotation"] }
 
         # TRANSFER NODE_HIDDEN PROPS #
 

--- a/augur/export.py
+++ b/augur/export.py
@@ -144,7 +144,11 @@ def process_colorings(jsn, color_mapping, nodes=None, node_metadata=None, nextfl
             if "menuItem" not in options: options["menuItem"] = trait
             if "key" not in options: options["key"] = trait
         else:
-            if "title" not in options: options["title"] = trait
+            if "title" not in options: 
+                if trait == 'clade_membership':
+                    options["title"] = "Clade"
+                else:
+                    options["title"] = trait
             if "type" not in options:
                 raise Exception("coloring {} missing type...".format(trait))
 
@@ -359,6 +363,10 @@ def transfer_metadata_to_strains(strains, raw_strain_info, traits):
         # TRANSFER VACCINE INFO #
 
         # TRANSFER LABELS #
+        if "clade_annotation" in raw_data:
+            node["labels"] = {
+                "clade": raw_data["clade_annotation"]
+            }
 
         # TRANSFER NODE_HIDDEN PROPS #
 
@@ -534,6 +542,8 @@ def run(args):
     traits = get_traits(node_data)
     if args.extra_traits:
         traits.extend(args.extra_traits)
+    if "clade_annotation" in traits:
+        traits.remove("clade_annotation")
 
     raw_strain_info = collect_strain_info(node_data, args.metadata)
     unified["tree"], strains = convert_tree_to_json_structure(T.root, raw_strain_info)


### PR DESCRIPTION
Most of this I discussed with @jameshadfield at ABPHM. These address various issues with migrating to `augur export` V2 and how it works with Auspice 2.0.

1. Renames `clade_membership` to `Clade` for the Color By dropdown (via `title` field). `clade_membership` comes from our own `clades` function so this variable name can be relied upon.

2. Excludes `clade_annotation` as a Color By option and includes it instead in `labels`. Again we set this name in `clades` so we can depend on it. This now displays correctly in Auspice 2.0

3. Any traits passed in with `--geography-traits` argument is automatically included in the overall list of `traits` if not already there. Currently it doesn't work unless they are also in `traits.json` or `--extra-traits`, which seems unnecessarily redundant.

4. An attempt at auto-detecting continuous traits without a config. If a trait doesn't have a colorby information passed in, we look to see if all values are `int` or `float` (can be a mix of these two), and set continuous if so. This should be expanded upon but prevents setting all data categorical, which is what currently happens, and is nuts for something like 'age'.

5. AA mutations are now included under `labels` so that they can be selected from the Branch Labels drop-down.