### PR TITLE
Override Fixes for Filters and Panels

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -536,7 +536,7 @@ def register_arguments_v2(subparsers):
     config.add_argument('--maintainer-urls', metavar="url", nargs='+', help="URL of maintainers")
     config.add_argument('--geography-traits', metavar="trait", nargs='+', help="What location traits are used to plot on map")
     config.add_argument('--extra-traits', metavar="trait", nargs='+', help="Metadata columns not run through 'traits' to be added to tree")
-    config.add_argument('--panels', default=['tree', 'map', 'entropy'], nargs='+', help="Restrict panel display in auspice. Options are %(default)s. Ignore this option to display all available panels.")
+    config.add_argument('--panels', metavar="panels", nargs='+', choices=['tree', 'map', 'entropy', 'frequencies'], help="Restrict panel display in auspice. Options are %(choices)s. Ignore this option to display all available panels.")
 
     optional_inputs = v2.add_argument_group(
         title="OPTIONAL INPUTS"
@@ -685,10 +685,11 @@ def run_v2(args):
     if genome_annotations:
         auspice_json["genome_annotations"] = genome_annotations
 
-    # Set up panels for both config and command-line
+    # Set up panels - command line overrides config
+    panels = None #if this remains, defaults will be set in process_panels
     if config.get("panels"):
         panels = config["panels"]
-    else:
+    if args.panels:
         panels = args.panels
     auspice_json["panels"] = process_panels(panels, auspice_json)
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -659,13 +659,6 @@ def run_v2(args):
     node_metadata = transfer_metadata_to_strains(strains, raw_strain_info, traits)
     set_author_on_nodes(node_metadata, raw_strain_info)
 
-    # Set up filters
-    if config.get('filters'):
-        auspice_json['filters'] = config['filters']
-        if "authors" in auspice_json['filters']:
-            del auspice_json['filters'][auspice_json['filters'].index("authors")]
-            auspice_json['filters'].append("author")
-
     add_metadata_to_tree(auspice_json["tree"], node_metadata)
 
     auspice_json["colorings"] = get_colorings(
@@ -675,6 +668,15 @@ def run_v2(args):
         node_metadata=node_metadata,
         mutations_present=bool(check_muts(node_metadata))
     )
+
+    # Set up filters - if in config but empty, no filters.
+    if config.get('filters') or config.get('filters') == []:
+        auspice_json['filters'] = config['filters']
+        if "authors" in auspice_json['filters']:
+            del auspice_json['filters'][auspice_json['filters'].index("authors")]
+            auspice_json['filters'].append("author")
+    else: # if not specified, include all boolean and categorical colorbys
+        auspice_json['filters'] = [key for key,value in auspice_json["colorings"].items() if value['type'] in ['categorical', 'boolean']]
 
     auspice_json["geographic_info"] = process_geographic_info(config, args.geography_traits, read_lat_longs(args.lat_longs), node_metadata)
 


### PR DESCRIPTION
In effort to get CL to override `config` in a sensible way, some changes to how `filters` and `panels` work.

There is no way to specify `filters` in CL-only. If using CL-only, all colorby traits that are categorical or boolean will appear as filters.

However, we want there to be more options when using `config`. Therefore:
* If there is no `filters` in `config`, behaves as if CL-only, above
* If there is `filters` in `config`, then only those listed in this get a filter
* If there is `filters` in `config` but it is empty, there are no filters (provides a way to have none)

_(In a way this leads to `config` overriding CL, but as there is no actual CL option for `filters` (just a default behaviour if you don't specify 'either'), I presume this is ok)_

-----

The default `arg` values for `panels` are removed, as these led to there always 'being' a CL option, even if the user did not give one - and if CL overrides `config`, then the config option was always ignored, even when `--panels` wasn't explicitly used in CL. 

Now panels is `None` by default, overwritten by `config` if present, and overwritten again by CL if present. If it remains `None`, is determined by `process_panels` function.