### PR TITLE
Support Parentheses in Strain Name

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -141,7 +141,7 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
     log_file = tmp_aln_file.replace(".fasta", ".iqtree.log")
     with open(tmp_aln_file, 'w') as ofile:
         for line in tmp_seqs:
-            ofile.write(line.replace('/', '_X_X_').replace('|','_Y_Y_'))
+            ofile.write(line.replace('/', '_X_X_').replace('|','_Y_Y_').replace("(","_X_Y_").replace(")","_Y_X_"))
 
     # For compat with older versions of iqtree, we avoid the newish -fast
     # option alias and instead spell out its component parts:
@@ -179,7 +179,7 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
         T = Phylo.read(tmp_aln_file+".treefile", 'newick')
         shutil.copyfile(tmp_aln_file+".treefile", out_file)
         for n in T.get_terminals():
-            n.name = n.name.replace('_X_X_','/').replace('_Y_Y_','|')
+            n.name = n.name.replace('_X_X_','/').replace('_Y_Y_','|').replace("_X_Y_","(").replace("_Y_X_",")")
         #this allows the user to check intermediate output, as tree.nwk will be
         if clean_up:
             #allow user to see chosen model if modeltest was run


### PR DESCRIPTION
[IQTree remove](https://groups.google.com/forum/#!topic/iqtree/Xo8baNMJxAU)s all characters apart from alphanumeric, underscore, dash, and period (full-stop) from strain names, and replaces them with underscore.

Currently, we have a workaround that allows pipe and forward-slash to be preserved, by replacing them before sending to IQTree, and back-converting after IQTree has completed.

This PR simply extends this functionality to open and close parentheses, allowing them to also be maintained. Strain names with parentheses works fine through the entire pipeline, as Bio.Phylo `read` and `write` seem to automatically handle this by putting these strain names in quotes, making them compatible with other steps (and FigTree). In other locations, like in JSON files, the strain names are already string objects, thus the presence of other symbols doesn't matter.

Preserving parentheses in strain names can make it much easier to ensure one is referencing the recognised names when writing something based on Nextstrain analysis/results. I have encountered this with RVF sequences like "Kenya 57 (Rintoul)" - having this as the strain name in Nextstrain means it's easy to know I'm using the name that will result in the correct sequences appearing in Genbank and match what other papers use, without having to remember to convert the names.

We could extend this to support other characters.