### PR TITLE
Config File Update for V6

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -381,7 +381,7 @@ def add_config_args(parser):
     config.add_argument('--maintainer-urls', nargs='+', help="URL of maintainers")
     config.add_argument('--geography-traits', nargs='+', help="What location traits are used to plot on map")
     config.add_argument('--extra-traits', nargs='+', help="Metadata columns not run through 'traits' to be added to tree")
-    config.add_argument('--panels', default=['tree', 'map', 'entropy'], nargs='+', help="What panels to display in auspice. Options are : xxx")
+    config.add_argument('--panels', default=['tree', 'map', 'entropy'], nargs='+', help="What panels to display in auspice. Options are : tree, map, entropy, frequencies")
     return config
 
 def add_option_args(parser):
@@ -543,7 +543,13 @@ def run_v2(args):
 
     auspice_json["updated"] = time.strftime('%Y-%m-%d')
     auspice_json["genome_annotations"] = process_annotations(node_data)
-    auspice_json["panels"] = process_panels(args.panels, auspice_json)
+
+    # Set up panels for both config and command-line
+    if config.get("panels"):
+        panels = config["panels"]
+    else:
+        panels = args.panels
+    auspice_json["panels"] = process_panels(panels, auspice_json)
 
     if args.tree_name:
         if not re.search("(^|_|/){}(_|.json)".format(args.tree_name), str(args.output_main)):

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -376,7 +376,7 @@ def add_config_args(parser):
     config = parser.add_argument_group("CONFIG OPTIONS")
     # XXX TODO: make clear either use auspice-config or additional config options
     config.add_argument('--auspice-config', help="file with auspice configuration")
-    config.add_argument('--title', help="Title to be displayed by auspice")
+    config.add_argument('--title', nargs='+', help="Title to be displayed by auspice")
     config.add_argument('--maintainers', nargs='+', help="Analysis maintained by")
     config.add_argument('--maintainer-urls', nargs='+', help="URL of maintainers")
     config.add_argument('--geography-traits', nargs='+', help="What location traits are used to plot on map")
@@ -466,7 +466,7 @@ def run_v2(args):
     if config.get("title"):
         auspice_json['title'] = config['title']
     elif args.title:
-        auspice_json['title'] = args.title
+        auspice_json['title'] = ' '.join(args.title)
     else:
         print("ERROR: 'title' is required. Please specify one using the --title argument or "
               "the 'title' field in a config file.")

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -376,9 +376,9 @@ def add_config_args(parser):
     config = parser.add_argument_group("CONFIG OPTIONS")
     # XXX TODO: make clear either use auspice-config or additional config options
     config.add_argument('--auspice-config', help="file with auspice configuration")
-    config.add_argument('--title', default="Analysis", help="Title to be displayed by auspice")
-    config.add_argument('--maintainers', default=[""], nargs='+', help="Analysis maintained by")
-    config.add_argument('--maintainer-urls', default=[""], nargs='+', help="URL of maintainers")
+    config.add_argument('--title', help="Title to be displayed by auspice")
+    config.add_argument('--maintainers', nargs='+', help="Analysis maintained by")
+    config.add_argument('--maintainer-urls', nargs='+', help="URL of maintainers")
     config.add_argument('--geography-traits', nargs='+', help="What location traits are used to plot on map")
     config.add_argument('--extra-traits', nargs='+', help="Metadata columns not run through 'traits' to be added to tree")
     config.add_argument('--panels', default=['tree', 'map', 'entropy'], nargs='+', help="What panels to display in auspice. Options are : xxx")
@@ -463,7 +463,6 @@ def run_v2(args):
             auspice_json["display_defaults"] = config["display_defaults"]
 
     # Get title - config file overwrites command-line args.
-    # Error currently doesn't print because of defaults in args.
     if config.get("title"):
         auspice_json['title'] = config['title']
     elif args.title:
@@ -475,7 +474,6 @@ def run_v2(args):
 
     # Get maintainers. Config file overwrites command-line args.
     # Recognises and implements v1-style config spec without warnings.
