### PR TITLE
Add support for keeping polytomies in tree inference and refinement

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -106,6 +106,7 @@ def register_arguments(parser):
                                 "rates and/or rerooting. "
                                 "Use --no-covariance to turn off.")
     parser.add_argument('--no-covariance', dest='covariance', action='store_false')  #If you set help here, it displays 'default: True' - which is confusing!
+    parser.add_argument('--keep-polytomies', action='store_true', help='Do not attempt to resolve polytomies')
     parser.add_argument('--date-format', default="%Y-%m-%d", help="date format")
     parser.add_argument('--date-confidence', action="store_true", help="calculate confidence intervals for node dates")
     parser.add_argument('--date-inference', default='joint', choices=["joint", "marginal"],
@@ -194,7 +195,7 @@ def run(args):
                     branch_length_inference = args.branch_length_inference or 'auto',
                     clock_rate=args.clock_rate, clock_std=args.clock_std_dev,
                     clock_filter_iqd=args.clock_filter_iqd,
-                    covariance=args.covariance)
+                    covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies))
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,
                               'intercept': tt.date2dist.intercept,


### PR DESCRIPTION
Makes two changes to the augur command line interface including:

  1. the addition of an `--extra-args` argument for `augur tree` that allows
  users to pass arguments directly to their chosen tree building method
  2. the addition of a `--keep-polytomies` flag for `augur refine` that prevents
  TreeTime from trying to resolve polytomies when it increases the likelihood

The first change allows users to specify the IQ-TREE flag "-czb" that collapses
"zero branches", maintaining polytomies in the raw tree. The second change
allows users to keep those polytomies in the time tree. This change is copied
directly from the existing `--keep-polytomies` flag in the TreeTime command line
interface.