### PR TITLE
Remove dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ You can also install from a git clone or other copy of the source code by runnin
 
 If your system has both Python 2 and Python 3 installed side-by-side, you may need to use `pip3` or `python3 -m pip` instead of just `pip` (which often defaults to Python 2 when both Python versions are installed).
 
+This install depends on a fairly minimal set of external Python libraries. There are some
+functions in augur that require a larger set of dependencies. These can be installed via:
+
+    pip install .[full]
+
 Augur uses some common external bioinformatics programs which you'll need to install to have a fully functioning toolkit:
 
 * `augur align` requires [mafft](https://mafft.cbrc.jp/alignment/software/)

--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -618,7 +618,7 @@ class TiterModel(object):
         try:
             from cvxopt import matrix, solvers
         except ImportError:
-            raise ImportError("To infer titer models, you a working installation of cvxopt")
+            raise ImportError("To infer titer models, you need a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         n_genetic = self.genetic_params
         n_sera = len(self.sera)
@@ -661,7 +661,7 @@ class TiterModel(object):
         try:
             from cvxopt import matrix, solvers
         except ImportError:
-            raise ImportError("To infer titer models, you a working installation of cvxopt")
+            raise ImportError("To infer titer models, you need a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         P = matrix(np.dot(self.design_matrix.T, self.design_matrix) + self.lam_drop*np.eye(n_params))
         q = matrix( -np.dot( self.titer_dist, self.design_matrix))
@@ -682,7 +682,7 @@ class TiterModel(object):
         try:
             from cvxopt import matrix, solvers
         except ImportError:
-            raise ImportError("To infer titer models, you a working installation of cvxopt")
+            raise ImportError("To infer titer models, you need a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         n_genetic = self.genetic_params
         n_sera = len(self.sera)

--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -618,7 +618,7 @@ class TiterModel(object):
         try:
             from cvxopt import matrix, solvers
         except ImportError:
-            raise("To infer titer models, you a working installation of cvxopt")
+            raise ImportError("To infer titer models, you a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         n_genetic = self.genetic_params
         n_sera = len(self.sera)
@@ -661,7 +661,7 @@ class TiterModel(object):
         try:
             from cvxopt import matrix, solvers
         except ImportError:
-            raise("To infer titer models, you a working installation of cvxopt")
+            raise ImportError("To infer titer models, you a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         P = matrix(np.dot(self.design_matrix.T, self.design_matrix) + self.lam_drop*np.eye(n_params))
         q = matrix( -np.dot( self.titer_dist, self.design_matrix))
@@ -682,7 +682,7 @@ class TiterModel(object):
         try:
             from cvxopt import matrix, solvers
         except ImportError:
-            raise("To infer titer models, you a working installation of cvxopt")
+            raise ImportError("To infer titer models, you a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         n_genetic = self.genetic_params
         n_sera = len(self.sera)

--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -615,7 +615,10 @@ class TiterModel(object):
         TYPE
             Description
         '''
-        from cvxopt import matrix, solvers
+        try:
+            from cvxopt import matrix, solvers
+        except ImportError:
+            raise("To infer titer models, you a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         n_genetic = self.genetic_params
         n_sera = len(self.sera)
@@ -655,7 +658,10 @@ class TiterModel(object):
 
 
     def fit_nnl2reg(self):
-        from cvxopt import matrix, solvers
+        try:
+            from cvxopt import matrix, solvers
+        except ImportError:
+            raise("To infer titer models, you a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         P = matrix(np.dot(self.design_matrix.T, self.design_matrix) + self.lam_drop*np.eye(n_params))
         q = matrix( -np.dot( self.titer_dist, self.design_matrix))
@@ -673,7 +679,10 @@ class TiterModel(object):
         TYPE
             Description
         '''
-        from cvxopt import matrix, solvers
+        try:
+            from cvxopt import matrix, solvers
+        except ImportError:
+            raise("To infer titer models, you a working installation of cvxopt")
         n_params = self.design_matrix.shape[1]
         n_genetic = self.genetic_params
         n_sera = len(self.sera)

--- a/setup.py
+++ b/setup.py
@@ -25,20 +25,20 @@ setup(
     url = "https://github.com/nextstrain/augur",
     project_urls = {
         "Bug Reports": "https://github.com/nextstrain/augur/issues",
-        "Change Log":  "https://github.com/nextstrain/augur/blob/master/CHANGES.md#next",
-        "Source":      "https://github.com/nextstrain/augur",
+        "Change Log": "https://github.com/nextstrain/augur/blob/master/CHANGES.md#next",
+        "Source": "https://github.com/nextstrain/augur",
     },
     packages = ['augur'],
     package_data = {'augur': ['data/*']},
     data_files = [("", ["LICENSE.txt"])],
     python_requires = '>=3.4',
     install_requires = [
-        "bcbio-gff >=0.6.4, ==0.6.*",
-        "biopython >=1.73, ==1.*",
-        "jsonschema ==3.0.0a3",
-        "pandas >=0.23.4",
-        "phylo-treetime >=0.6.2, ==0.6.*",
-        "snakemake >=5.5.4, ==5.*"
+        "bcbio-gff >=0.6.0, ==0.6.*",
+        "biopython >=1.67, ==1.*",
+        "jsonschema >=3.0.0, ==3.*",
+        "pandas >=0.20.0, ==0.*",
+        "phylo-treetime >=0.5.6, <0.7",
+        "snakemake >=5.4.0, ==5.*"
     ],
     extras_require = {
         'full': [
@@ -49,12 +49,12 @@ setup(
         'dev': [
             "pylint >=1.7.6, ==1.7.*",
             "pytest >=3.2.1, ==3.*",
-            "recommonmark >=0.5.0",
-            "Sphinx >=2.0.1",
-            "sphinx-argparse >=0.2.5",
-            "sphinx-rtd-theme >=0.4.3",
+            "recommonmark >=0.5.0, ==0.*",
+            "Sphinx >=2.0.1, ==2.*",
+            "sphinx-argparse >=0.2.5, ==0.*",
+            "sphinx-rtd-theme >=0.4.3, ==0.*",
             "wheel >=0.32.3, ==0.32.*",
-            "ipdb >=0.10.1"
+            "ipdb >=0.10.1, ==0.*"
         ]
     },
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from setuptools import setup
 from pathlib    import Path
+from setuptools import setup
 
-base_dir     = Path(__file__).parent.resolve()
+base_dir = Path(__file__).parent.resolve()
 version_file = base_dir / "augur/__version__.py"
-readme_file  = base_dir / "README.md"
+readme_file = base_dir / "README.md"
 
 # Eval the version file to get __version__; avoids importing our own package
 with version_file.open() as f:
@@ -14,66 +14,65 @@ with readme_file.open(encoding = "utf-8") as f:
     long_description = f.read()
 
 setup(
-        name = "nextstrain-augur",
-        version = __version__,
-        author = "Nextstrain developers",
-        author_email = "trevor@bedford.io, richard.neher@unibas.ch",
-        description = "A bioinformatics toolkit for phylogenetic analysis.",
-        long_description = long_description,
-        long_description_content_type = "text/markdown",
-        keywords = "nextstrain, molecular epidemiology",
-        url = "https://github.com/nextstrain/augur",
-        project_urls = {
-            "Bug Reports": "https://github.com/nextstrain/augur/issues",
-            "Change Log":  "https://github.com/nextstrain/augur/blob/master/CHANGES.md#next",
-            "Source":      "https://github.com/nextstrain/augur",
-        },
-        packages=['augur'],
-        package_data={'augur': ['data/*']},
-        data_files = [("", ["LICENSE.txt"])],
-        python_requires = '>=3.4',
-        install_requires = [
-            "bcbio-gff >=0.6.4, ==0.6.*",
-            "biopython >=1.73, ==1.*",
-            "jsonschema ==3.0.0a3",
-            "pandas >=0.23.4",
-            "phylo-treetime >=0.6.2, ==0.6.*",
-            "snakemake >=5.5.4, ==5.*"
+    name = "nextstrain-augur",
+    version = __version__,
+    author = "Nextstrain developers",
+    author_email = "trevor@bedford.io, richard.neher@unibas.ch",
+    description = "A bioinformatics toolkit for phylogenetic analysis",
+    long_description = long_description,
+    long_description_content_type = "text/markdown",
+    keywords = "nextstrain, molecular epidemiology",
+    url = "https://github.com/nextstrain/augur",
+    project_urls = {
+        "Bug Reports": "https://github.com/nextstrain/augur/issues",
+        "Change Log":  "https://github.com/nextstrain/augur/blob/master/CHANGES.md#next",
+        "Source":      "https://github.com/nextstrain/augur",
+    },
+    packages = ['augur'],
+    package_data = {'augur': ['data/*']},
+    data_files = [("", ["LICENSE.txt"])],
+    python_requires = '>=3.4',
+    install_requires = [
+        "bcbio-gff >=0.6.4, ==0.6.*",
+        "biopython >=1.73, ==1.*",
+        "jsonschema ==3.0.0a3",
+        "pandas >=0.23.4",
+        "phylo-treetime >=0.6.2, ==0.6.*",
+        "snakemake >=5.5.4, ==5.*"
+    ],
+    extras_require = {
+        'full': [
+            "cvxopt >=1.1.9, ==1.1.*",
+            "matplotlib >=2.0, ==2.*",
+            "seaborn >=0.9.0, ==0.9.*"
         ],
-        extras_require = {
-            'full': [
-                "cvxopt >=1.1.9, ==1.1.*",
-                "matplotlib >=2.0, ==2.*",
-                "seaborn >=0.9.0, ==0.9.*"
-            ],
-            'dev': [
-                "pylint >=1.7.6, ==1.7.*",
-                "pytest >=3.2.1, ==3.*",
-                "recommonmark >=0.5.0",
-                "Sphinx >=2.0.1",
-                "sphinx-argparse >=0.2.5",
-                "sphinx-rtd-theme >=0.4.3",
-                "wheel >=0.32.3, ==0.32.*",
-                "ipdb >=0.10.1"
-            ]
-        },
-        classifiers=[
-            "Development Status :: 3 - Alpha",
-            "Topic :: Scientific/Engineering :: Bio-Informatics",
-            "License :: OSI Approved :: GNU Affero General Public License v3",
+        'dev': [
+            "pylint >=1.7.6, ==1.7.*",
+            "pytest >=3.2.1, ==3.*",
+            "recommonmark >=0.5.0",
+            "Sphinx >=2.0.1",
+            "sphinx-argparse >=0.2.5",
+            "sphinx-rtd-theme >=0.4.3",
+            "wheel >=0.32.3, ==0.32.*",
+            "ipdb >=0.10.1"
+        ]
+    },
+    classifiers = [
+        "Development Status :: 3 - Alpha",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+        "License :: OSI Approved :: GNU Affero General Public License v3",
 
-            # Python 3 only; pathlib is >=3.4
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.4",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: 3.6",
-            ],
-
-        # Install an "augur" program which calls augur.__main__.main()
-        #   https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation
-        entry_points = {
-            "console_scripts": [
-                "augur = augur.__main__:main",
-            ],
-        },
-        )
+        # Python 3 only; pathlib is >=3.4
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6"
+    ],
+    # Install an "augur" program which calls augur.__main__.main()
+    #   https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation
+    entry_points = {
+        "console_scripts": [
+            "augur = augur.__main__:main",
+        ]
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,9 @@ setup(
         install_requires = [
             "bcbio-gff >=0.6.4, ==0.6.*",
             "biopython >=1.73, ==1.*",
-            "boto >=2.38, ==2.*",
-            "cvxopt >=1.1.9, ==1.1.*",
             "jsonschema ==3.0.0a3",
             "pandas >=0.23.4",
-            "phylo-treetime >=0.5.6, ==0.5.*",
+            "phylo-treetime >=0.5.6, ==0.*",
             "snakemake >=5.1.5, ==5.*"
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
             "biopython >=1.73, ==1.*",
             "jsonschema ==3.0.0a3",
             "pandas >=0.23.4",
-            "phylo-treetime >=0.5.6, ==0.*",
+            "phylo-treetime >=0.5.6, =<0.7.0",
             "snakemake >=5.1.5, ==5.*"
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
             "biopython >=1.73, ==1.*",
             "jsonschema ==3.0.0a3",
             "pandas >=0.23.4",
-            "phylo-treetime >=0.5.6,<0.7",
+            "phylo-treetime >=0.6.2, ==0.6.*",
             "snakemake >=5.1.5, ==5.*"
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,12 @@ setup(
             "phylo-treetime >=0.6.2, ==0.6.*",
             "snakemake >=5.5.4, ==5.*"
         ],
-        extras_require={
+        extras_require = {
+            'full': [
+                "cvxopt >=1.1.9, ==1.1.*",
+                "matplotlib >=2.0, ==2.*",
+                "seaborn >=0.9.0, ==0.9.*"
+            ],
             'dev': [
                 "pylint >=1.7.6, ==1.7.*",
                 "pytest >=3.2.1, ==3.*",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
             "jsonschema ==3.0.0a3",
             "pandas >=0.23.4",
             "phylo-treetime >=0.6.2, ==0.6.*",
-            "snakemake >=5.1.5, ==5.*"
+            "snakemake >=5.5.4, ==5.*"
         ],
         extras_require={
             'dev': [

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
             "biopython >=1.73, ==1.*",
             "jsonschema ==3.0.0a3",
             "pandas >=0.23.4",
-            "phylo-treetime >=0.5.6, =<0.7.0",
+            "phylo-treetime >=0.5.6,<0.7",
             "snakemake >=5.1.5, ==5.*"
         ],
         extras_require={


### PR DESCRIPTION
this removes cvxopt and boto as core dependencies. boto wasn't used, cvxopt is only used by the titer model and will now raise an ImportError complaining about the lack of cvxopt. I also relax the treetime version to include recent bugfixes, incl the one by @trvrb 