-    # Error currently doesn't print because of defaults in args.
     if config.get("maintainer"): #v1-type specification
         auspice_json["maintainers"] = [{ "name": config["maintainer"][0], "url": config["maintainer"][1]}]
     elif config.get("maintainers"): #v2-type specification (proposed by Emma)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -445,14 +445,22 @@ def run_v2(args):
                   "'colorings'.")
             config["colorings"] = config["color_options"]
 
-        # Set up display defaults
+        # v2 schema uses 'display_defaults' not 'defaults' (v1). Tolerate this but
+        # give a warning and fix.
         if config.get("defaults"):
+            print("CONFIG FILE WARNING: 'defaults' is depreciated. Please use 'display_defaults' in your "
+                  "config file instead. The run will proceed, treating 'defaults' as "
+                  "'display_defaults'.")
+            config["display_defaults"] = config["defaults"]
 
-            for key in config["defaults"]:
+        # Set up display defaults
+        if config.get("display_defaults"):
+
+            for key in config["display_defaults"]:
                 new_key = convert_camel_to_snake_case(key)
-                config["defaults"][new_key] = config["defaults"].pop(key)
+                config["display_defaults"][new_key] = config["display_defaults"].pop(key)
 
-            auspice_json["display_defaults"] = config["defaults"]
+            auspice_json["display_defaults"] = config["display_defaults"]
 
     # Get title - config file overwrites command-line args.
     # Error currently doesn't print because of defaults in args.

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -476,10 +476,6 @@ def run_v2(args):
         auspice_json['maintainers'] = [{'name': n[0], 'url': n[1]} for n in config['maintainers']]
     elif args.maintainers and args.maintainer_urls:
         auspice_json['maintainers'] = [{'name': name, 'url':url} for name, url in zip(args.maintainers, args.maintainer_urls)]
-    else:
-        print("ERROR: Maintainer information is required. Please specify using the --maintainer " 
-              " and --maintainer_urls arguments, or in a config file.")
-        sys.exit(2)
 
     # get traits to colour by etc - do here before node_data is modified below
     # this ensures we get traits even if they are not on every node

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -436,6 +436,15 @@ def run_v2(args):
 
     if args.auspice_config:
         config = read_config(args.auspice_config)
+
+        # v2 schema uses 'colorings' not 'color_options' (v1). Tolerate this but
+        # give a warning and fix.
+        if config.get("color_options"):
+            print("CONFIG FILE WARNING: 'color_options' is depreciated. Please use 'colorings' in your "
+                  "config file instead. The run will proceed, treating 'color_options' as "
+                  "'colorings'.")
+            config["colorings"] = config["color_options"]
+
         # Set up display defaults
         if config.get("defaults"):
 
@@ -473,8 +482,8 @@ def run_v2(args):
     # get traits to colour by etc - do here before node_data is modified below
     # this ensures we get traits even if they are not on every node
     traits = get_traits(node_data)
-    if config.get('color_options'):
-        traits.extend(config['color_options'].keys())
+    if config.get('colorings'):
+        traits.extend(config['colorings'].keys())
     if args.extra_traits:
         traits.extend(args.extra_traits)
     # Automatically add any specified geo traits - otherwise won't work!
@@ -505,11 +514,11 @@ def run_v2(args):
     add_metadata_to_tree(auspice_json["tree"], node_metadata)
 
     # Set up colorings
-    if config.get("color_options"):
-        color_config = config["color_options"]
+    if config.get("colorings"):
+        color_config = config["colorings"]
         # If have passed in clade info this will appear on branch labels
         # Treat as 'all-or-nothing' - must also have as color-by. Or exclude from --node-data
-        if 'clade_membership' in traits and 'clade_membership' not in config['color_options']:
+        if 'clade_membership' in traits and 'clade_membership' not in config['colorings']:
             color_config['clade_membership'] = {}
     else:
         color_config = traits

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -467,10 +467,6 @@ def run_v2(args):
         auspice_json['title'] = config['title']
     elif args.title:
         auspice_json['title'] = ' '.join(args.title)
-    else:
-        print("ERROR: 'title' is required. Please specify one using the --title argument or "
-              "the 'title' field in a config file.")
-        sys.exit(2)
 
     # Get maintainers. Config file overwrites command-line args.
     # Recognises and implements v1-style config spec without warnings.


