### PR TITLE
Handle Missing/Empty file Error in Refine

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -133,8 +133,8 @@ def run(args):
             T = Phylo.read(args.tree, fmt)
             node_data['input_tree'] = args.tree
             break
-        except:
-            print("\n\nERROR: reading tree from %s failed."%args.tree)
+        except Exception as error:
+            print("\n\nERROR: reading tree from %s failed: %s" % (args.tree, error))
             return 1
     if T is None:
         print("\n\nERROR: reading tree from %s failed."%args.tree)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -134,9 +134,10 @@ def run(args):
             node_data['input_tree'] = args.tree
             break
         except:
-            pass
+            print("\n\nERROR: reading tree from %s failed."%args.tree)
+            return 1
     if T is None:
-        print("ERROR: reading tree from %s failed."%args.tree)
+        print("\n\nERROR: reading tree from %s failed."%args.tree)
         return 1
 
     if not args.alignment:


### PR DESCRIPTION
Doesn't pass the exception when trying to read a non-existent or empty tree file. Related to Issue [302](https://github.com/nextstrain/augur/issues/302).

From [research](https://biopython.org/DIST/docs/api/Bio.Phylo._io-module.html#read) and testing, it doesn't seem that `Phylo.read` will ever pass back `None`, therefore it should be handled within the exception catch instead. 

I've left the `None` catch in there for the moment in case there is a reason. I haven't addressed this elsewhere in the code, though there are almost certainly other instances. 

Similar statements which use things other than `Phylo.read` should be checked carefully as they may indeed return `None` in some instances. And, some may be in functions where the file is not required to run the analysis - we should decide what should be done in these cases. (Where the file is not required, but it appears the user has tried to give it via an argument.)

