### PR TITLE
Config file & CL Overrides - All Major Qs Answered

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -650,8 +650,10 @@ def run_v2(args):
     # Ensures we get all traits even if not on every node
     traits = get_traits(node_data)
     # Get first line of metdata to know metadata columns
-    with open(args.metadata) as f:
-        meta_cols = f.readline().strip().split('\t' if args.metadata[-3:]=='tsv' else ',')
+    meta_cols = []
+    if args.metadata:
+        with open(args.metadata) as f:
+            meta_cols = f.readline().strip().split('\t' if args.metadata[-3:]=='tsv' else ',')
 
     # remove keys which may look like traits but are not
     excluded_traits = [

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -698,9 +698,10 @@ def run_v2(args):
         mutations_present=bool(check_muts(node_metadata))
     )
 
-    # Set up filters - if in config but empty, no filters.
+    # Set up filters - if "filters" is in config but empty - no filters.
+    # Only allow filters that are actually in traits...
     if config.get('filters') or config.get('filters') == []:
-        auspice_json['filters'] = config['filters']
+        auspice_json['filters'] = [f for f in config['filters'] if f in traits]
         if "authors" in auspice_json['filters']:
             del auspice_json['filters'][auspice_json['filters'].index("authors")]
             auspice_json['filters'].append("author")

--- a/tests/builds/various_export_settings/Snakefile
+++ b/tests/builds/various_export_settings/Snakefile
@@ -157,7 +157,7 @@ rule export_with_boolean_metadata:
             --tree {input.tree} \
             --node-data {input.branch_lengths} \
             --metadata {input.metadata} \
-            --extra-traits top_half_True_False top_half_1_0 top_half_yes_no all_missing \
+            --color-by-metadata top_half_True_False top_half_1_0 top_half_yes_no all_missing \
             --colors {input.colors} \
             --title "Boolean metadata traits" \
             --output-main {output.auspice};


### PR DESCRIPTION
With the desire to have CL arguments override `config` file came a few questions about exactly how this would work for more complicated stuff. I've been working with James on this in detail, and I believe have a proposal that addresses all the goals:

## What is a Colorby

Outline of what we want:
- Sensible default runs when using (the simpler) CL-only
- A way to control color-by options both in CL and config - with CL overriding config
  - This is difficult with current CL default where everything from `--node-data` plus `--extra-traits` stuff is automatically a colorby
- Always auto-include genotype and date if available - user never has to specify<sup>1</sup>
- Easy way to include output from `augur clades` and `augur seqtraits`. 
  - `augur clades` generates `clade_membership` and `clade_annotation`, both internal names users have never seen, and shouldn't have to learn in order to include
  - `augur seqtraits` generates a highly variable number of traits that are on any particular tree (ex: as DRM in TB, there are 10 drugs where resistance is possible, unknown before running how many are on tree and thus need to be included)
  - Users should never have to write names of traits that _aren't in their metadata_ (ex: `clade_membership`) - they are our internal names and users should not have to learn them!
- No data should go on the tree 'in secret' - if it's not a colorby, geo, or filter, it shouldn't be written out - the user may not realise it's there!

<sup>1</sup> User can put them in config if they want to change `title` (can't change `type`)


### Colorbys and Traits
Some of this (in the code at least) has been further confused because we haven't done much to distinguish colorbys and traits. **TRAITS** are data written onto the nodes of the tree. These include nuc and AA muts, numdate, and more. **COLORBYS** are traits that can be used to colour the tree. Colorbys are always traits but traits are not always colorbys. For the map to work, `country` must be a trait, but it does not have to be a colorby.

To clarify this further, `--traits-to-color` has been replaced with `--color-by-metadata`. More details on how this is different below.

### How we decide what's a Colorby

Things like genotype, author, date are handled separately and always included as **traits** and **colorbys** if present - but these are separate from below code flow:

- Everything passed in via `--node-data` is read in as a **trait**
- Any **traits** that are in `metadata` file are excluded
- What remains will be auto-colorbys (ex: `clade_membership`, DRM data) (more below)
- Any requested geo terms (country, region) are added to **traits**
- Only `--color-by-metadata`<sup>2</sup> entries are **colorbys**, plus any auto-colorbys above
- Any **colorbys** missing from **traits** are added to **traits**
- Only **colorbys** and **traits** are written to the JSON (no data is 'secretly' written out)

<sup>2</sup> Or in `config` if using _only_ `config` - override rules addressed below.

Caveats:
- Special treatment is needed for anything to be a node label - both AA and Clade. This will have to continue to be manually detected.
- Special treatment is needed to auto-set `clade_membership` `title` to 'Clade' so it displays more prettily without users having to learn internal names (see above). This will continue to have to be manually detected.

Going forward:
- This would be easy to expand upon. If you change/predict/modify/add things that are in `metadata`, it needs to be explicitly included (ex: `--metadata-color-by`) to be a colorby. If someone makes a new function that generates new internal names (ex: `coalescent_prob`), they will be automatically included if passed to `--node-data` without users having to know about them.
- For the moment if any of these needed manual adjusting (`title` setting or putting as a node label) this would have to be done manually in `export v2`
- In future we can move towards redoing `augur clades` and `augur seqtraits` so that the output JSON includes all the info `export v2` needs to auto-add node labels and set `title` (if needed), and any new functions can use this format

----
## CL and `config` Override Rules

For anything with both a CL and `config` option, the CL option will override the `config`. The only way to get the `config` option to be valid is to not use the CL argument.

There are 3 exceptions (which do not all except in the same way):
- Display defaults
- Filters
- Colorbys

#### Display defaults
- No way to specify in CL. Defaults are set by `auspice`
- Anything set in `config` is used.

#### Filters
- No way to specify in CL. If no `config`, all colorbys that are categorical or boolean will be filters automatically
- If there is a `config`:
  - If there is no `filters` in `config`, behaves as if CL-only, above
  - If there is `filters` in `config`, then only those listed in this get a filter (must also be in `traits`)
  - If there is `filters` in `config` but it is empty, there are no filters (provides a way to have none)

#### Colorbys
- Colorbys can be set in CL (`--metadata-color-by`) but `title` and `type` cannot by set in CL alone.
- If using CL:
  - If no `config`, all entries in `--metadata-color-by` are given guessed types and variable titles
  - If `config`, _only_ entries in `--metadata-color-by` are used, with `type` and `title` taken from `config` if present (If there are more/fewer entries in `config` they are irrelevant.)
- If using `config`:
  - Only entries in `config` `colorings` will be used (with `type` and `title` used if present, and guessed if not)

In short, unless using `config` alone, `config` can provide `title` and `type` to entries already given in CL, but that's it. 
I can give a chart of examples if anyone wants.

-----
##Remaining questions:
Currently it seems like (?) `author` is always a colorby if present. Is this what we want

'Date' is a bit complicated. `numdate` (the decimal date which includes any estimated dates) is auto-included as a trait and colorby. `date` is the column in the metadata: only on tips, non-decimal, may be ambiguous. Currently if users ask to colorby `date` things get weird. How should we handle this? (Not allow users to pass 'date' in to `--metadata-color-by'?)