### PR DESCRIPTION
Lots of work here. As previously discussed, `config` file should override anything supplied by command-line (CL). 

**My Idea**: During workshop or after following update tutorial, user gets basic run working in CL  & now wants to add more features. They should not have to supply whole `config` file straight away (hard). Should be able to pick&mix just what they need to customise. The rest comes from CL options. Makes building a `config` _easy_ as can be done bit-by-bit. 
However, you can also just pass everything in in a `config`, too, if that's easier.

Here's a list of changes, but also observations on behaviour/checks that I did.

_These changes work towards this aim and fix other stuff I encountered on the way._

## View options

- v1 uses `default` for display values; v2 uses `default_display`. We should encourage users to use the correct v2 value in their configs (less confusing) but tolerate old v1 hangovers. So using `defaults` gives a warning but converts it to `default_display` in background. (So also now supports using `default_display` in `config`.)

- Checked behaviour when set `default`/`default_display` to nonsensical values. `color_by` fails quietly with no detectable error in `augur` or `auspice`. `geo_resolution`, `distance_measure`, and `map_triplicate` give quiet (console) errors in `auspice` and revert to their default. (_Note: setting `map_triplicate` to 'cake' seems to be taken as 'true'... Mostly harmless, but should this happen?_) **TO-DO**: Explain these options in `--help` - or somewhere. I have not attempted to make these work in CL. Should we?

- `title` can now be specified either in `config` or CL or both (`config` overrules). I added a check/error if neither was supplied, but we currently have a default value for `--title` ('Analysis') so this error never happens. **What behaviour do we want here?**

- Maintainer info can also now be specified both places - same as `title` above, and same error question as above - we have "" and "" default values if nothing passed in, so error never prints. Is this what we want?

- Old v1 `maintainer` format (which works if passed in via `config`) was like this:
```
"maintainer": [
  "Emma H, Richard N, Robert D, Jan A",
  "http://neherlab.org"
],
```
But new v2 `maintainers` format in final JSON is like this:
```
"maintainers": [
  {
    "href": "http://neherlab.org",
    "name": "Emma Hodcroft"
  },
  {
    "href": "http://neherlab.org",
    "name": "Richard Neher"
  },
  {
    "href": "https://ki.se/en/people/janalb",
    "name": "Robert Dyrdak"
  },
  {
    "href": "https://ki.se/en/people/janalb",
    "name": "Jan Albert"
  }
],
```
I figured we want a way to _easily_ support multi-maintainers in `config`, which can use `maintainers` to match the new schema. I don't know much about JSON rules but I made up my own version:
```
"maintainers": [
  ["Emma H", "http://neherlab.org"], 
  ["Richard N","http://neherlab.org"],
  ["Robert D","https://ki.se/en/people/janalb"],
  ["Jan A", "https://ki.se/en/people/janalb"]
],
```
**Is this ok? If not, let's change it but stick with concept.** (As in, let's please not make users write 'href' and 'name' 4 times for 4 maintainers.)




## `color_options`/`colorings`:

- In general, options passed in `config` override CL, like we want. But more detail on this below.

- Checked that 'authors' can be specified as a colorby, just like anything else

- v1 uses `color_options`; v2 uses `colorings`. As with `default`/`default_display` above, we should encourage users to use the correct v2 value in their configs (less confusing) but tolerate old v1 hangovers. So using `color_options` gives a warning but converts it to `colorings` in background. (So also now supports using `colorings` in `config`.)

### `process_colorings()`

- `process_colorings()` was overwriting any JSON-format info (`title`, `type` etc) passed in. Looks at type now and acts accordingly. 

- Default for anything (`config` or CL) without a `type` is `categorical` - checked later to see if could be `continuous` - should add other checks in future.

- `type` is checked to ensure is one of: `continuous`, `ordinal`, `categorical`, `boolean` in line with Schema. If is `discrete` (v1 term) a warning is printed and this is internally converted to `categorical`. If anything else, an error is printed and the trait is removed from the export. **Is this ok?**

