### PR TITLE
Authorship in v2 JSONs

### DIFF
--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -157,9 +157,10 @@
         },
         "colorings": {
             "description": "Available colorBys for Auspice",
-            "$comment": "The property names are found on node->traits, where the value there defines the deme for that node",
-            "$comment": "There are a few exceptions - a property of 'numDate', 'gt' (genotype) or 'authors' are interpreted differently by Auspice as they are defined on the node itself, not node->traits",
-            "$comment": "Property strings are not themselves displayed in auspice.",
+            "$comment": "Property names here match those found on node.traits, where node.traits[propertyName] defines the value of that coloring for that node",
+            "$comment": "Property names are not displayed by auspice - use 'title' for this",
+            "$comment": "Exceptions: property names 'num_date', 'gt' (genotype), 'authors' or 'citekey'",
+            "$comment": "as their info is defined as a prop on the node itself (not node.traits)",
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {

--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -63,8 +63,8 @@
                             "description": "Journal title",
                             "type": "string"
                         },
-                        "url": {
-                            "description": "URL link to paper or NCBI genome.",
+                        "paper_url": {
+                            "description": "URL link to paper (if available)",
                             "type": "string",
                             "pattern": "^https?://.+$"
                         }

--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -34,44 +34,6 @@
                 }
             }
         },
-        "author_info": {
-            "description": "Used to display information about terminal nodes & for filtering by author (if \"authors\" is in \"filters\", see below)",
-            "$comment": "Keys are ideally first authors last name + year of publication + first word of title, all in lowercase. E.g. \"white2015isolation\"",
-            "$comment": "Keys must exist in the attrs object of at least one terminal node of the tree",
-            "type": "object",
-            "additionalProperties": false,
-            "patternProperties": {
-                "^[0-9A-Za-z-]+$": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "$comment": "Unknown properties should simply be excluded",
-                    "properties": {
-                        "author": {
-                            "description": "Authors",
-                            "$comment": "Case is respected by auspice",
-                            "type": "string"
-                        },
-                        "title": {
-                            "description": "Publication title",
-                            "type": "string"
-                        },
-                        "year": {
-                            "description": "Publication year",
-                            "type": "number"
-                        },
-                        "journal": {
-                            "description": "Journal title",
-                            "type": "string"
-                        },
-                        "paper_url": {
-                            "description": "URL link to paper (if available)",
-                            "type": "string",
-                            "pattern": "^https?://.+$"
-                        }
-                    }
-                }
-            }
-        },
         "genome_annotations": {
             "description": "Genome annotations (e.g. genes), relative to the reference genome",
             "$comment": "Required for the entropy panel",
@@ -338,24 +300,37 @@
                 },
                 "url": {
                     "description": "URL of the sequence (usually https://www.ncbi.nlm.nih.gov/nuccore/...)",
-                    "$comment": "Obviously only for terminal nodes",
-                    "$comment": "If not known/available, don't include this as a property of the node",
+                    "$comment": "terminal nodes only",
                     "type": "string",
                     "pattern": "^https?://.+$"
                 },
