### PR TITLE
Update V6 author export

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -334,11 +334,17 @@ def set_author_on_nodes(node_metadata, raw_strain_info):
 
         node["author"] = {"author": author}
         if "title" in raw_strain_info[strain]:
-            node["author"]["title"] = raw_strain_info[strain]["title"].strip()
+            title = raw_strain_info[strain]["title"].strip()
+            if isValueValid(title):
+                node["author"]["title"] = title
         if "journal" in raw_strain_info[strain]:
-            node["author"]["journal"] = raw_strain_info[strain]["journal"].strip()
-        if "paper_url" in raw_strain_info[strain] and not raw_strain_info[strain]["paper_url"].strip("/").endswith("pubmed"):
-            node["author"]["paper_url"] = raw_strain_info[strain]["paper_url"].strip()
+            journal = raw_strain_info[strain]["journal"].strip()
+            if isValueValid(journal):
+                node["author"]["journal"] = journal
+        if "paper_url" in raw_strain_info[strain]:
+            paper_url = raw_strain_info[strain]["paper_url"].strip()
+            if isValueValid(paper_url) and not paper_url.strip("/").endswith("pubmed"):
+                node["author"]["paper_url"] = paper_url
 
         # add to `seen` which will later be used to create the unique value which auspice will display
         year_matches = re.findall(r'\([0-9A-Z-]*(\d{4})\)', node["author"].get("journal", ""))

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -343,7 +343,7 @@ def set_author_on_nodes(node_metadata, raw_strain_info):
                 node["author"]["journal"] = journal
         if "paper_url" in raw_strain_info[strain]:
             paper_url = raw_strain_info[strain]["paper_url"].strip()
-            if isValueValid(paper_url) and not paper_url.strip("/").endswith("pubmed"):
+            if isValueValid(paper_url):
                 node["author"]["paper_url"] = paper_url
 
         # use author_tuple to make a unique list of citations to disambiguate


### PR DESCRIPTION
This PR addresses issue #343 and also improves on failed PR #342.

1. The first change in commit c63813a04fc48f8f441cc4c5791f3617ebe26df6 is to not export keys like `"paper_url": "?"` in the auspice JSON. This was causing validation errors of the sort:
```
ERROR: '?' does not match '^https?://.+$'. Trace: ... - properties - author - properties - paper_url - pattern
```

2. The second change in commit f0e4b1c314fdfc367693195aebc8f04b3ca27df2 is to update how `author.value` is assigned. Previously, it resulted in `Hadfied (2018) a`, `Hadfield (2018) b`, etc... I didn't like how this interacted with filters as described in issue #343, as the filters would then contain text like "Hadfield (2018) a (2)", "Hadfield (2018) b (5)". I found the use of numbers as years vs numbers as counts and the duel parenthesis to be confusing. The updated behavior results in `Hadfield et al A`, `Hadfield et al B`. The `et al` is just flowed through from the `authors.authors` key. A single author paper would still be `Neher A`, `Neher B`. The disambiguation of A, B, C... occurs by comparing the full tuple of `author`, `title` and `journal` for each tip.

Previous filters for Zika:

<img width="819" alt="before" src="https://user-images.githubusercontent.com/1176109/62567827-e02d6580-b840-11e9-9e22-5b033d20cb47.png">

Updated filters for Zika:

<img width="819" alt="after" src="https://user-images.githubusercontent.com/1176109/62567842-e6bbdd00-b840-11e9-8cae-519e31c8a9ef.png">



_Resolves #343_