- v1 uses `legendTitle` and `menuItem`; v2 uses `title`. If these are present, a warning is printed, but internally `legendTitle` or `menuItem` (in that order) is used for `title`, and these fields are removed to prevent them from being written out to the JSON.

- v1 value `key` is no longer used. I checked it's completely ignored and not written into JSON.

- Checked that genotype data passed in via `config` `gt` and date data passed in via `config` `num_date` (as was done in v1) is completely ignored. 

- Checked that you can pass in traits via `config` with no values (no `title` or `type`) and they will be handled just like as if passed in by CL.

## Color-by/Traits Discord Question
Currently, to get 'traits' (all data on nodes) we get from any of the following: anything passed in via `--node-data` (clades, `augur traits` output, AA/Nuc muts, branchlengths), anything passed in with `--geography-traits`, anything listed under `colorings` in a `config`, and anything passed in with `--extra-traits`. 

This is used to put data on the nodes to be written out and to set up filters. 

'Color-by's (things you can select from the drop-down in `auspice`) are a subset of 'traits' but can be decided separately. If using CL (no `config`) they are the same. If using a `config`, then they are only those things listed under `colorings`/`color_options` in the `config`.

This can lead to some slightly weird behaviour:
- If something is passed in in `--extra-traits` but is not in the `config`, it cannot be colored by (not in drop-down), but _will_ be on the nodes of the final JSON and _will_ be a filter option (unless the user manually sets the filter options). 

- The same is true (but perhaps even less obvious) if something comes in via `--node-data` from being run in `augur traits`. Ex, 'country' has been run through `augur traits`, but is _not_ specified as a color-by option in the `config` or in `--extra-traits`, and not given in `geo` (`config`) or `--geography-traits`, the information is still written in the final JSON (on nodes) and is still a filter option. (In short, you did not put country anywhere in export specs, but it's still 'there'.)

This seems odd to me. **How should we handle this?** If it's not given as a color-by in `config` (when using `config`) should it be excluded as a 'trait' as well? What if it's not given as a color-by but it is given as `geo`? (Then we need the node-data to map it - does this make sense without coloring-by as well?)

A similar situation is true for Clades. If passed in via `--node-data` from running in `augur clades`, but is NOT given in `config` color options, then it won't appear in the color-by drop-down, but it will: still have clades appear as branch labels, appear as a filter, be written on nodes in the JSON. This case was more clear to me so I handled it. Unlike 'traits', clade info is generated by a separate `augur` command and passed into `--node-data` as a separate file. So excluding it entirely is easy (just don't pass in the file), whereas to exclude a 'trait' is harder (the 'traits' file may have multiple traits, so may require re-running `augur traits`). 

So, I took an 'all-or-nothing' approach. If you pass in `clades` data via `--node-data`, then you will get it as a color-by option (as well as branch labels, filter, etc) whether it's specified or not. If not wanted, exclude file. **Is this ok?**


## BUGS:
- `continuous` traits are still made a filter option (unless user uses a `config` to explicitly declare what should be a filter). This is very silly:
![image](https://user-images.githubusercontent.com/14290674/61318018-64716780-a804-11e9-8085-de6868beded6.png)

- If I put into `config` or `--extra-traits` (if using CL only) a color-by that doesn't exist in the data, I get no errors from `export v2`, but this really messes up `auspice`:
![image](https://user-images.githubusercontent.com/14290674/61317503-625ad900-a803-11e9-8cc3-05171ecc3035.png)
This persists in the legend even after you try to change to a different color-by:
![image](https://user-images.githubusercontent.com/14290674/61317551-7999c680-a803-11e9-9829-e7e338ff81fd.png)

- If I put a `categorical` trait (something with string values) to `continuous`, it totally kills `auspice`:
![image](https://user-images.githubusercontent.com/14290674/61317741-eca33d00-a803-11e9-8cc4-08f2f7409ecf.png)
The inverse does no harm as it's picked up by our check and transformed back into `continuous`... But do we always want this? **Should we have a way to specify number-only data as categorical?** (I think probably yes.)


It would be super-good to have more people testing this out and seeing what they think of these options. I've put a how-to-switch guide in the docs (on a branch) if you need help!
All reviewers welcome - unsure who is currently working on `v6` stuff. 