### PR TITLE
Run shell commands with more robust error checking

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -27,7 +27,7 @@ def find_executable(names, default = None):
 
     if exe is None:
         print("Unable to find any of %s in PATH=%s" % (names, os.environ["PATH"]))
-        print("Hint: You can install the missing program using conda or homebrew or apt-get.")
+        print("\nHint: You can install the missing program using conda or homebrew or apt-get.\n")
         raise Exception
 
     return exe

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -462,9 +462,10 @@ def run_shell_command(cmd, raise_errors = False, extra_env = None):
 
     except subprocess.CalledProcessError as error:
         print_error(
-            "shell exited {rc} when running: {cmd}",
+            "shell exited {rc} when running: {cmd}{extra}",
             rc  = error.returncode,
-            cmd = error.cmd,
+            cmd = error.cmd.replace("set -euo pipefail; ",""),
+            extra = "\nAre you sure this program is installed?" if error.returncode==127 else "",
         )
         if raise_errors:
             raise
@@ -496,7 +497,7 @@ def print_error(message, **kwargs):
     :func:`textwrap.dedent` and uses it to print an error message to
     ``sys.stderr``.
     """
-    print("ERROR: " + dedent(message.format(**kwargs)).lstrip("\n"), file = sys.stderr)
+    print("\nERROR: " + dedent(message.format(**kwargs)).lstrip("\n")+"\n", file = sys.stderr)
 
 
 def first_line(text):

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -8,6 +8,7 @@ from treetime.utils import numeric_date
 from collections import defaultdict
 from pkg_resources import resource_stream
 from io import TextIOWrapper
+from textwrap import dedent
 
 def myopen(fname, mode):
     if fname.endswith('.gz'):
@@ -437,7 +438,7 @@ def write_VCF_translation(prot_dict, vcf_file_name, ref_file_name):
 
 def run_shell_command(cmd, raise_errors = False, extra_env = None):
     """
-    Run the given command string via the shell with error checking.
+    Run the given command string via Bash with error checking.
 
     Returns True if the command exits normally.  Returns False if the command
     exits with failure and "raise_errors" is False (the default).  When
@@ -453,22 +454,49 @@ def run_shell_command(cmd, raise_errors = False, extra_env = None):
 
     try:
         # Use check_call() instead of run() since the latter was added only in Python 3.5.
-        subprocess.check_call(cmd, shell = True, env = env)
+        subprocess.check_call(
+            "set -euo pipefail; " + cmd,
+            shell = True,
+            executable = "/bin/bash",
+            env = env)
+
     except subprocess.CalledProcessError as error:
-        print(
-            "ERROR: {program} exited {returncode}, invoked as: {cmd}".format(
-                program    = cmd.split()[0],
-                returncode = error.returncode,
-                cmd        = cmd,
-            ),
-            file = sys.stderr
+        print_error(
+            "shell exited {rc} when running: {cmd}",
+            rc  = error.returncode,
+            cmd = error.cmd,
         )
         if raise_errors:
             raise
         else:
             return False
+
+    except FileNotFoundError as error:
+        print_error(
+            """
+            Unable to run shell commands using {shell}!
+
+            Augur requires {shell} to be installed.  Please open an issue on GitHub
+            <https://github.com/nextstrain/augur/issues/new> if you need assistance.
+            """,
+            shell = error.filename
+        )
+        if raise_errors:
+            raise
+        else:
+            return False
+
     else:
         return True
+
+
+def print_error(message, **kwargs):
+    """
+    Formats *message* with *kwargs* using :meth:`str.format` and
+    :func:`textwrap.dedent` and uses it to print an error message to
+    ``sys.stderr``.
+    """
+    print("ERROR: " + dedent(message.format(**kwargs)).lstrip("\n"), file = sys.stderr)
 
 
 def first_line(text):

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -464,7 +464,7 @@ def run_shell_command(cmd, raise_errors = False, extra_env = None):
         print_error(
             "shell exited {rc} when running: {cmd}{extra}",
             rc  = error.returncode,
-            cmd = error.cmd.replace("set -euo pipefail; ",""),
+            cmd = cmd,
             extra = "\nAre you sure this program is installed?" if error.returncode==127 else "",
         )
         if raise_errors:


### PR DESCRIPTION
Shell commands are now run under Bash's errexit, nounset, and pipefail
options.  These provide a "strict mode" for Bash that help errors be
caught more reliably and earlier in execution.

The default pipeline error handling tripped up augur filter/mask on VCF
input when vcftools was missing: the command appeared to succeed because
vcftools was invoked as the first part of a multi-command pipeline.

Since we're now explicitly using features of Bash and not defaulting to
/bin/sh, we go the extra mile to report a nicer error if the
near-ubiquitous /bin/bash isn't actually available.

In the future, we'll bypass the shell entirely by switching from shell
command strings to executing programs directly.  For now, that's a
larger change which will have to wait.

Resolves #329.