### PR TITLE
Prevent Bad Error if 'vcftools' not Present

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -90,6 +90,14 @@ def run(args):
         if args.sequences.lower().endswith('.gz'):
             is_compressed = True
 
+    ### Check users has vcftools. If they don't, a one-blank-line file is created which
+    #   allows next step to run but error very badly.
+    if is_vcf:
+        from shutil import which
+        if which("vcftools") is None:
+            print("ERROR: 'vcftools' is not installed! This is required for VCF data. "
+                  "Please see the augur install instructions to install it.")
+            return 1
 
     ####Read in files
 

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -16,6 +16,7 @@ def get_mask_sites(vcf_file, mask_file):
 
     #Need CHROM name from VCF file:
     import gzip
+    chromName = None
     opn = gzip.open if vcf_file.lower().endswith('.gz') else open
     with opn(vcf_file, mode='rt') as f: #'rt' necessary for gzip
         for line in f:
@@ -23,6 +24,11 @@ def get_mask_sites(vcf_file, mask_file):
                 header = line.strip().split('\t')
                 chromName = header[0]
                 break   # once chrom is found, no need to go through rest
+
+    if chromName is None or not chromName:
+        print("ERROR: Something went wrong reading your VCF file: a CHROM column could not be found. "
+              "Please check the file is valid VCF format.")
+        return None
 
     #Read in BED file - 2nd column always chromStart, 3rd always chromEnd
     #I timed this against sets/update/sorted; this is faster
@@ -73,6 +79,8 @@ def run(args):
         return 1
 
     tempMaskFile = get_mask_sites(args.sequences, args.mask)
+    if tempMaskFile is None:
+        return 1
 
     #Read in/write out according to file ending
     inCall = "--gzvcf" if args.sequences.lower().endswith('.gz') else "--vcf"

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -57,6 +57,20 @@ def run(args):
 
     If users don't specify output, will overwrite the input file.
     '''
+    # Check files exist and are not empty
+    if not os.path.isfile(args.sequences):
+        print("ERROR: File {} does not exist!".format(args.sequences))
+        return 1
+    if not os.path.isfile(args.mask):
+        print("ERROR: File {} does not exist!".format(args.mask))
+        return 1
+    if os.path.getsize(args.sequences) == 0:
+        print("ERROR: {} is empty. Please check how this file was produced. "
+              "Did an error occur in an earlier step?".format(args.sequences))
+        return 1
+    if os.path.getsize(args.mask) == 0:
+        print("ERROR: {} is an empty file.".format(args.mask))
+        return 1
 
     tempMaskFile = get_mask_sites(args.sequences, args.mask)
 


### PR DESCRIPTION
Brought to attention by issue #320 

If working with VCF data (ex: TB tutorial), if `vcftools` is not installed, a file with one blank line is output from `augur filter` (first step of tutorial) as `filtered.vcf.gz`. `augur mask` then tries to process this. However, the error that's produced is:
`UnboundLocalError: local variable 'chromName' referenced before assignment`

Which gives absolutely no information as to what the original problem was (in the previous step!).

I added some checks for existing and empty files in `mask.py` but this actually doesn't solve this problem, as the file isn't 'empty' (size 0). 

The problem is caused because the call is something like:
`vcftools --remove-indv G22696 --gzvcf data/lee_2015.vcf.gz --recode --stdout | gzip -c > results/filtered.vcf.gz`

When the `vcftools` part fails, the `gzip` part goes ahead and zips up nothing, creating the one-blank-line file. 

Interestingly, this is *not* caught by `utils.py` function `run_shell_command` (which is what puts the call through). This function uses `subprocess.check_call` to check the call is successful - but apparently this does not catch `/bin/sh: 1: vcftools: not found`. (I could not find much info about this online; it proved hard to google.)

It seemed the simplest way to address this was just to check if `vcftools` was installed (if using VCF data) at the beginning of `filter` and give the user a useful error message about it. I did this with `which` from `shutil`. 

It might be preferable to implement this somehow in `run_shell_command` in a more general way, so that any external program call is checked - but I was unsure whether we could reliably break off the first bit of the command sent to `run_shell_command` as the part to check. 