-                "citekey": {
-                    "description": "Author lookup key for the relevant publication / credit",
-                    "$comment": "Must have a corresponding entry in the #/author_info property",
-                    "$comment": "Keys are first authors last name + year of publication + first word of title, all in lowercase. E.g. \"white2015isolation\"",
-                    "$comment": "Only for terminal nodes",
-                    "$comment": "If not known/available, don't include this as a property of the node",
-                    "type": "string",
-                    "pattern": "^[0-9A-Za-z-]+$"
+                "author": {
+                    "description": "Author information (terminal nodes only)",
+                    "type": "object",
+                    "required": ["value"],
+                    "properties": {
+                        "value": {
+                            "description": "unique value for this publication. Displayed as-is by auspice.",
+                            "type": "string"
+                        },
+                        "title": {
+                          "description": "Publication title",
+                          "type": "string"
+                        },
+                        "journal": {
+                            "description": "Journal title (including year, if applicable)",
+                            "type": "string"
+                        },
+                        "paper_url": {
+                            "description": "URL link to paper (if available)",
+                            "type": "string",
+                            "pattern": "^https?://.+$"
+                        }
+                    }
                 },
                 "accession": {
                     "description": "Sequence accession number",
-                    "$comment": "Obviously only for terminal nodes",
-                    "$comment": "If not known/available, don't include this as a property of the node",
+                    "$comment": "terminal nodes only",
                     "type": "string",
                     "pattern": "^[0-9A-Za-z-_]+$"
                 },

--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -46,7 +46,7 @@
                     "additionalProperties": false,
                     "$comment": "Unknown properties should simply be excluded",
                     "properties": {
-                        "authors": {
+                        "author": {
                             "description": "Authors",
                             "$comment": "Case is respected by auspice",
                             "type": "string"
@@ -342,7 +342,7 @@
                     "type": "string",
                     "pattern": "^https?://.+$"
                 },
-                "authors": {
+                "citekey": {
                     "description": "Author lookup key for the relevant publication / credit",
                     "$comment": "Must have a corresponding entry in the #/author_info property",
                     "$comment": "Keys are first authors last name + year of publication + first word of title, all in lowercase. E.g. \"white2015isolation\"",

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -181,8 +181,8 @@ def construct_author_info_and_make_keys(node_metadata, raw_strain_info):
             data["title"] = raw_strain_info[strain]["title"].strip()
         if "journal" in raw_strain_info[strain]:
             data["journal"] = raw_strain_info[strain]["journal"].strip()
-        if "url" in raw_strain_info[strain]:
-            data["url"] = raw_strain_info[strain]["url"].strip()
+        if "paper_url" in raw_strain_info[strain]:
+            data["paper_url"] = raw_strain_info[strain]["paper_url"].strip()
 
         # make unique key...
         key = authors.split()[0].lower()

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -156,9 +156,16 @@ def collect_strain_info(node_data, tsv_path):
 
 
 def construct_author_info_and_make_keys(node_metadata, raw_strain_info):
-    """
-    For each node, gather the relevant author information (returned)
-    and create a unique key inside node_metadata
+    """Gather the authors which appear in the metadata and assign them
+    to nodes on the tree. Produce a mapping of seen authors and the
+    metadata associated with them.
+
+    :param node_metadata:
+    :type node_metadata: dict
+    :param raw_strain_info:
+    :type raw_strain_info: dict
+    :returns: author information. See JSON schema for format.
+    :rtype: dict
     """
     author_info = {}
     for strain, node in node_metadata.items():
@@ -424,9 +431,12 @@ def run_v2(args):
     if args.geography_traits:
         traits.extend(args.geography_traits)
         traits = list(set(traits)) #ensure no duplicates
-    # Clade annotation is label, not colorby!
-    if "clade_annotation" in traits:
-        traits.remove("clade_annotation")
+    # remove keys which may look like traits but are not
+    excluded_traits = [
+      "clade_annotation", # Clade annotation is label, not colorby!
+      "authors" # authors are set as a node property, not a trait property
+    ]
+    traits = [t for t in traits if t not in excluded_traits]
 
     raw_strain_info = collect_strain_info(node_data, args.metadata)
     auspice_json["tree"], strains = convert_tree_to_json_structure(T.root, raw_strain_info)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -168,7 +168,7 @@ def construct_author_info_and_make_keys(node_metadata, raw_strain_info):
             continue # internal node / terminal node without authors
 
         data = {
-            "authors": authors
+            "author": authors
         }
         if "title" in raw_strain_info[strain]:
             data["title"] = raw_strain_info[strain]["title"].strip()
@@ -187,7 +187,7 @@ def construct_author_info_and_make_keys(node_metadata, raw_strain_info):
         if "title" in data:
             key += raw_strain_info[strain]["title"].strip().split()[0].lower()
 
-        node["authors"] = key
+        node["citekey"] = key
 
         if key not in author_info:
             author_info[key] = data


### PR DESCRIPTION
We previously had a mapping of a "citekey" (or similar) attached to a node and a lookup-dictionary of publication info ("author_info"). This was done mainly to save space in the JSON, which is now less of a concern since we almost always use compressed files (see below). By shifting the authorship information to each node we 
* simplify human readability of the JSON (no lookups needed)
* simplify the auspice code related to authors.

For instance, an example node (zika-tutorial) looks like:
```
    "accession": "KX702400",
    "author": {
      "author": "Blohm et al",
      "journal": "Genome Announc 5 (17), e00231-17 (2017)",
      "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28450510",
      "title": "Complete Genome Sequences of Identical Zika virus Isolates in a Nursing Mother and Her Infant",
      "value": "Blohm (2017)"
    },
    "div": 0.004561105829182921,
    ...
```

The corresponding auspice branch which reflects these changes can be seen at https://github.com/nextstrain/auspice/pull/741

## The "unique" key of authorship
Auspice needs some way of traversing the tree & collecting the list of authors to display. Since auspice simply displays this value (unless we build in special cases) it helps to have a key which is human readable as opposed to a "citekey"-like syntax. Additionally, @trvrb pointed out possible collisions with "citekey"-like syntax.

Here I've made `augur export` collect all the unique Author -> Year -> Title triplets and rename them (e.g.) "Blohm (2017)" (see above). If Multiple papers exist for the same author in the same year, they would be (e.g.) "Blohm (2017) a", "Blohm (2017) b", etc. This is nicely displayed in auspice:

![image](https://user-images.githubusercontent.com/8350992/61342900-f7131480-a89f-11e9-9655-3e5357c433d8.png)

I can think of 2 bugs which could result from this, both of which relate to URL consistency over different builds:
1. If build A contains only one Bedford paper for 2019, then the key will be "Bedford (2019)", which can be stored in the URL if we filter to that author. If a later build contains 2 bedford papers for 2019 they will be "Bedford (2019) a" and  "Bedford (2019) b", and the previous URL won't filter to any authors. 
2. If a build contains 2 Neher papers from 2019, and a subsequent build contains 3, then "Neher (2019) a" may refer to different papers in the two builds. 

## JSON size increases:
Using the zika tutorial as an example:
uncompressed: 137739B -> 142236B (3% increase)
compressed: 14782B -> 14877B (0.6% increase)

## Other points
* The paper URL (now called `paper_url`) is now correctly output from `augur export`. The validate errors are much reduced, but they will still be printed on every mismatch. This should be improved.
* @emmahodcroft I've changed the code for how colorings are produced, which will conflict with #314. I'll sort this out when we merge.



