### PR TITLE
Version Change Docs & Help

### DIFF
--- a/docs/auspice.md
+++ b/docs/auspice.md
@@ -1,0 +1,43 @@
+# How Augur Export and Auspice Versions Connect
+
+From mid-2019, we're changing the format of the output file produced by `augur export` to allow us more flexibility going forward. This lines up with a big update to `auspice`, which also opens up exciting new possibilities. 
+
+We also recognise that we may need to adjust things again in the future. By setting up versions now, we'll be able to continue to expand `augur` and `auspice` while minimizing disruption to users.
+
+You can get more information on how to move to using `export v2` in `augur` 6.0 in our [handy guide](exportv.md).
+
+## Why Does Compatibility Matter?
+
+To get great visualizations, the final step of the `augur` pipeline, `augur export` produces output as (a) JSON file(s)*. This/these file(s) are then read by `auspice` to produce trees, graphs, and maps. 
+
+*_This compatibility only refers to the JSON file(s) produced by `augur export`, not those produced by other `augur` steps._
+
+Different `augur` versions will produce different JSON output formats, which in turn will work with different `auspice` versions. We aim to support backwards compatibility as much as possible, and of course, if you're you're using the latest `augur`, JSON, and `auspice` versions, everything will work smoothly!
+
+Whenever possible, we recommend updating your run to work with the latest `augur` and outputing the most recent JSON format to view with the latest `auspice` - it future-proofs your work and ensures you'll benefit from all the latest features and improvements.
+
+But, we know that for a variety of reasons, you can't always do this straight away. To help keep your research flowing, here are some tables of how different versions of `augur`, export JSONs, and `auspice` are compatible.
+
+## Compatibility Tables
+
+### Augur
+
+| Augur Version | Produces JSON | Works with Auspice  |
+| ------------- |---------------| --------------------|
+| 5.x           | v1 (via `export`)   | 1.x or 2.0          |
+| 6.0           | v1 (via `export v1`) <br> v2 (via `export v2`) | 1.x or 2.0 |
+
+
+### `export` JSON versions
+
+| JSON Version | Produced by Aupice Version | Works with Auspice  |
+| -------------|---------------| --------------------|
+| v1           | 5.x (via `export`) <br> 6.0 (via `export v1`)| 1.x or 2.0 |
+| v2           | 6.0 (via `export v2`) | 2.0 |
+
+### Auspice
+
+| Auspice Version | Takes JSON | Produced by Auspice Version  |
+| -------------|---------------| --------------------|
+| 1.x           | v1        | 5.x (via `export`) <br> 6.0 (via `export v1`) |
+| 2.0           | v1 <br> v2 | 5.x (via `export`) <br> 6.0 (via `export v1`) <br> 6.0 (via `export v2`) |

