### PR TITLE
color scales are exported as arrays so as to preserve supplied ordering

### DIFF
--- a/augur/data/schema.json
+++ b/augur/data/schema.json
@@ -143,16 +143,16 @@
                         },
                         "scale": {
                             "description": "Provided mapping between trait values & hex values",
-                            "$comment": "If type is continuous or ordinal, values between those provided here are interpolated",
+                            "$comment": "TODO: If type is continuous or ordinal, values between those provided here are interpolated",
                             "$comment": "If type is categorical, values not present here are grey",
-                            "$comment": "If type is boolean, use \"1\" (true) and \"0\" (false) as properties",
-                            "type": "object",
-                            "patternProperties": {
-                                "^.+$": {
-                                    "description": "color hex value",
-                                    "type": "string",
-                                    "pattern": "^#[0-9A-Fa-f]{6}$"
-                                }
+                            "$comment": "TODO: If type is boolean, use \"1\" (true) and \"0\" (false) as properties",
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": [
+                                    {"type": "string", "description": "value of trait (should exist on >= 1 nodes)"},
+                                    {"type": "string", "description": "color hex value", "pattern": "^#[0-9A-Fa-f]{6}$"}
+                                ]
                             }
                         }
                     }

--- a/augur/validate_v2.py
+++ b/augur/validate_v2.py
@@ -172,14 +172,14 @@ def verifyMainJSONIsInternallyConsistent(main):
                 error("The coloring \"{}\" does not appear as an attr on any tree nodes.".format(colorBy))
             if "scale" in data["colorings"][colorBy]:
                 scale = data["colorings"][colorBy]["scale"]
-                if isinstance(scale, dict):
-                    for value, hex in scale.items():
+                if isinstance(scale, list):
+                    for value, hex in scale:
                         if value not in treeTraits[colorBy]["values"]:
                             warn("Color option \"{}\" specifies a hex code for \"{}\" but this isn't ever seen on the tree nodes.".format(colorBy, value))
-                elif isinstance(scale, list):
-                    error("List colour scales are invalid")
-                else:
+                elif isinstance(scale, str):
                     error("String colour scales are not yet implemented")
+                else:
+                    error("Invalid color scale (for trait \"{}\")".format(colorBy))
             if "domain" in data["colorings"][colorBy]:
                 domain = data["colorings"][colorBy]["domain"]
                 if data["colorings"][colorBy]["type"] in ["ordinal", "categorical"]:


### PR DESCRIPTION
See https://github.com/nextstrain/auspice/pull/748 