### PR TITLE
Allow "?" for URL attributes in schema

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -308,7 +308,7 @@
                     "description": "URL of the sequence (usually https://www.ncbi.nlm.nih.gov/nuccore/...)",
                     "$comment": "terminal nodes only",
                     "type": "string",
-                    "pattern": "^https?://.+$"
+                    "pattern": "(^https?://.+$)|(^[?]$)"
                 },
                 "author": {
                     "description": "Author information (terminal nodes only)",
@@ -330,7 +330,7 @@
                         "paper_url": {
                             "description": "URL link to paper (if available)",
                             "type": "string",
-                            "pattern": "^https?://.+$"
+                            "pattern": "(^https?://.+$)|(^[?]$)"
                         }
                     }
                 },


### PR DESCRIPTION
I was just working through Zika v2 export. If I run https://github.com/nextstrain/zika/tree/v2 on augur branch `v6`, I get the following:
```
Validating produced JSON
	ERROR: '?' does not match '^https?://.+$'. Trace: ... - properties - author - properties - paper_url - pattern
	ERROR: '?' does not match '^https?://.+$'. Trace: ... - properties - author - properties - paper_url - pattern
	ERROR: '?' does not match '^https?://.+$'. Trace: ... - properties - author - properties - paper_url - pattern
	ERROR: '?' does not match '^https?://.+$'. Trace: ... - properties - author - properties - paper_url - pattern
	ERROR: '?' does not match '^https?://.+$'. Trace: ... - properties - author - properties - paper_url - pattern
	ERROR: '?' does not match '^https?://.+$'. Trace: ... - properties - author - properties - paper_url - pattern
	ERROR: '?' does not match '^https?://.+$'. Trace: ... - properties - author - properties - 
...
Validation failed.
```

(There is a long list of validation errors.) I believe that a `?` should be an allowed value for both `paper_url` and `url`. Not all sequences will have associated papers (or even be available online). With this change to the schema, this set of errors disappears. 

Absence of this data was encoded as `?` in the Zika `metadata.tsv`. We may want to generalize this more, but accounting for `?` solves the Zika export issue.