--- a/docs/breaking.md
+++ b/docs/breaking.md
@@ -1,0 +1,38 @@
+# Breaking Changes to `augur`
+
+This is a list of known 'breaking changes' to `augur`. These are changes that require users to modify existing scripts or calls to `augur` functions because the old usage is no longer supported. 'Depreciated' changes, which work for the moment but will no longer be supported in future, are also included. 
+
+_Note this list only includes changes to `augur` code and may not cover breaking changes introduced due to changes in dependancy packages. We try to support these too, so please [open an issue](https://github.com/nextstrain/augur/issues/new) if you think you've found something we didn't catch._
+
+This list will **only** be helpful if you are _sure_ the command used to work and only stopped working after you upgraded your `augur` installation. If your `augur` installation is from earlier than 2019, or if this list doesn't solve your problem, run `--help` for the command you're using and use that information to try re-writing your call.
+
+Click on the `augur` function that used to work, and we'll try to get you up and running ASAP!
+
+* [ancestral](#ancestral)
+* [export](#export)
+
+## ancestral
+
+### `--output` argument
+
+* **Possible error/warning messages:**<br>
+  > > "WARNING: the `--output` flag will be deprecated in the next major augur release. Use `--output-node-data` instead."
+
+  > > augur: error: unrecognized arguments: `--output`
+
+* **Solution:**<br>
+  To specify the JSON file to write ancestral mutations/sequences to, use the argument `--output-node-data` instead of `--output`.<br><br>
+
+* **Explanation:**<br>
+  `ancestral` now supports outputting a Fasta file of reconstructed ancestral sequences (for Fasta-input runs - this was already supported in VCF-format for VCF-input runs). Users can ask for this output and specify a file name using `--output-sequences`. Since there are now two types of output from `ancestral`, the arguments have become more descriptive.<br><br>
+
+
+## export
+
+### Version error
+
+* **Possible error/warning messages:**<br>
+  > > augur export: error: the following arguments are required: Augur export now needs you to define the JSON version you want, e.g. `augur export v2`.
+
+* **Solution:**<br>
+  We've upgraded `augur export`. Find out how to adjust your `augur export` call to work with the latest version [using our handy guide](exportv.md).<br><br>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ author = prose_list(git_authors())
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['recommonmark', 'sphinx.ext.autodoc', 'sphinxarg.ext', 'sphinx.ext.napoleon']
+extensions = ['recommonmark', 'sphinx_markdown_tables', 'sphinx.ext.autodoc', 'sphinxarg.ext', 'sphinx.ext.napoleon']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -1,0 +1,141 @@
+# How to Change 'Export' Versions
+
+<span style="color:blue">
+
+Emma's questions to be answered for this doc:
+* Do we actually support config files now? _(Ensure this is up-to-date before we go live)_
+* How do tip frequencies work in V2? Still separate file? Does 'panels' need to be specified to display this?
+* Does panel specification work as I've described it? If you don't include a panel, is it definitely excluded? (Or what panels does this work for?)
+* How do we specify default view, and does this work in `export v2`?
+* When specifying `--title` in V2, why do we need to use quotes inside quotes? Can we do this better?
+* How did (could?) we previously do multiple maintainers in old config file? (to include as comparison)
+
+* Do we need `--tree-name` (seems not always?)? In what circumstances? (Modify argument help description to reflect this)
+* Do we support any of: `--output-sequence` `--reference` `--reference-translations` yet? In export only? In Auspice? If not, can we comment these out for the time being?
+
+</span>
+
+## What is `augur export v2`?
+
+The `augur export` function is getting an upgrade! This is tied to an upgrade to Auspice (the visualization side of Nextstrain) to enable more functionality and flexibility. Your old 'version 1' (v1) JSON files will still work with the new version of `auspice`, but we recommend you switch to using 'version 2' (v2) JSONs from `export v2`, as this will become the new default. _Future versions of `auspice` may not support v1 JSON files._
+
+### Why did we make this change?
+* **Compactness**: Tree and Meta JSON files are now combined, so you only have to worry about one output file
+* **Flexibility**: The new v2 JSONs allow us flexiblity to include more features and data, and will let us move towards getting in line with existing conventions like GFF and BibTex
+* **Ease of use**: Users commonly got confused by the 'config' file. For basic runs you can now specify everything you need to see your data right in the command-line - no 'config' file needed! For more advanced exports, you can still specify a config file with more detail. (See [bottom of the page](#how-do-i-use-a-config-file-in-v2)) _(coming soon)_
+
+## **I just need my old run to work _right now_!**
+*When you upgrade to the latest version of `augur`, `augur export` will no longer work.* But we understand you may not have time to make the change right this second, and that there's nothing more frustrating than having a run break right before a presentation or deadline!
+
+If you want to keep using the old version _for now_, use `augur export v1` - everything else remains the same. 
+
+To use the new version, use `augur export v2`. You'll need to make a few changes, but they are pretty simple, and you'll be future-proofing your runs! _(Future you will thank past you!)_
+
+<br>
+
+
+## Great! What do I need to do to move to `v2`?
+You can always get a full overview of the arguments for export v2 with `augur export v2 --help`.
+
+Here's how you can convert your v1 export and config file to  a **command-line-only** v2 export: 
+_(See [bottom of page](#how-do-i-use-a-config-file-in-v2) for using a config file in v2)_
+
+
+### What's the same:
+
+You will still pass in your tree, metadata, and node-data files with `--tree`, `--metadata`, and `--node-data` - just like in `export v1`.
+
+Also just like in export v1, you can pass in files containing colours and latitute and longitude data using `--colors` and `--lat-longs`, respectively.
+
+
+### What's almost the same:
+
+Instead of specifying two output files (`--output-tree` and `--output-meta`) you now just need to specify one with `--output-main`. 
+
+For example, if your old files were `auspice/virus_AB_tree.json` and `auspice/virus_AB_meta.json`, you might want to call the single output `auspice/virus_AB.json` - or if you want to tell it apart from your v1 export, you might call it `auspice/virus_ABv2.json`. 
+
+The URL for these, respectively, would be `...virus/AB` or `...virus/ABv2`.
+
+### What's different:
+* Specify the title of your run using `--title`. You'll need to use a bit of a strange quote system for this to work. For example: `--title '\'Phylodynamics of My Interesting Pathogen\''`  
+
+  _(Previously the "title" field in your config file.)_
+<br>
+
+* You can now have more than one maintainer associated with your run! Specify the maintainers with `--maintainers`. Use double quotes for the  whole argument, and single-quotes to separate names (ex: `--maintainers "'Jane Doe' 'Ravi Kupra'"`)
+
+   _(Previously the first part of the "maintainer" field in your config file.)_
+<br>
+
+* Specify the websites of maintainers with `--maintainer-urls`. Put them in the same order as the `--maintainers` so they link up with the right people! (ex: `--maintainer-urls 'www.janedoe.com www.ravikupra.co.uk'`)
+
+  _(Previously the second part of the "maintainer" field in your config file.)_
+<br>
+
+* If you want to specify what panels are visible, use `--panels`. By default, if the data is available, Auspice will show the tree, map, and entropy panels. 
+You can specify "tree", "map", "entropy", and "frequencies". _(???)_ (ex: `--panels "tree map entropy"`)
+
+  _(Previously the "panels" field in the your config file.)_
+<br>
+
+* Specify how you'd like to locate samples on the map using `--geography-traits`. For many users, these might be "country" and "region". (ex: `--geography-traits "country region"`)
+
+  _(Previously the "geo" field in your config file.)_
+<br>
+
+  #### Traits
+
+* Any traits that you have run with `augur traits` are now automatically included by `export v2` and available to color by! (These are often in a file called `traits_`(something)`.json`.)
+
+  If you'd like to exclude any traits, you'll need to re-run `augur traits` without that trait. You can also do this with a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2)).
+
+  `export v2` will also automatically include date, genotype, and author information (if available) - you don't have to specify them!
+<br>
+
+* If you have extra meta-data that you'd like to include to color by, but
+haven't run in `augur traits`, you can include it with `--extra-traits`.
+Ensure you use the name of the column in the metadata file with the same
+spelling and capitalization! 
+(ex: `--extra-traits "age host"`)
+
+  *(Previously, included traits were those things listed under "color_options" in your old config. `gt`, `num_date`, and `authors` don't need to be specified anymore - they'll be automatically included if present.)*
+<br>
+
+* `export v2` will set traits as 'discrete' unless they contain only numbers, in which case they will be 'continuous.' If you want to have more control over how your trait is interpreted, you should use a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2))
+
+
+
+### What about filter?
+When using `export v2` with only command-line arguments, every trait (both those from `augur traits` and passed in with `--extra-traits`), geographical trait, and the authors will automatically be available to filter by. Without using a config file, you can't exclude any of these from being filter options.
+
+
+<span style="color:red">
+
+_**TO DO**_
+
+</span>
+
+
+## How do I use a config file in `v2`?
+
+### Why might I want to use a config file?
+* exclude filter options
+* make color-by traits pretty
+* specify trait type (what do we support so far? discrete, continuous...)
+* More advanced (flu?) options
+
+### Config file priority
+* Which overrides what and how, what must be included
+
+### How one might start using a config
+* Example of using a partial config to do simple things like traits and panels or filters
+
+### Using an old (`export v1`) config
+* Can this just go in as-is? Or what?
+
+### Advanced use - second config file
+* I don't think this exists yet?
+ 
+
+
+

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -133,7 +133,7 @@ If you would like to have more control over these options, you will need to incl
 <br>
 
 #### Filter
-When using `export v2` with only command-line arguments, every trait (both those from `augur traits` and passed in with `--extra-traits`), geographical trait, and the authors will automatically be available to filter by. Without using a config file, you can't exclude any of these from being filter options. **TO DO**
+When using `export v2` with only command-line arguments, every trait that's a coloring option and is either categorical or boolean will automatically be available to filter by. Without using a config file, you can't exclude any of these (or include others) as being filter options. **TO DO**
 
 
 <span style="color:red">
@@ -196,7 +196,7 @@ All of the options listed here go directly inside the main pair of curly bracket
     ["Ravi Kupra","www.ravikupra.co.uk"]
   ]
   ```
-  If you only have one maintiner, you still need to use the same format of two sets of square brackets: `"maintainers": [["Hanna Kukk", "www.hkukk.ee"]]`
+  If you only have one maintainer, you still need to use the same format of two sets of square brackets: `"maintainers": [["Hanna Kukk", "www.hkukk.ee"]]`
 
   _(Previously the "maintainer" field in your v1 config file.)_
 <br>
@@ -221,13 +221,58 @@ You can specify "tree", "map", "entropy", and "frequencies". You must specify "f
   _(Same as the "filters" field in your v1 config file.)_
 <br>
 
-* filters
-* display options
+* You can specify the default view that users will see when they load your road by using `"display_defaults"`. If you do not change the options here, `auspice` will revert to the defaults listed below. 
 
-* example
+  There are five options you can set here:
+  * `geo_resolution` - Sets which `geo` option is used to position data on the map. Default is `country` - if not available, other `geo` options will be tried.
+  * `color_by` - Sets what coloring trait the tree should be colored by. Must be an available coloring trait. Default is `country` - if not available, other coloring options will be tried.
+  * `distance_measure` - Sets whether tree branch lengths are in 'time' or 'divergence'. Default is `num_date` (time), if available. Options are `num_date` (time) or `div` (divergence).
+  * `layout` - Sets how the tree is visualized. Default is `rect` (rectangle). Options are `rect`, `radial`, `unrooted`, and `clock`, corresponding to the four options normally shown on the left in Auspice.
+  * `map_triplicate` - Sets whether the map is extended / wrapped around, which can be useful if transmissions are worldwide. Set to 'true' or 'false'.
+  <br>
 
+  _(Previously the "defaults" field in your config file.)_
+<br>
+
+* Here is an example of how all of the above options would fit into a config file _(Note this excludes trait color options, which is covered in the next section)_:
+  ```
+  {
+    "title": "Phylodynamics of my Pathogen",
+    "maintainers": [
+      ["Jane Doe", "www.janedoe.com"], 
+      ["Ravi Kupra","www.ravikupra.co.uk"]
+    ],
+    "panels": ["tree", "map"],
+    "geo": [ "country", "region"],
+    "filters": [
+      "country", "region", "symptom", "age"
+    ],
+    "display_defaults": {
+      "color_by": "symptom",
+      "geo_resolution": "region",
+      "distance_measure": "div",
+      "map_triplicate": "true"
+    }
+  }
+  ```
 
 #### Traits
+**CHECK THIS WHOLE BIT FOR HOW WE END UP MAKING CONFIG/CL WORK TOGETHER**
+
+In the export v1 config file, `"color_options"` was used to specify and describe traits that you wanted as colouring options. This is now replaced by `"colorings"`, and works in a very similar way.
+
+As in export v1, the `"colorings"` section of the config file will hold all the trait information within its curly brackets. You should provide traits using the column name you use in the metadata. 
+
+If you wish, you can provide more information about the trait using `"title"` (what should display in the drop-down menu in Auspice) and `"type"` (should the trait be treated as ordinal, boolean, continuous, or categorical). If you don't provide these, export v2 will simply use the trait name as provided and try to guess the type. The export v1 options `"legendTitle"` and `"key"` are no longer used.
+
+Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `augur seqtraits` output (ex: drug resistance information) in your config file - if that information is present, it will automatically be included. 
+
+**TO DO**
+##### Config file only
+To specify coloring options using only a config file, **do not** use `--traits-to-color` in the command line. Then include all traits you want as coloring options in `"colorings"` in the config file. As mentioned above, you can include `"title"` and `"type"` information, or not.
+
+##### Config file and Command Line
+**Using `--traits-to-color` on the command line will override what's included in `"colorings"` in the config file to decide what will be a coloring option.** If a trait is listed in `--traits-to-color` and not in the config, it will be included. If a trait is in the config but not in `--traits-to-color` it will be excluded. _However_, if a trait is in both, but has `"title"` and `"type"` information in the config file, this _will_ be used by export v2.
 
 ### Using an old (`export v1`) config
 * Can this just go in as-is? Or what?

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -96,7 +96,7 @@ You can specify "tree", "map", "entropy", and "frequencies". (ex: `--panels tree
   _(Previously the "panels" field in the your config file.)_
 <br>
 
-* Specify how you'd like to locate samples on the map using `--geography-traits`. For many users, these might be "country" and "region". (ex: `--geography-traits country region`)
+* Specify how you'd like to position samples on the map using `--geography-traits`. For many users, these might be "country" and "region". (ex: `--geography-traits country region`)
 
   _(Previously the "geo" field in your config file.)_
 <br>
@@ -189,10 +189,39 @@ All of the options listed here go directly inside the main pair of curly bracket
   _(Same as the "title" field in your v1 config file.)_
 <br>
 
-* Specify the runs maintainers and their URLs using "maintainers".
-* Geography
+* You can now have more than one maintainer associated with your run! Specify the runs maintainers and their websites using `"maintainers"` and listing the name and URL in pairs:
+  ```
+  "maintainers": [
+    ["Jane Doe", "www.janedoe.com"], 
+    ["Ravi Kupra","www.ravikupra.co.uk"]
+  ]
+  ```
+  If you only have one maintiner, you still need to use the same format of two sets of square brackets: `"maintainers": [["Hanna Kukk", "www.hkukk.ee"]]`
+
+  _(Previously the "maintainer" field in your v1 config file.)_
+<br>
+
+* To specify what panels are visible, use `"panels"`. By default, if the data is available, Auspice will show the tree, map, and entropy panels. 
+You can specify "tree", "map", "entropy", and "frequencies". You must specify "frequencies" _and_ supply a tip frequency file to `auspice` to display tip frequencies.
+
+  (ex: `"panels": ["tree", "map"]`) 
+
+  _(Same as the "panels" field in the your v1 config file.)_
+<br>
+
+* Specify how you'd like to position samples on the map using `"geo"`. For many users, these might be "country" and "region". (ex: `"geo": [ "country", "region"]`)
+
+  _(Same as the "geo" field in your v1 config file.)_
+<br>
+
+* Set what you would like to be able to filter by using `"filters"`. These must be traits present on your tree. (ex: `"filters": ["country", "region", "symptom", "age"]`)
+
+  If you don't include this option in your config file, all non-continuous traits that are coloring options will be included as filters. If you don't want any filter options, include `"filters"` with no options (ex: `"filters": []`).
+
+  _(Same as the "filters" field in your v1 config file.)_
+<br>
+
 * filters
-* panels
 * display options
 
 * example

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -46,6 +46,8 @@ You still pass in your tree, metadata, and node-data files with `--tree`, `--met
 
 Also just like in export v1, you can pass in files containing colors and latitute and longitude data using `--colors` and `--lat-longs`, respectively.
 
+If you want to use a config file, you can pass this in with `--auspice-config`, just like in export v1.
+
 ### What's almost the same:
 
 Instead of specifying two output files (`--output-tree` and `--output-meta`) you now just need to specify one with `--output-main`. 
@@ -143,10 +145,10 @@ _**TO DO**_
 
 ## How do I use a config file in `v2`?
 
-### Why might I want to use a config file?
+### Why use a config file?
 We have tried to make the command line options cover everything you need to get a run working in `augur` and `auspice`. However, there are still some features that offer more options or are only available when you use a config file. 
 
-If you use a config file, you can:
+With a config file, you can:
 * Specify exactly what you want as a filter option
 * Set the default display view
 * Give color-by traits more specific titles to display
@@ -154,7 +156,7 @@ If you use a config file, you can:
 * _More advanced (flu?) options_ **TO DO**
 
 ### Config file priority
-It is important to remember that if you set an option both in the config file _and_ in the command line, the command line option will override the config file option. For example, if you set `"title"` in your config file as "A Title About Apples", and then import this config file using `--auspice-config` _and_ use `--title "Better Title Befitting Bears"`, the title displayed by `auspice` will be "Better Title Befitting Bears". To use the one in the config file, simply don't use `--title` in the command line!
+It is important to remember that if you set an option both in the config file _and_ in the command line, **the command line option will override the config file option**. For example, if you set `"title"` in your config file as "A Title About Apples", and then import this config file using `--auspice-config` _and_ use `--title "Better Title Befitting Bears"`, the title displayed by `auspice` will be "Better Title Befitting Bears". To use the one in the config file, simply don't use `--title` in the command line!
 
 There are a couple of exceptions to this:
 * There is no way to set default display views using command line only, so using `"display_defaults"` in your config file will set this
@@ -162,8 +164,41 @@ There are a couple of exceptions to this:
 * **???** _INCLUDE HOW THIS AFFECTS TRAITS DEPENDING ON HOW WE DECIDE THIS IN CL_
 **TO DO**
 
-### How one might start using a config
-* Example of using a partial config to do simple things like traits and panels or filters
+### Using a Config File
+You will always need to pass in some information, like your tree and metadata, via the command line. Jump back up to [What's the same](#what-s-the-same) and
+[What's almost the same](#what-s-almost-the-same) to see what these are.
+
+You'll also need to use `--auspice-config` to pass in the config file you'd like to use (this is the same as in export v1).
+
+**Remember:** You don't have to include every field in your config file if you specify it in the command line (or are happy with the default) instead.
+
+#### Config file format
+Just like in export v1, the config file is a JSON-format file. In general, this means that it's divided into sections that then include more options and/or information in the curly (`{}`) or square (`[]`) brackets that follow.
+
+**It is important that everything in your config file is enclosed in one pair of curly brackets.** These can be on a separate line at the very top and very bottom of your file. 
+
+Indenting is not required for JSON files, but it can help make it easier to read your file. Syntax is important - if you are getting errors, check your brackets and quotation marks match up! Everything inside brackets is essentially a list, so needs commas between each item - but not after the last one!
+
+_Export v2 config files are generally very simliar to export v1, but there are a few changes._ They are explained in detail below, or you can see [how to convert your v1 config to v2](#using-an-old-export-v1-config).
+
+#### General Display
+All of the options listed here go directly inside the main pair of curly brackets. See the [end of this section] for an example.
+
+* Specify the title of your run using `"title"`. (ex: `"title": "Phylodynamics of my Pathogen"`)
+
+  _(Same as the "title" field in your v1 config file.)_
+<br>
+
+* Specify the runs maintainers and their URLs using "maintainers".
+* Geography
+* filters
+* panels
+* display options
+
+* example
+
+
+#### Traits
 
 ### Using an old (`export v1`) config
 * Can this just go in as-is? Or what?

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -6,7 +6,7 @@ TO DO:
 * **Update what's a colorby in CL to whatever we decide.**
 * Update filter behaviour and explanation
 * Explanation of config files and how/when overrides happen with CL. _Will be easier to write when we have resolved all questions ourselves_ (needs to include default view info)
-* Decide how best to explain `--title` and `--maintainers` so that works both for CL and with snakemake
+* Decide how best to explain `--title` and `--maintainers` so that works both for CL and with snakemake _Current explanataion ok?_
 * Confirm all options for `display_defaults`
 * Do we need `--tree-name` (seems not always?)? In what circumstances? (Modify argument help description to reflect this)
 * Do we support any of: `--output-sequence` `--reference` `--reference-translations` yet? In export only? In Auspice? If not, can we comment these out for the time being?
@@ -60,28 +60,41 @@ In your metadata file, any column called `url` will be considered a link to that
 
  #### General Display
 
-* Specify the title of your run using `--title`. You'll need to use a bit of a strange quote system for this to work. For example: `--title '\'Phylodynamics of My Interesting Pathogen\''`  **TO DO**
+* Specify the title of your run using `--title`. If running directly from the command line, put your title in quotes (ex: `--title "Phylodynamics of my Pathogen"`). If you are using snakemake and passing the value using `params`, you'll need to double-quote the title using single and double quotes. For example:
+  ```
+  params:
+    title = "'Phylodynamics of my Pathogen'"
+  shell:
+    "augur export v2 --title {params.title} ..."
+  ```
 
   _(Previously the "title" field in your config file.)_
 <br>
 
-* You can now have more than one maintainer associated with your run! Specify the maintainers with `--maintainers`. Use double quotes for the  whole argument, and single-quotes to separate names (ex: `--maintainers "'Jane Doe' 'Ravi Kupra'"`) **TO DO**
+* You can now have more than one maintainer associated with your run! Specify the maintainers with `--maintainers`. If running directly from the command line, put each maintainer in quotes (ex: `--maintainers "Jane Doe" "Ravi Kupra"`). If you are using snakemake and passing the value using `params`, you'll need to put the whole list in double quotes, and each person in single quotes. For example:
+  ```
+  params:
+    maints = "'Jane Doe' 'Ravi Kupra'"
+  shell:
+    "augur export v2 --maintainers {params.maints} ..."
+  ```
+  You will need to use quotes in the same way even if you only have one maintainer!
 
    _(Previously the first part of the "maintainer" field in your config file.)_
 <br>
 
-* Specify the websites of maintainers with `--maintainer-urls`. Put them in the same order as the `--maintainers` so they link up with the right people! (ex: `--maintainer-urls 'www.janedoe.com www.ravikupra.co.uk'`) **TO DO**
+* Specify the websites of maintainers with `--maintainer-urls`. Put them in the same order as the `--maintainers` so they link up with the right people! (ex: `--maintainer-urls www.janedoe.com www.ravikupra.co.uk`) **TO DO**
 
   _(Previously the second part of the "maintainer" field in your config file.)_
 <br>
 
 * If you want to specify what panels are visible, use `--panels`. By default, if the data is available, Auspice will show the tree, map, and entropy panels. 
-You can specify "tree", "map", "entropy", and "frequencies". (ex: `--panels "tree map entropy"`) You must specify "frequencies" here _and_ supply a tip frequency file to `auspice` to display tip frequencies.
+You can specify "tree", "map", "entropy", and "frequencies". (ex: `--panels tree map entropy`) You must specify "frequencies" here _and_ supply a tip frequency file to `auspice` to display tip frequencies.
 
   _(Previously the "panels" field in the your config file.)_
 <br>
 
-* Specify how you'd like to locate samples on the map using `--geography-traits`. For many users, these might be "country" and "region". (ex: `--geography-traits "country region"`)
+* Specify how you'd like to locate samples on the map using `--geography-traits`. For many users, these might be "country" and "region". (ex: `--geography-traits country region`)
 
   _(Previously the "geo" field in your config file.)_
 <br>
@@ -99,7 +112,7 @@ You can specify "tree", "map", "entropy", and "frequencies". (ex: `--panels "tre
 haven't run in `augur traits`, you can include it with `--extra-traits`.
 Ensure you use the name of the column in the metadata file with the same
 spelling and capitalization! 
-(ex: `--extra-traits "age host"`)
+(ex: `--extra-traits age host`)
 
   *(Previously, included traits were those things listed under "color_options" in your old config. `gt`, `num_date`, and `authors` don't need to be specified anymore - they'll be automatically included if present.)*
 <br>
@@ -131,13 +144,23 @@ _**TO DO**_
 ## How do I use a config file in `v2`?
 
 ### Why might I want to use a config file?
-* exclude filter options
-* make color-by traits pretty
-* specify trait type (what do we support so far? discrete, continuous...)
-* More advanced (flu?) options
+We have tried to make the command line options cover everything you need to get a run working in `augur` and `auspice`. However, there are still some features that offer more options or are only available when you use a config file. 
+
+If you use a config file, you can:
+* Specify exactly what you want as a filter option
+* Set the default display view
+* Give color-by traits more specific titles to display
+* Specify color-by trait type
+* _More advanced (flu?) options_ **TO DO**
 
 ### Config file priority
-* Which overrides what and how, what must be included
+It is important to remember that if you set an option both in the config file _and_ in the command line, the command line option will override the config file option. For example, if you set `"title"` in your config file as "A Title About Apples", and then import this config file using `--auspice-config` _and_ use `--title "Better Title Befitting Bears"`, the title displayed by `auspice` will be "Better Title Befitting Bears". To use the one in the config file, simply don't use `--title` in the command line!
+
+There are a couple of exceptions to this:
+* There is no way to set default display views using command line only, so using `"display_defaults"` in your config file will set this
+* There is no way to modify the default filters displayed when using command line only, so using `"filters"` in your config file will set this
+* **???** _INCLUDE HOW THIS AFFECTS TRAITS DEPENDING ON HOW WE DECIDE THIS IN CL_
+**TO DO**
 
 ### How one might start using a config
 * Example of using a partial config to do simple things like traits and panels or filters

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -3,9 +3,7 @@
 <span style="color:blue">
 
 TO DO:
-* **Update what's a colorby in CL to whatever we decide.**
-* Update filter behaviour and explanation
-* Explanation of config files and how/when overrides happen with CL. _Will be easier to write when we have resolved all questions ourselves_ (needs to include default view info)
+* Check CL and config override stuff
 * Decide how best to explain `--title` and `--maintainers` so that works both for CL and with snakemake _Current explanataion ok?_
 * Are we including 'advanced config' options...?
 
@@ -18,7 +16,7 @@ The `augur export` function is getting an upgrade! This is tied to an upgrade to
 ### Why did we make this change?
 * **Compactness**: Tree and Meta JSON files are now combined, so you only have to worry about one output file
 * **Flexibility**: The new v2 JSONs allow us flexiblity to include more features and data, and will let us move towards getting in line with existing conventions like GFF and BibTex
-* **Ease of use**: Users commonly got confused by the 'config' file. For basic runs you can now specify everything you need to see your data right in the command-line - no 'config' file needed! For more advanced exports, you can still specify a config file with more detail. (See [bottom of the page](#how-do-i-use-a-config-file-in-v2))
+* **Ease of use**: Users commonly got confused by the 'config' file. For basic runs you can now specify everything you need to see your data right in the command-line - no 'config' file needed! For more advanced exports, you can still specify a config file with more detail. (See [bottom of the page](#config-file-options))
 
 ## **I just need my old run to work _right now_!**
 *When you upgrade to the latest version of `augur`, `augur export` will no longer work.* But we understand you may not have time to make the change right this second, and that there's nothing more frustrating than having a run break right before a presentation or deadline!
@@ -33,9 +31,9 @@ To use the new version, use `augur export v2`. You'll need to make a few changes
 ## Great! What do I need to do to move to `v2`?
 You can always get a full overview of the arguments for export v2 with `augur export v2 --help`.
 
-You can now choose between exporting using just the command-line or using a combination of the command-line and config file. Remember that generally **any command line options you use will override the same option in your config file**. 
+You can now choose between exporting using just the command-line, or using a combination of the command-line and config file. Remember that generally **any command line options you use will override the same option in your config file**. 
 
-We'll first cover what's the same/almost the same as in `export v1`, which are all things that must be passed in via command-line. Then we'll cover how to use [command-line options](#command-line-options), and finally how to use a [config file](#how-do-i-use-a-config-file-in-v2).
+We'll first cover what's the same/almost the same as in `export v1`, which are all things that must be passed in via command-line. Then we'll cover how to use [command-line options](#command-line-options), and finally how to use a [config file](#config-file-options).
 
 
 ### What's the same:
@@ -51,12 +49,11 @@ Instead of specifying two output files (`--output-tree` and `--output-meta`) you
 For example, if your old files were `auspice/virus_AB_tree.json` and `auspice/virus_AB_meta.json`, you might want to call the single output `auspice/virus_AB.json` - or if you want to tell it apart from your v1 export, you might call it `auspice/virus_ABv2.json`. 
 
 ### How Coloring by Traits is Smarter
-**TO DO**
 Previously config files always had to include `gt` and `num_date` to allow coloring by genotype and date, respectively. If you had run `augur clades`, you had to remember to add `clade_membership` to the config file, and if you'd run `augur seqtraits` you had to add every resulting option. 
 
-We've made things a little smarter! You never have to include `gt` or `num_date` in command-line or config - if the right data is sent export v2, they'll automatically be included as a coloring option. The same is true for `augur clades` and `augur seqtraits` - if you pass the resulting JSON files in with `--node-data`, they'll be included as coloring options. 
+We've made things a little smarter! You never have to include `gt` or `num_date` in the command-line or config file - if the right data is sent to export v2, they'll automatically be included as a coloring option. The same is true for `augur clades` and `augur seqtraits` - if you pass the resulting JSON files in with `--node-data`, they'll be included as coloring options. _(If you don't want them as a coloring option, just don't pass in the files!)_
 
-_Everything else_ you want to have as a coloring option must be specified either by `--traits-to-color` or in the config file (what's specified in `--traits-to-color` will override what's in the config file).
+_Everything else_ you want to have as a coloring option must be specified either by `--metadata-color-by` or in the config file (what's specified in `--metadata-color-by` will override what's in the config file).
 
 ## Command-line Options
 Remember that generally **any command line options you use will override the same option in your config file**. 
@@ -90,7 +87,7 @@ Remember that generally **any command line options you use will override the sam
 ##### Maintainer Websites
 * Specify with `--maintainer-urls`. 
 * Put them in the same order as the `--maintainers` so they link up with the right people! (ex: `--maintainer-urls www.janedoe.com www.ravikupra.co.uk`) 
-* **TO DO**
+* **TO DO** _We ok with this?_
 * _(Previously the second part of the "maintainer" field in your v1 config file.)_
 
 ##### Panels
@@ -106,45 +103,34 @@ Remember that generally **any command line options you use will override the sam
 
 #### Traits
 
-**TO DO TO DO**
+* Genotype and date (if present) are always automatically included as coloring options - you don't need to include them.<br>  - _(Previously `gt` and `numdate` in your v1 config file)_
+  <br><br>
+* If you pass output from `augur clades` or `augur seqtraits` in using `--node-data`, that will also be automatically included as a coloring option <br>  - If you don't want them to be included, just don't pass the file in with `--node-data` <br>  - _(Previously things like `clade_membership`)_
+<br><br>
+* Pass in anything else from your metadata file you'd like to include with `--metadata-color-by` (ex: `--metadata-color-by country age host`) <br>  - _(Previously listed under "color_options" in your v1 config file)_
+<br><br>
+* You **can't** specify the title or type of a colouring option using just command-line - but `export v2` will make its best guess. <br>  - Excluding missing data, if a trait contains only 'True', 'False', 'Yes', 'No', '0' or '1', it will be set to 'boolean.' If it contains only numbers (integers and/or decimals), it will be set to 'continuous.' Otherwise, it will be set as 'discrete.' <br>  - If you want to have more control over how your trait is interpreted, you should use a config file (see [bottom of the page](#config-file-options)).
 
-* Any traits that you have run with `augur traits` are now automatically included by `export v2` and available to color by! (These are often in a file called `traits_`(something)`.json`.) **TO DO**
-
-  If you'd like to exclude any traits, you'll need to re-run `augur traits` without that trait. You can also do this with a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2)).
-
-  `export v2` will also automatically include date, genotype, and author information (if available) - you don't have to specify them!
-<br>
-
-* If you have extra meta-data that you'd like to include to color by, but
-haven't run in `augur traits`, you can include it with `--extra-traits`.
-Ensure you use the name of the column in the metadata file with the same
-spelling and capitalization! 
-(ex: `--extra-traits age host`)
-
-  *(Previously, included traits were those things listed under "color_options" in your old config. `gt`, `num_date`, and `authors` don't need to be specified anymore - they'll be automatically included if present.)*
-<br>
-
-* If you don't provide a config file, `export v2` will try to 'guess' the type of the traits you include. Excluding missing data, if a trait contains only 'True', 'False', 'Yes', 'No', '0' or '1', it will be set to 'boolean.' If it contains only numbers (integers and/or decimals), it will be set to 'continuous.' Otherwise, it will be set as 'discrete.' If you want to have more control over how your trait is interpreted, you should use a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2)).
 
 
 
 ### What's not possible in command-line only:
 #### Default view
-It is not possible to set the default view options using only command-line arguments in `export v2`.
+* It is not possible to set the default view options using only command-line arguments in `export v2`.
 
-By default, `auspice` will display your tree in rectangle view, with branch lengths, color, and map position based on the available data. You can read more about the defaults [here] **TO DO**.
+* By default, `auspice` will display your tree in rectangle view, with branch lengths, color, and map position based on the available data. You can read more about the defaults [here](#id6). 
 
-If you would like to have more control over these options, you will need to include a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2)). **TO DO** _Direct this link to a better place_
+* If you would like to have more control over these options, you will need to include a config file. You can find more information [here](#id6). 
 
-  _(Previously the "defaults" field in your v1 config file.)_
+* _(Previously the "defaults" field in your v1 config file.)_
 <br>
 
 #### Filter
-When using `export v2` with only command-line arguments, every trait that's a coloring option and is either categorical or boolean will automatically be available to filter by. 
+* When using `export v2` with only command-line arguments, every trait that's a coloring option and is either categorical or boolean will automatically be available to filter by. 
 
-If you'd like to specify exactly what traits are listed as filters, you'll need to use a config file. You can find more information [here]. **TO DO**
+* If you'd like to specify exactly what traits are listed as filters, you'll need to use a config file. You can find more information [here](#filters). 
 
-  _(The same as the "filters" field in your v1 config file.)_
+*  _(The same as the "filters" field in your v1 config file.)_
 
 
 
@@ -156,7 +142,7 @@ We have tried to make the command line arguments cover everything you need to ge
 With a config file, you can:
 * Specify exactly what you want as a filter option
 * Set the default display view
-* Give color-by traits more specific titles to display
+* Give color-by traits more specific titles
 * Specify color-by trait type
 * _More advanced (flu?) options_ **TO DO**
 
@@ -166,16 +152,16 @@ It is important to remember that if you set an option both in the config file _a
 There are a couple of exceptions to this:
 * There is no way to set default display views using command line only, so using `"display_defaults"` in your config file will set this
 * There is no way to modify the default filters displayed when using command line only, so using `"filters"` in your config file will set this
-* **???** _INCLUDE HOW THIS AFFECTS TRAITS DEPENDING ON HOW WE DECIDE THIS IN CL_
-**TO DO**
+* If you set color-by options in command-line using `--metadata-color-by` _and_ pass in a config file, only the things listed in `--metadata-color-by` will be coloring options, but if they have a 'title' and 'type' set in the config file, these will be used.
+
 
 ### Using a Config File
-You will always need to pass in some information, like your tree and metadata, via the command line. Jump back up to [What's the same](#what-s-the-same) and
+* You will always need to pass in some information, like your tree and metadata, via the command line. Jump back up to [What's the same](#what-s-the-same) and
 [What's almost the same](#what-s-almost-the-same) to see what these are.
 
-You'll also need to use `--auspice-config` to pass in the config file you'd like to use (this is the same as in export v1).
+* You'll also need to use `--auspice-config` to pass in the config file you'd like to use (this is the same as in export v1).
 
-**Remember:** You don't have to include every field in your config file if you specify it in the command line (or are happy with the default) instead.
+* **Remember:** You don't have to include every field in your config file - you can specify it in the command line (or use the default default) instead, if you prefer.
 
 #### Config file format
 Just like in export v1, the config file is a JSON-format file. _It is important that everything in your config file is enclosed in one pair of curly brackets._ These can be on a separate line at the very top and very bottom of your file. 
@@ -185,7 +171,7 @@ Syntax is important - if you are getting errors, ensure all your brackets and qu
 _Export v2 config files are generally very simliar to export v1, but there are a few changes._ They are explained in detail below, or you can see [an example of converting a v1 config to v2](#using-an-old-export-v1-config).
 
 #### General Display
-All of the options listed here go directly inside the main pair of curly brackets. See the [end of this section] for an example.
+All of the options listed here go directly inside the main pair of curly brackets. See the [end of this section](#example) for an example.
 
 ##### Title
 * Specify the title of your run using `"title"`. 
@@ -260,24 +246,23 @@ Here is an example of how all of the above options would fit into a config file 
   ```
 
 #### Traits
-**CHECK THIS WHOLE BIT FOR HOW WE END UP MAKING CONFIG/CL WORK TOGETHER**
+**Remember that if you are using `--metadata-color-by` on the command-line, only the traits given there will be color-by options! To include everything in your config file, don't use `--metadata-color-by`.
 
 In the export v1 config file, `"color_options"` was used to specify and describe traits that you wanted as colouring options. This is now replaced by `"colorings"`, and works in a very similar way.
 
-As in export v1, the `"colorings"` section of the config file will hold all the trait information within its curly brackets (see [the example]). You should provide traits using the column name in the metadata. 
+As in export v1, the `"colorings"` section of the config file will hold all the trait information within its curly brackets (see [the example](#example)). You should provide traits using the column name in the metadata. 
 
 If you wish, you can provide more information about the trait using `"title"` (what should display in the drop-down menu in Auspice - previously `"menuItem"` in export v1) and `"type"` (should the trait be treated as ordinal, boolean, continuous, or categorical). If you don't provide these, export v2 will simply use the trait name as provided and try to guess the type. The export v1 options `"legendTitle"` and `"key"` are no longer used.
 
-Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `augur seqtraits` output (ex: drug resistance information) in your config file - if that information is present, it will automatically be included. To exclude it, simply don't pass in the corresponding file to `--node-data`.
+Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `augur seqtraits` output (like clade or drug resistance information) in your config file - if that information is present, it will automatically be included. To exclude it, simply don't pass in the corresponding file to `--node-data`.
 
-**TO DO**
 ##### Config file only
-To specify coloring options using only a config file, **do not** use `--traits-to-color` in the command line. Then include all traits you want as coloring options in `"colorings"` in the config file. As mentioned above, you can include `"title"` and `"type"` information, or not.
+To specify coloring options using only a config file, **do not** use `--metadata-color-by` in the command line. Then include all traits you want as coloring options in `"colorings"` in the config file. As mentioned above, you can include `"title"` and `"type"` information, or not.
 
 ##### Config file and Command Line
-**Using `--traits-to-color` on the command line will override what's included in `"colorings"` in the config file to decide what will be a coloring option.** If a trait is listed in `--traits-to-color` and not in the config, it will be included. If a trait is in the config but not in `--traits-to-color` it will be excluded. _However_, if a trait is in both, but has `"title"` and `"type"` information in the config file, this information _will_ be used by export v2.
+**Using `--metadata-color-by` on the command line will override what's included in `"colorings"` in the config file to decide what will be a coloring option.** If a trait is listed in `--metadata-color-by` and not in the config, it will be included. If a trait is in the config but not in `--metadata-color-by` it will be excluded. _However_, if a trait is in both, but has `"title"` and `"type"` information in the config file, this information _will_ be used by export v2.
 
-In short, if using a config file and the command line, ensure everything you want as a coloring option is in `--traits-to-color`. You only need to also include it `"colorings"` in the config file if you want to set the `"title"` and/or `"type"`.
+In short, if using a config file and the command line, ensure everything you want as a coloring option is in `--metadata-color-by`. You only need to also include it `"colorings"` in the config file if you want to set the `"title"` and/or `"type"`.
 
 ##### Example
 Here's an example of how display and trait options (for `age`, `hospitalized`, `country`, and `region`) might fit together in a config file:

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -7,9 +7,7 @@ TO DO:
 * Update filter behaviour and explanation
 * Explanation of config files and how/when overrides happen with CL. _Will be easier to write when we have resolved all questions ourselves_ (needs to include default view info)
 * Decide how best to explain `--title` and `--maintainers` so that works both for CL and with snakemake _Current explanataion ok?_
-* Confirm all options for `display_defaults`
-* Do we need `--tree-name` (seems not always?)? In what circumstances? (Modify argument help description to reflect this)
-* Do we support any of: `--output-sequence` `--reference` `--reference-translations` yet? In export only? In Auspice? If not, can we comment these out for the time being?
+* Are we including 'advanced config' options...?
 
 </span>
 
@@ -35,7 +33,7 @@ To use the new version, use `augur export v2`. You'll need to make a few changes
 ## Great! What do I need to do to move to `v2`?
 You can always get a full overview of the arguments for export v2 with `augur export v2 --help`.
 
-You can now choose between exporting using just the command-line or using a combination of the command-line and config file. Remember that **any command line options you use will override anything set in your config file**, if you are using both. 
+You can now choose between exporting using just the command-line or using a combination of the command-line and config file. Remember that generally **any command line options you use will override the same option in your config file**. 
 
 We'll first cover what's the same/almost the same as in `export v1`, which are all things that must be passed in via command-line. Then we'll cover how to use [command-line options](#command-line-options), and finally how to use a [config file](#how-do-i-use-a-config-file-in-v2).
 
@@ -44,9 +42,7 @@ We'll first cover what's the same/almost the same as in `export v1`, which are a
 
 You still pass in your tree, metadata, and node-data files with `--tree`, `--metadata`, and `--node-data` - just like in `export v1`.
 
-Also just like in export v1, you can pass in files containing colors and latitute and longitude data using `--colors` and `--lat-longs`, respectively.
-
-If you want to use a config file, you can pass this in with `--auspice-config`, just like in export v1.
+Similarly, you can pass in files containing colors and latitute and longitude data using `--colors` and `--lat-longs`, respectively. If you want to use a [config file](#config-file-options), you can pass this in with `--auspice-config`.
 
 ### What's almost the same:
 
@@ -54,26 +50,34 @@ Instead of specifying two output files (`--output-tree` and `--output-meta`) you
 
 For example, if your old files were `auspice/virus_AB_tree.json` and `auspice/virus_AB_meta.json`, you might want to call the single output `auspice/virus_AB.json` - or if you want to tell it apart from your v1 export, you might call it `auspice/virus_ABv2.json`. 
 
-The URL for these, respectively, would be `...virus/AB` or `...virus/ABv2`.
+### How Coloring by Traits is Smarter
+**TO DO**
+Previously config files always had to include `gt` and `num_date` to allow coloring by genotype and date, respectively. If you had run `augur clades`, you had to remember to add `clade_membership` to the config file, and if you'd run `augur seqtraits` you had to add every resulting option. 
 
-In your metadata file, any column called `url` will be considered a link to that unique sequence in an online database (like Genbank), and will be the link attached to the Accession number. Any column called `paper_url` will be taken as a link associated to that author/title/journal. 
+We've made things a little smarter! You never have to include `gt` or `num_date` in command-line or config - if the right data is sent export v2, they'll automatically be included as a coloring option. The same is true for `augur clades` and `augur seqtraits` - if you pass the resulting JSON files in with `--node-data`, they'll be included as coloring options. 
+
+_Everything else_ you want to have as a coloring option must be specified either by `--traits-to-color` or in the config file (what's specified in `--traits-to-color` will override what's in the config file).
 
 ## Command-line Options
+Remember that generally **any command line options you use will override the same option in your config file**. 
 
  #### General Display
 
-* Specify the title of your run using `--title`. If running directly from the command line, put your title in quotes (ex: `--title "Phylodynamics of my Pathogen"`). If you are using snakemake and passing the value using `params`, you'll need to double-quote the title using single and double quotes. For example:
+##### Title 
+* `--title` sets the title of your run
+* If running directly from the command line, put your title in quotes (ex: `--title "Phylodynamics of my Pathogen"`). If you are using snakemake and passing the value using `params`, you'll need to double-quote the title using single and double quotes. For example:
   ```
   params:
     title = "'Phylodynamics of my Pathogen'"
   shell:
     "augur export v2 --title {params.title} ..."
   ```
+* _(Previously the "title" field in your v1 config file.)_
 
-  _(Previously the "title" field in your config file.)_
-<br>
-
-* You can now have more than one maintainer associated with your run! Specify the maintainers with `--maintainers`. If running directly from the command line, put each maintainer in quotes (ex: `--maintainers "Jane Doe" "Ravi Kupra"`). If you are using snakemake and passing the value using `params`, you'll need to put the whole list in double quotes, and each person in single quotes. For example:
+##### Maintainers
+* You can now have more than one maintainer associated with your run! 
+* Specify with `--maintainers`. 
+* If running directly from the command line, put each maintainer in quotes (ex: `--maintainers "Jane Doe" "Ravi Kupra"`). If you are using snakemake and passing the value using `params`, you'll need to put the whole list in double quotes, and each person in single quotes. For example:
   ```
   params:
     maints = "'Jane Doe' 'Ravi Kupra'"
@@ -81,27 +85,28 @@ In your metadata file, any column called `url` will be considered a link to that
     "augur export v2 --maintainers {params.maints} ..."
   ```
   You will need to use quotes in the same way even if you only have one maintainer!
+* _(Previously the first part of the "maintainer" field in your v1 config file.)_
 
-   _(Previously the first part of the "maintainer" field in your config file.)_
-<br>
+##### Maintainer Websites
+* Specify with `--maintainer-urls`. 
+* Put them in the same order as the `--maintainers` so they link up with the right people! (ex: `--maintainer-urls www.janedoe.com www.ravikupra.co.uk`) 
+* **TO DO**
+* _(Previously the second part of the "maintainer" field in your v1 config file.)_
 
-* Specify the websites of maintainers with `--maintainer-urls`. Put them in the same order as the `--maintainers` so they link up with the right people! (ex: `--maintainer-urls www.janedoe.com www.ravikupra.co.uk`) **TO DO**
+##### Panels
+* `--panels` sets the visible panels. 
+* By default, if the data is available, Auspice will show the tree, map, and entropy panels. 
+* Options are "tree", "map", "entropy", and "frequencies". (ex: `--panels tree map entropy`) You must specify "frequencies" here _and_ supply a tip frequency file to `auspice` to display tip frequencies.
+* _(Previously the "panels" field in the your v1 config file.)_
 
-  _(Previously the second part of the "maintainer" field in your config file.)_
-<br>
+##### Geography
+* Specify how you'd like to position samples on the map using `--geography-traits`. 
+* For many users, these might be "country" and "region". (ex: `--geography-traits country region`)
+* _(Previously the "geo" field in your v1 config file.)_
 
-* If you want to specify what panels are visible, use `--panels`. By default, if the data is available, Auspice will show the tree, map, and entropy panels. 
-You can specify "tree", "map", "entropy", and "frequencies". (ex: `--panels tree map entropy`) You must specify "frequencies" here _and_ supply a tip frequency file to `auspice` to display tip frequencies.
+#### Traits
 
-  _(Previously the "panels" field in the your config file.)_
-<br>
-
-* Specify how you'd like to position samples on the map using `--geography-traits`. For many users, these might be "country" and "region". (ex: `--geography-traits country region`)
-
-  _(Previously the "geo" field in your config file.)_
-<br>
-
-  #### Traits
+**TO DO TO DO**
 
 * Any traits that you have run with `augur traits` are now automatically included by `export v2` and available to color by! (These are often in a file called `traits_`(something)`.json`.) **TO DO**
 
@@ -125,28 +130,28 @@ spelling and capitalization!
 
 ### What's not possible in command-line only:
 #### Default view
-It is not possible to set the default view options using only command-line arguments in `export v2`. If the data is available, `auspice` will display your tree in rectangle view with branch lengths in time, colored by country, and plotted on the map by country. If time data is not available, it will set the branch lengths by divergence. If country data is not available as a geography trait, it will cycle through other options you passed in via `--geography-traits`. If country data is not available as a coloring option, it will cycle through other available colouring options. _What about `layout` option?_
+It is not possible to set the default view options using only command-line arguments in `export v2`.
+
+By default, `auspice` will display your tree in rectangle view, with branch lengths, color, and map position based on the available data. You can read more about the defaults [here] **TO DO**.
 
 If you would like to have more control over these options, you will need to include a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2)). **TO DO** _Direct this link to a better place_
 
-  _(Previously the "defaults" field in your config file.)_
+  _(Previously the "defaults" field in your v1 config file.)_
 <br>
 
 #### Filter
-When using `export v2` with only command-line arguments, every trait that's a coloring option and is either categorical or boolean will automatically be available to filter by. Without using a config file, you can't exclude any of these (or include others) as being filter options. **TO DO**
+When using `export v2` with only command-line arguments, every trait that's a coloring option and is either categorical or boolean will automatically be available to filter by. 
+
+If you'd like to specify exactly what traits are listed as filters, you'll need to use a config file. You can find more information [here]. **TO DO**
+
+  _(The same as the "filters" field in your v1 config file.)_
 
 
-<span style="color:red">
 
-_**TO DO**_
-
-</span>
-
-
-## How do I use a config file in `v2`?
+## Config File Options
 
 ### Why use a config file?
-We have tried to make the command line options cover everything you need to get a run working in `augur` and `auspice`. However, there are still some features that offer more options or are only available when you use a config file. 
+We have tried to make the command line arguments cover everything you need to get a run working in `augur` and `auspice`. However, there are still some features that offer more options or are only available when you use a config file. 
 
 With a config file, you can:
 * Specify exactly what you want as a filter option
@@ -173,55 +178,54 @@ You'll also need to use `--auspice-config` to pass in the config file you'd like
 **Remember:** You don't have to include every field in your config file if you specify it in the command line (or are happy with the default) instead.
 
 #### Config file format
-Just like in export v1, the config file is a JSON-format file. In general, this means that it's divided into sections that then include more options and/or information in the curly (`{}`) or square (`[]`) brackets that follow.
+Just like in export v1, the config file is a JSON-format file. _It is important that everything in your config file is enclosed in one pair of curly brackets._ These can be on a separate line at the very top and very bottom of your file. 
 
-**It is important that everything in your config file is enclosed in one pair of curly brackets.** These can be on a separate line at the very top and very bottom of your file. 
+Syntax is important - if you are getting errors, ensure all your brackets and quotation marks match up, and that commas separate items in the same pair of brackets.
 
-Indenting is not required for JSON files, but it can help make it easier to read your file. Syntax is important - if you are getting errors, check your brackets and quotation marks match up! Everything inside brackets is essentially a list, so needs commas between each item - but not after the last one!
-
-_Export v2 config files are generally very simliar to export v1, but there are a few changes._ They are explained in detail below, or you can see [how to convert your v1 config to v2](#using-an-old-export-v1-config).
+_Export v2 config files are generally very simliar to export v1, but there are a few changes._ They are explained in detail below, or you can see [an example of converting a v1 config to v2](#using-an-old-export-v1-config).
 
 #### General Display
 All of the options listed here go directly inside the main pair of curly brackets. See the [end of this section] for an example.
 
-* Specify the title of your run using `"title"`. (ex: `"title": "Phylodynamics of my Pathogen"`)
+##### Title
+* Specify the title of your run using `"title"`. 
+* Ex: `"title": "Phylodynamics of my Pathogen"`
+* _(Same as the "title" field in your v1 config file.)_
 
-  _(Same as the "title" field in your v1 config file.)_
-<br>
-
-* You can now have more than one maintainer associated with your run! Specify the runs maintainers and their websites using `"maintainers"` and listing the name and URL in pairs:
+##### Maintainers
+* You can now have more than one maintainer associated with your run! 
+* Specify maintainers and their websites using `"maintainers"` and listing the name and URL in pairs:
   ```
   "maintainers": [
     ["Jane Doe", "www.janedoe.com"], 
     ["Ravi Kupra","www.ravikupra.co.uk"]
   ]
   ```
-  If you only have one maintainer, you still need to use the same format of two sets of square brackets: `"maintainers": [["Hanna Kukk", "www.hkukk.ee"]]`
+* If you only have one maintainer, you still need to use the same format of two sets of square brackets: `"maintainers": [["Hanna Kukk", "www.hkukk.ee"]]`
+* _(Previously the "maintainer" field in your v1 config file.)_
 
-  _(Previously the "maintainer" field in your v1 config file.)_
-<br>
+##### Panels
+* Use `"panels"` to specify visible panels.
+* By default, if the data is available, Auspice will show the tree, map, and entropy panels. 
+* Options are "tree", "map", "entropy", and "frequencies". You must specify "frequencies" _and_ supply a tip frequency file to `auspice` to display tip frequencies.
+* Ex: `"panels": ["tree", "map"]`
+* _(Same as the "panels" field in the your v1 config file.)_
 
-* To specify what panels are visible, use `"panels"`. By default, if the data is available, Auspice will show the tree, map, and entropy panels. 
-You can specify "tree", "map", "entropy", and "frequencies". You must specify "frequencies" _and_ supply a tip frequency file to `auspice` to display tip frequencies.
+##### Geography
+* Specify how you'd like to position samples on the map using `"geo"`. 
+* For many users, these might be "country" and "region". (ex: `"geo": [ "country", "region"]`)
+* _(Same as the "geo" field in your v1 config file.)_
 
-  (ex: `"panels": ["tree", "map"]`) 
+##### Filters
+* Set what you would like to be able to filter by using `"filters"`.
+* These must be traits present on your tree. 
+* Ex: `"filters": ["country", "region", "symptom", "age"]`
+* If you don't include this option in your config file, all non-continuous traits that are coloring options will be included as filters. If you don't want any filter options, include `"filters"` with no options (ex: `"filters": []`).
+* _(Same as the "filters" field in your v1 config file.)_
 
-  _(Same as the "panels" field in the your v1 config file.)_
-<br>
-
-* Specify how you'd like to position samples on the map using `"geo"`. For many users, these might be "country" and "region". (ex: `"geo": [ "country", "region"]`)
-
-  _(Same as the "geo" field in your v1 config file.)_
-<br>
-
-* Set what you would like to be able to filter by using `"filters"`. These must be traits present on your tree. (ex: `"filters": ["country", "region", "symptom", "age"]`)
-
-  If you don't include this option in your config file, all non-continuous traits that are coloring options will be included as filters. If you don't want any filter options, include `"filters"` with no options (ex: `"filters": []`).
-
-  _(Same as the "filters" field in your v1 config file.)_
-<br>
-
-* You can specify the default view that users will see when they load your road by using `"display_defaults"`. If you do not change the options here, `auspice` will revert to the defaults listed below. 
+##### Default View
+* You can specify the default view that users will see when they load your run by using `"display_defaults"`. 
+* If you do not change the options here, `auspice` will revert to the defaults listed below:
 
   There are five options you can set here:
   * `geo_resolution` - Sets which `geo` option is used to position data on the map. Default is `country` - if not available, other `geo` options will be tried.
@@ -230,11 +234,10 @@ You can specify "tree", "map", "entropy", and "frequencies". You must specify "f
   * `layout` - Sets how the tree is visualized. Default is `rect` (rectangle). Options are `rect`, `radial`, `unrooted`, and `clock`, corresponding to the four options normally shown on the left in Auspice.
   * `map_triplicate` - Sets whether the map is extended / wrapped around, which can be useful if transmissions are worldwide. Set to 'true' or 'false'.
   <br>
+* _(Previously the "defaults" field in your config file. Note the spelling of the five options has changed slightly!)_
 
-  _(Previously the "defaults" field in your config file.)_
-<br>
-
-* Here is an example of how all of the above options would fit into a config file _(Note this excludes trait color options, which is covered in the next section)_:
+##### Example
+Here is an example of how all of the above options would fit into a config file _(Note this excludes trait color options, which is covered in the next section)_:
   ```
   {
     "title": "Phylodynamics of my Pathogen",
@@ -261,24 +264,173 @@ You can specify "tree", "map", "entropy", and "frequencies". You must specify "f
 
 In the export v1 config file, `"color_options"` was used to specify and describe traits that you wanted as colouring options. This is now replaced by `"colorings"`, and works in a very similar way.
 
-As in export v1, the `"colorings"` section of the config file will hold all the trait information within its curly brackets. You should provide traits using the column name you use in the metadata. 
+As in export v1, the `"colorings"` section of the config file will hold all the trait information within its curly brackets (see [the example]). You should provide traits using the column name in the metadata. 
 
-If you wish, you can provide more information about the trait using `"title"` (what should display in the drop-down menu in Auspice) and `"type"` (should the trait be treated as ordinal, boolean, continuous, or categorical). If you don't provide these, export v2 will simply use the trait name as provided and try to guess the type. The export v1 options `"legendTitle"` and `"key"` are no longer used.
+If you wish, you can provide more information about the trait using `"title"` (what should display in the drop-down menu in Auspice - previously `"menuItem"` in export v1) and `"type"` (should the trait be treated as ordinal, boolean, continuous, or categorical). If you don't provide these, export v2 will simply use the trait name as provided and try to guess the type. The export v1 options `"legendTitle"` and `"key"` are no longer used.
 
-Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `augur seqtraits` output (ex: drug resistance information) in your config file - if that information is present, it will automatically be included. 
+Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `augur seqtraits` output (ex: drug resistance information) in your config file - if that information is present, it will automatically be included. To exclude it, simply don't pass in the corresponding file to `--node-data`.
 
 **TO DO**
 ##### Config file only
 To specify coloring options using only a config file, **do not** use `--traits-to-color` in the command line. Then include all traits you want as coloring options in `"colorings"` in the config file. As mentioned above, you can include `"title"` and `"type"` information, or not.
 
 ##### Config file and Command Line
-**Using `--traits-to-color` on the command line will override what's included in `"colorings"` in the config file to decide what will be a coloring option.** If a trait is listed in `--traits-to-color` and not in the config, it will be included. If a trait is in the config but not in `--traits-to-color` it will be excluded. _However_, if a trait is in both, but has `"title"` and `"type"` information in the config file, this _will_ be used by export v2.
+**Using `--traits-to-color` on the command line will override what's included in `"colorings"` in the config file to decide what will be a coloring option.** If a trait is listed in `--traits-to-color` and not in the config, it will be included. If a trait is in the config but not in `--traits-to-color` it will be excluded. _However_, if a trait is in both, but has `"title"` and `"type"` information in the config file, this information _will_ be used by export v2.
+
+In short, if using a config file and the command line, ensure everything you want as a coloring option is in `--traits-to-color`. You only need to also include it `"colorings"` in the config file if you want to set the `"title"` and/or `"type"`.
+
+##### Example
+Here's an example of how display and trait options (for `age`, `hospitalized`, `country`, and `region`) might fit together in a config file:
+  ```
+  {
+    "title": "Phylodynamics of my Pathogen",
+    "colorings": {
+      "age": {
+        "title": "Host age",
+        "type": "continuous"
+      },
+      "hospitalized": {
+        "type": "boolean"
+      },
+      "country": {
+      },
+      "region": {
+      }
+    },
+    "maintainers": [
+      ["Jane Doe", "www.janedoe.com"], 
+      ["Ravi Kupra","www.ravikupra.co.uk"]
+    ],
+    "geo": [ "country", "region" ],
+    "filters": [ "country", "region" ],
+    "display_defaults": {
+      "geo_resolution": "region",
+    }
+  }
+  ```
 
 ### Using an old (`export v1`) config
-* Can this just go in as-is? Or what?
+It's fairly easy to convert old export v1 config files to work with export v2. 
+
+Here's an export v1 config file on the left, and an export v2 config file on the right. We've tried to line them up to highlight the differences:
+
+<div style="overflow: hidden">
+    <div id="column1" style="float:left; margin:0.5; width:50%;" markdown="1">
+Export v1 config:
+    <div class="highlight-default notranslate"><div class="highlight"><pre>
+{
+  "title": "Phylodynamics of Virus A",
+  "color_options": {
+    "gt": {
+      "menuItem": "genotype",
+      "legendTitle": "Genotype",
+      "type": "discrete",
+      "key": "genotype"
+    },
+    "num_date": {
+      "menuItem": "date",
+      "legendTitle": "Sampling date",
+      "type": "continuous",
+      "key": "num_date"
+    },
+    "age": {
+      "menuItem": "Host age",
+      "legendTitle": "Host Age (years)",
+      "type": "continuous",
+      "key": "age"
+    },
+    "host": {
+      "menuItem": "Animal",
+      "legendTitle": "Animal",
+      "type": "discrete",
+      "key": "host"
+    },
+    "country": {
+      "type": "discrete"
+    },
+    "region": {
+      "type": "discrete"
+    },
+    "clade_membership":{
+      "menuItem": "Clade",
+      "legendTitle": "Clade",
+      "type": "discrete",
+      "key": "clade_membership"
+    }
+  },
+  "geo": [
+    "country", "region"
+  ],
+  "maintainer": [
+    "Hanna Kukk, Mohammad Fahir",
+    "http://vamuzlab.org"
+  ],
+  "filters": [
+    "country", "region"
+  ],
+  "defaults": {
+    "layout": "unrooted",
+    "colorBy": "age"
+  }
+}
+    </pre></div></div>
+    </div>
+    <div id="column2" style="float:left; margin:0.5; width:50%;" markdown="1">
+Export v2 config:
+    <div class="highlight-default notranslate"><div class="highlight"><pre>
+{
+  "title": "Phylodynamics of Virus A",
+  "colorings": {<br><br><br><br><br><br><br><br><br><br><br><br>
+    "age": {
+      "title": "Host age",<br>
+      "type": "continuous"<br>
+    },
+    "host": {
+      "title": "Animal",<br>
+      "type": "categorical"<br>
+    },
+    "country": {
+      "type": "categorical"
+    },
+    "region": {
+      "type": "categorical"
+    }<br><br><br><br><br><br>
+  },
+  "geo": [
+    "country", "region"
+  ],
+  "maintainers": [
+    ["Hanna Kukk", "http://vamuzlab.org"],
+    ["Mohammad Fahir", "http://mfahir.co.uk"]
+  ],
+  "filters": [
+    "country", "region"
+  ],
+  "display_defaults": {
+    "layout": "unrooted",
+    "color_by": "age"
+  }
+}
+    </pre></div></div>
+    </div>
+</div>
+
+#### What changed?
+
+* `title`, `geo` and `filters` are unchanged
+* `"color_options"` is now `"colorings"`. In this section:
+  * `gt`, `num_date`, and `clade_membership` no longer have to be included - they are automatically included if the necessary information is present
+  * `legendTitle` and `key` are gone
+  * `menuItem` is now `title`
+  * The type `discrete` is now `categorical`
+* `maintainer` is now `maintainers` and uses the new format
+* `defaults` is now `display_defaults` and within its options, `colorBy` is now `color_by`
+
 
 ### Advanced use - second config file
+**TO DO**
 * I don't think this exists yet?
+_Are we doing this?_
  
 
 

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -2,14 +2,12 @@
 
 <span style="color:blue">
 
-Emma's questions to be answered for this doc:
-* Do we actually support config files now? _(Ensure this is up-to-date before we go live)_
-* How do tip frequencies work in V2? Still separate file? Does 'panels' need to be specified to display this?
-* Does panel specification work as I've described it? If you don't include a panel, is it definitely excluded? (Or what panels does this work for?)
-* How do we specify default view, and does this work in `export v2`?
-* When specifying `--title` in V2, why do we need to use quotes inside quotes? Can we do this better?
-* How did (could?) we previously do multiple maintainers in old config file? (to include as comparison)
-
+TO DO:
+* **Update what's a colorby in CL to whatever we decide.**
+* Update filter behaviour and explanation
+* Explanation of config files and how/when overrides happen with CL. _Will be easier to write when we have resolved all questions ourselves_ (needs to include default view info)
+* Decide how best to explain `--title` and `--maintainers` so that works both for CL and with snakemake
+* Confirm all options for `display_defaults`
 * Do we need `--tree-name` (seems not always?)? In what circumstances? (Modify argument help description to reflect this)
 * Do we support any of: `--output-sequence` `--reference` `--reference-translations` yet? In export only? In Auspice? If not, can we comment these out for the time being?
 
@@ -22,7 +20,7 @@ The `augur export` function is getting an upgrade! This is tied to an upgrade to
 ### Why did we make this change?
 * **Compactness**: Tree and Meta JSON files are now combined, so you only have to worry about one output file
 * **Flexibility**: The new v2 JSONs allow us flexiblity to include more features and data, and will let us move towards getting in line with existing conventions like GFF and BibTex
-* **Ease of use**: Users commonly got confused by the 'config' file. For basic runs you can now specify everything you need to see your data right in the command-line - no 'config' file needed! For more advanced exports, you can still specify a config file with more detail. (See [bottom of the page](#how-do-i-use-a-config-file-in-v2)) _(coming soon)_
+* **Ease of use**: Users commonly got confused by the 'config' file. For basic runs you can now specify everything you need to see your data right in the command-line - no 'config' file needed! For more advanced exports, you can still specify a config file with more detail. (See [bottom of the page](#how-do-i-use-a-config-file-in-v2))
 
 ## **I just need my old run to work _right now_!**
 *When you upgrade to the latest version of `augur`, `augur export` will no longer work.* But we understand you may not have time to make the change right this second, and that there's nothing more frustrating than having a run break right before a presentation or deadline!
@@ -37,16 +35,16 @@ To use the new version, use `augur export v2`. You'll need to make a few changes
 ## Great! What do I need to do to move to `v2`?
 You can always get a full overview of the arguments for export v2 with `augur export v2 --help`.
 
-Here's how you can convert your v1 export and config file to  a **command-line-only** v2 export: 
-_(See [bottom of page](#how-do-i-use-a-config-file-in-v2) for using a config file in v2)_
+You can now choose between exporting using just the command-line or using a combination of the command-line and config file. Remember that **any command line options you use will override anything set in your config file**, if you are using both. 
+
+We'll first cover what's the same/almost the same as in `export v1`, which are all things that must be passed in via command-line. Then we'll cover how to use [command-line options](#command-line-options), and finally how to use a [config file](#how-do-i-use-a-config-file-in-v2).
 
 
 ### What's the same:
 
-You will still pass in your tree, metadata, and node-data files with `--tree`, `--metadata`, and `--node-data` - just like in `export v1`.
+You still pass in your tree, metadata, and node-data files with `--tree`, `--metadata`, and `--node-data` - just like in `export v1`.
 
-Also just like in export v1, you can pass in files containing colours and latitute and longitude data using `--colors` and `--lat-longs`, respectively.
-
+Also just like in export v1, you can pass in files containing colors and latitute and longitude data using `--colors` and `--lat-longs`, respectively.
 
 ### What's almost the same:
 
@@ -56,24 +54,29 @@ For example, if your old files were `auspice/virus_AB_tree.json` and `auspice/vi
 
 The URL for these, respectively, would be `...virus/AB` or `...virus/ABv2`.
 
-### What's different:
-* Specify the title of your run using `--title`. You'll need to use a bit of a strange quote system for this to work. For example: `--title '\'Phylodynamics of My Interesting Pathogen\''`  
+In your metadata file, any column called `url` will be considered a link to that unique sequence in an online database (like Genbank), and will be the link attached to the Accession number. Any column called `paper_url` will be taken as a link associated to that author/title/journal. 
+
+## Command-line Options
+
+ #### General Display
+
+* Specify the title of your run using `--title`. You'll need to use a bit of a strange quote system for this to work. For example: `--title '\'Phylodynamics of My Interesting Pathogen\''`  **TO DO**
 
   _(Previously the "title" field in your config file.)_
 <br>
 
-* You can now have more than one maintainer associated with your run! Specify the maintainers with `--maintainers`. Use double quotes for the  whole argument, and single-quotes to separate names (ex: `--maintainers "'Jane Doe' 'Ravi Kupra'"`)
+* You can now have more than one maintainer associated with your run! Specify the maintainers with `--maintainers`. Use double quotes for the  whole argument, and single-quotes to separate names (ex: `--maintainers "'Jane Doe' 'Ravi Kupra'"`) **TO DO**
 
    _(Previously the first part of the "maintainer" field in your config file.)_
 <br>
 
-* Specify the websites of maintainers with `--maintainer-urls`. Put them in the same order as the `--maintainers` so they link up with the right people! (ex: `--maintainer-urls 'www.janedoe.com www.ravikupra.co.uk'`)
+* Specify the websites of maintainers with `--maintainer-urls`. Put them in the same order as the `--maintainers` so they link up with the right people! (ex: `--maintainer-urls 'www.janedoe.com www.ravikupra.co.uk'`) **TO DO**
 
   _(Previously the second part of the "maintainer" field in your config file.)_
 <br>
 
 * If you want to specify what panels are visible, use `--panels`. By default, if the data is available, Auspice will show the tree, map, and entropy panels. 
-You can specify "tree", "map", "entropy", and "frequencies". _(???)_ (ex: `--panels "tree map entropy"`)
+You can specify "tree", "map", "entropy", and "frequencies". (ex: `--panels "tree map entropy"`) You must specify "frequencies" here _and_ supply a tip frequency file to `auspice` to display tip frequencies.
 
   _(Previously the "panels" field in the your config file.)_
 <br>
@@ -85,7 +88,7 @@ You can specify "tree", "map", "entropy", and "frequencies". _(???)_ (ex: `--pan
 
   #### Traits
 
-* Any traits that you have run with `augur traits` are now automatically included by `export v2` and available to color by! (These are often in a file called `traits_`(something)`.json`.)
+* Any traits that you have run with `augur traits` are now automatically included by `export v2` and available to color by! (These are often in a file called `traits_`(something)`.json`.) **TO DO**
 
   If you'd like to exclude any traits, you'll need to re-run `augur traits` without that trait. You can also do this with a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2)).
 
@@ -101,12 +104,21 @@ spelling and capitalization!
   *(Previously, included traits were those things listed under "color_options" in your old config. `gt`, `num_date`, and `authors` don't need to be specified anymore - they'll be automatically included if present.)*
 <br>
 
-* `export v2` will set traits as 'discrete' unless they contain only numbers, in which case they will be 'continuous.' If you want to have more control over how your trait is interpreted, you should use a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2))
+* If you don't provide a config file, `export v2` will try to 'guess' the type of the traits you include. Excluding missing data, if a trait contains only 'True', 'False', 'Yes', 'No', '0' or '1', it will be set to 'boolean.' If it contains only numbers (integers and/or decimals), it will be set to 'continuous.' Otherwise, it will be set as 'discrete.' If you want to have more control over how your trait is interpreted, you should use a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2)).
 
 
 
-### What about filter?
-When using `export v2` with only command-line arguments, every trait (both those from `augur traits` and passed in with `--extra-traits`), geographical trait, and the authors will automatically be available to filter by. Without using a config file, you can't exclude any of these from being filter options.
+### What's not possible in command-line only:
+#### Default view
+It is not possible to set the default view options using only command-line arguments in `export v2`. If the data is available, `auspice` will display your tree in rectangle view with branch lengths in time, colored by country, and plotted on the map by country. If time data is not available, it will set the branch lengths by divergence. If country data is not available as a geography trait, it will cycle through other options you passed in via `--geography-traits`. If country data is not available as a coloring option, it will cycle through other available colouring options. _What about `layout` option?_
+
+If you would like to have more control over these options, you will need to include a config file (see [bottom of the page](#how-do-i-use-a-config-file-in-v2)). **TO DO** _Direct this link to a better place_
+
+  _(Previously the "defaults" field in your config file.)_
+<br>
+
+#### Filter
+When using `export v2` with only command-line arguments, every trait (both those from `augur traits` and passed in with `--extra-traits`), geographical trait, and the authors will automatically be available to filter by. Without using a config file, you can't exclude any of these from being filter options. **TO DO**
 
 
 <span style="color:red">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,5 +15,6 @@ Augur originated as part of `Nextstrain <https://nextstrain.org>`__, an open-sou
 
    installation
    usage
+   upgrading
    api
    authors

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -1,0 +1,18 @@
+===============
+Upgrading Augur 
+===============
+
+To make an omelette, you have to break some eggs. 
+To keep improving and adding to ``augur`` and ``auspice``, we sometimes have 
+to break old code!
+
+We know these kinds of changes can be really frustrating for users - 
+things that used to work suddenly don't. Finding out what went wrong 
+and learning what you need to change should be as pain-free as possible.
+
+.. toctree::
+   :maxdepth: 2
+
+   breaking
+   exportv
+   auspice


### PR DESCRIPTION
I wasn't sure whether this should go live immediately (it has some comments to-do, so maybe not), and also I included an extension to handle markdown tables, so made a branch instead.

This PR includes a new section in `augur` docs: "Upgrading Augur"

This includes 3 new pages:
- Breaking Changes to augur
- How to Change ‘Export’ Versions
- How Augur Export and Auspice Versions Connect

The first is more generic, and should include breaking changes as we make them, with instructions on how to update the call to get it working. It currently has two, I'm not sure if we need to go backwards, but thought it will be good going forward.

The second gives details on how to move from using `export` to `export v2`. I figure this is going to be a more confusing change for users so we should have a good guide. In future, if we have more versions, we can stream line the v1-to-v2 part and include moving to other versions (which should hopefully be less confusing/more straightforward).
(This may be useful for anyone in the group trying to make the switch/test!)

The third gives some guide as to how to figure out what versions of what work with what. Currently this assumes we are tying export JSON version to Auspice version, but this is currently under discussion. Whatever we choose, we can keep a record of this here, so that it's always easy to find and figure out.

The three tables are definitely redundant, but that's intentional, so it's easy as possible to figure out whatever direction you're trying to go. 



I'll try to answer some of my own questions in 'How to Change Export Versions' soon. We should try to get these complete before we go live with augur v6/export v2/auspice 2.0. 