### PR TITLE
Refactor logic to read trees from multiple formats into a function

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -6,7 +6,7 @@ import os, shutil, time, json, sys
 from Bio import Phylo, SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from .utils import write_json
+from .utils import read_tree, InvalidTreeError, write_json
 from treetime.vcf_utils import read_vcf, write_vcf
 from collections import defaultdict
 
@@ -106,15 +106,11 @@ def run(args):
     is_vcf = False
     ref = None
     anc_seqs = {}
-    # check if tree is provided and can be read
-    for fmt in ["newick", "nexus"]:
-        try:
-            T = Phylo.read(args.tree, fmt)
-            break
-        except:
-            pass
-    if T is None:
-        print("ERROR: reading tree from %s failed."%args.tree)
+
+    try:
+        T = read_tree(args.tree)
+    except (FileNotFoundError, InvalidTreeError) as error:
+        print("ERROR: %s" % error, file=sys.stderr)
         return 1
 
     import numpy as np


### PR DESCRIPTION
Adds a new function `read_tree` to the `utils` module that tries to safely
handle reading trees in multiple input formats. This kind of try/except approach
to loading trees is necessary because Bio.Phylo.read requires a specified tree
format, but we do not know the format of a given tree by the filename extension
alone.

A side effect of this commit is that missing input files are also now properly
caught and reported to the user on the command line instead of raising a Python
exception.

Closes #302.