### PR TITLE
Minor Validate Fixes

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -126,7 +126,7 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
-                "^[A-Za-z_-]+$": {
+                "^[A-Za-z0-9_-]+$": {
                     "type": "object",
                     "required": ["title", "type"],
                     "properties": {
@@ -286,7 +286,7 @@
                             "type": "array",
                             "items": {
                               "oneOf": [
-                                {"type": "string", "pattern": "^[ATCGN-][0-9]+[ATCGN-]$"},
+                                {"type": "string", "pattern": "^[ATCGNYRWSKMDVHB-][0-9]+[ATCGNYRWSKMDVHB-]$"},
                                 {"type": "string", "pattern": "^insertion [0-9]+-[0-9]+$", "$comment": "TODO unused by auspice"},
                                 {"type": "string", "pattern": "^deletion [0-9]+-[0-9]+$", "$comment": "TODO unused by auspice"}
                               ]

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -702,7 +702,7 @@ def run_v2(args):
     except ValidateError as e:
         print(e)
         print("\n------------------------")
-        print("Validation of {} failed. Please check this in a local instance of `auspice` as we expect it to not to work in auspice. ".format(args.output_main))
+        print("Validation of {} failed. Please check this in a local instance of `auspice`, as it is not expected to display correctly. ".format(args.output_main))
         print("------------------------")
 
 

--- a/augur/validate_export.py
+++ b/augur/validate_export.py
@@ -69,7 +69,10 @@ def verifyMainJSONIsInternallyConsistent(data, ValidateError):
     Check all possible sources of conflict within the main (unified) JSON
     This function is only used for schema v2.0
     """
+    warnings = False
     def warn(msg):
+        nonlocal warnings
+        warnings = True
         print("\tWARNING: ", msg, file=sys.stderr)
 
 
@@ -139,6 +142,10 @@ def verifyMainJSONIsInternallyConsistent(data, ValidateError):
                 if gene not in data["genome_annotations"]:
                     warn("The tree defined mutations on gene {} which doesn't appear in the metadata annotations object.".format(gene))
 
+    if not warnings:
+        print("Validation succeeded")
+    else:
+        print("Validation failed")
 
 
 def collectTreeAttrsV1(root):


### PR DESCRIPTION
Changes to stop two validate errors that I didn't think seemed appropriate:

Allows ambiguous bases in nucleotide mutations ("YRWSKMDVHB"). This does not support 'X' which is listed by some places as an ambig base. Personally for nucleotides I think 'N' is better, but do we want this to cause an error if people have Xs in nuc data?

Allows numbers in trait names.