### PR TITLE
export_v2: Change node.strain to node.name

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -202,9 +202,9 @@
             "type" : "object",
             "$comment": "The phylogeny in a nested JSON structure",
             "additionalProperties": false,
-            "required": ["strain"],
+            "required": ["name"],
             "properties": {
-                "strain": {
+                "name": {
                     "description": "Strain name. Must be unique. No spaces",
                     "type": "string"
                 },

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -47,7 +47,7 @@ def convert_tree_to_json_structure(node, metadata, div=0, strains=None):
     """
     converts the Biopython tree structure to a dictionary that can
     be written to file as a json. This is called recursively.
-    Creates the strain property & divergence on each node
+    Creates the name property & divergence on each node
 
     input
         node -- node for which top level dict is produced.
@@ -63,14 +63,14 @@ def convert_tree_to_json_structure(node, metadata, div=0, strains=None):
     if div == 0 and 'mutation_length' not in metadata[node.name] and 'branch_length' not in metadata[node.name]:
         div = False
 
-    node_struct = {'strain': node.name}
+    node_struct = {'name': node.name}
     if div is not False: # div=0 is ok
         node_struct["div"] = div
 
     if strains is None:
-        strains = [node_struct["strain"]]
+        strains = [node_struct["name"]]
     else:
-        strains.append(node_struct["strain"])
+        strains.append(node_struct["name"])
 
     if node.clades:
         node_struct["children"] = []
@@ -466,7 +466,7 @@ def transfer_metadata_to_strains(strains, raw_strain_info, traits):
     return node_metadata
 
 def add_metadata_to_tree(node, metadata):
-    node.update(metadata[node["strain"]])
+    node.update(metadata[node["name"]])
     if "children" in node:
         for child in node["children"]:
             add_metadata_to_tree(child, metadata)


### PR DESCRIPTION
Re: Issue #185 
Update both the export-v2 schema and command to 
replace `node.strain` with `node.name`