### PR TITLE
Gff annotations

### DIFF
--- a/augur/data/schema-export-v1-meta.json
+++ b/augur/data/schema-export-v1-meta.json
@@ -68,7 +68,7 @@
                             "type": "number"
                         },
                         "end": {
-                            "description": "Gene end position (one-based, i.e. zero-based exclusive or BED format)",
+                            "description": "Gene end position (zero-based half open, i.e. BED format)",
                             "type": "number"
                         },
                         "strand": {

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -47,11 +47,11 @@
                     "properties": {
                         "seqid":{
                             "description": "Sequence on which the coordinates below are valid. Could be viral segment, bacterial contig, etc",
-                            "type": "str",
+                            "type": "string"
                         },
                         "type": {
                             "description": "Type of the feature. could be mRNA, CDS, or similar",
-                            "type": "str",
+                            "type": "string"
                         },
                         "start": {
                             "description": "Gene start position (one-based, following GFF format)",
@@ -63,7 +63,7 @@
                         },
                         "strand": {
                             "description": "Positive or negative strand",
-                            "type": "str",
+                            "type": "string",
                             "$comment": "not yet used by Auspice",
                             "enum": ["-","+"]
                         }

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -47,10 +47,12 @@
                     "properties": {
                         "seqid":{
                             "description": "Sequence on which the coordinates below are valid. Could be viral segment, bacterial contig, etc",
+                            "$comment": "currently unused by Auspice",
                             "type": "string"
                         },
                         "type": {
                             "description": "Type of the feature. could be mRNA, CDS, or similar",
+                            "$comment": "currently unused by Auspice",
                             "type": "string"
                         },
                         "start": {
@@ -58,13 +60,12 @@
                             "type": "number"
                         },
                         "end": {
-                            "description": "Gene end position (one-based, last position of feature, following GFF format)",
+                            "description": "Gene end position (one-based closed, last position of feature, following GFF format)",
                             "type": "number"
                         },
                         "strand": {
                             "description": "Positive or negative strand",
                             "type": "string",
-                            "$comment": "not yet used by Auspice",
                             "enum": ["-","+"]
                         }
                     }

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -45,19 +45,27 @@
                     "type": "object",
                     "$comment": "I imagine this can get more complex at some point",
                     "properties": {
+                        "seqid":{
+                            "description": "Sequence on which the coordinates below are valid. Could be viral segment, bacterial contig, etc",
+                            "type": "str",
+                        },
+                        "type": {
+                            "description": "Type of the feature. could be mRNA, CDS, or similar",
+                            "type": "str",
+                        },
                         "start": {
-                            "description": "Gene start position (zero-based, i.e. BED format)",
+                            "description": "Gene start position (one-based, following GFF format)",
                             "type": "number"
                         },
                         "end": {
-                            "description": "Gene end position (one-based, i.e. zero-based exclusive or BED format)",
+                            "description": "Gene end position (one-based, last position of feature, following GFF format)",
                             "type": "number"
                         },
                         "strand": {
                             "description": "Positive or negative strand",
+                            "type": "str",
                             "$comment": "not yet used by Auspice",
-                            "type": "number",
-                            "enum": [-1, 1]
+                            "enum": ["-","+"]
                         }
                     }
                 }

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -161,10 +161,20 @@ def process_geographic_info(jsn, lat_long_mapping, node_metadata=None, nodes=Non
 
 
 def process_annotations(node_data):
-    # treetime adds "annotations" to node_data
-    if "annotations" not in node_data: # if haven't run tree through treetime
+    # `augur translate` adds "annotations" to node_data
+    if "annotations" not in node_data:
         return None
-    return node_data["annotations"]
+    # starting with augur v6 the node data JSONs use GFF like syntax, i.e.
+    # [one-origin, inclusive], strand: "+" / "-"
+    # however v1 JSONs used [zero-origin, half-open), strand: "1" / "-1"
+    annotations = {}
+    for name, info in node_data["annotations"].items():
+        annotations[name] = {
+            "start": info["start"]-1,
+            "end": info["end"],
+            "strand": 0 if info["strand"] == "-" else 1
+        }
+    return annotations
 
 def process_panels(user_panels, meta_json):
     try:

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -321,7 +321,7 @@ def run(args):
     #
     # Note that BioPython FeatureLocations use
     # "Pythonic" coordinates: [zero-origin, half-open)
-    # Starting with v2 JSONs, we use coordinates: [one-origin, inclusive]
+    # Starting with augur v6 we use GFF coordinates: [one-origin, inclusive]
     annotations = {}
     for fname, feat in features.items():
         annotations[fname] = {'seqid':args.reference_sequence,

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -319,8 +319,9 @@ def run(args):
 
     ## glob the annotations for later auspice export
     #
-    # Note that both our JSON schema and BioPython FeatureLocations use
-    # "Pythonic" coordinates: [zero-origin, half-open).
+    # Note that BioPython FeatureLocations use
+    # "Pythonic" coordinates: [zero-origin, half-open)
+    # Starting with v2 JSONs, we use coordinates: [one-origin, inclusive]
     annotations = {}
     for fname, feat in features.items():
         annotations[fname] = {'seqid':args.reference_sequence,

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -323,13 +323,13 @@ def run(args):
     # "Pythonic" coordinates: [zero-origin, half-open).
     annotations = {}
     for fname, feat in features.items():
-        annotations[fname] = {'seqid':ref.id,
+        annotations[fname] = {'seqid':args.reference_sequence,
                               'type':feat.type,
                               'start':int(feat.location.start)+1,
                               'end':int(feat.location.end),
                               'strand': '+' if feat.location.strand else '-'}
     if is_vcf: #need to add our own nuc
-        annotations['nuc'] = {'seqid':"reference",
+        annotations['nuc'] = {'seqid':args.reference_sequence,
                               'type':ref.id,
                               'start': 1,
                               'end': len(ref),

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -323,13 +323,17 @@ def run(args):
     # "Pythonic" coordinates: [zero-origin, half-open).
     annotations = {}
     for fname, feat in features.items():
-        annotations[fname] = {'start':int(feat.location.start),
+        annotations[fname] = {'seqid':ref.id,
+                              'type':feat.type,
+                              'start':int(feat.location.start)+1,
                               'end':int(feat.location.end),
-                              'strand': feat.location.strand}
+                              'strand': '+' if feat.location.strand else '-'}
     if is_vcf: #need to add our own nuc
-        annotations['nuc'] = {'start': 0,
+        annotations['nuc'] = {'seqid':"reference",
+                              'type':ref.id,
+                              'start': 1,
                               'end': len(ref),
-                              'strand': 1}
+                              'strand': '+'}
 
     ## determine amino acid mutations for each node
     if is_vcf:

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -330,7 +330,7 @@ def run(args):
                               'strand': '+' if feat.location.strand else '-'}
     if is_vcf: #need to add our own nuc
         annotations['nuc'] = {'seqid':args.reference_sequence,
-                              'type':ref.id,
+                              'type':feat.type,
                               'start': 1,
                               'end': len(ref),
                               'strand': '+'}


### PR DESCRIPTION
Moves feature annotation to a subset of GFF syntax. Closes #187, as future extensions can be added by extending the GFF features we support as needed. This results in changes to the output of `augur translate` and `augur export v2` (see below). The format of mutations is unchanged.

### annotations

where | `start` | `end` | `strand` | `seqid` | `type`
--- | --- | --- | --- | --- | --- 
GFF input | 1-based | fully-closed | `"+"` or `"-"` | |
genbank input | 1-based  | fully-closed | `"+"` or `"-"` | |
`augur translate` output | 1-based | fully-closed |  `"+"` or `"-"` | included | included
`augur export v1` output | 0-based | half-open | `1` or `-1` | not included | not included
`augur export v2`  output | 1-based | fully-closed |  `"+"` or `"-"` | included | included

### mutations
nt & aa are both 1-based
