### PR TITLE
Exception for Duplicate Strain Names

### DIFF
--- a/augur/align.py
+++ b/augur/align.py
@@ -60,9 +60,13 @@ def run(args):
         output = "aligment.fasta"
 
     try:
-        seqs = {s.id:s for s in SeqIO.parse(seq_fname, 'fasta')}
-    except:
-        print("Cannot read sequences -- make sure the file %s exists and contains sequences in fasta format"%seq_fname)
+        seqs = SeqIO.to_dict(SeqIO.parse(args.sequences, 'fasta'))
+    except FileNotFoundError:
+        print("\nCannot read sequences -- make sure the file %s exists and contains sequences in fasta format"%seq_fname)
+        return 1
+    except ValueError as error:
+        print("\nERROR: Problem reading in {}:".format(args.sequences))
+        print(error)
         return 1
 
     if ref_name and (ref_name not in seqs):

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -107,11 +107,21 @@ def run(args):
 
     #if Fasta, read in file to get sequence names and sequences
     else:
-        seqs = {seq.id:seq for seq in SeqIO.parse(args.sequences, 'fasta')}
+        try:
+            seqs = SeqIO.to_dict(SeqIO.parse(args.sequences, 'fasta'))
+        except ValueError as error:
+            print("ERROR: Problem reading in {}:".format(args.sequences))
+            print(error)
+            return 1
         seq_keep = list(seqs.keys())
         all_seq = seq_keep.copy()
 
-    meta_dict, meta_columns = read_metadata(args.metadata)
+    try:
+        meta_dict, meta_columns = read_metadata(args.metadata)
+    except ValueError as error:
+        print("ERROR: Problem reading in {}:".format(args.metadata))
+        print(error)
+        return 1
 
 
     #####################################

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -75,7 +75,9 @@ def build_raxml(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_args
             os.remove("RAxML_result.%s"%(random_string))
 
     except:
-        print("TREE BUILDING FAILED, please inspect the raxml.log file\n")
+        print("ERROR: TREE BUILDING FAILED")
+        if os.path.isfile("RAxML_log.%s"%(random_string)):
+            print("Please see the log file for more details: {}".format("RAxML_log.%s"%(random_string)))
         T=None
 
     return T
@@ -119,7 +121,9 @@ def build_fasttree(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_a
         if clean_up:
             os.remove(log_file)
     except:
-        print("TREE BUILDING FAILED")
+        print("ERROR: TREE BUILDING FAILED")
+        if os.path.isfile(log_file):
+            print("Please see the log file for more details: {}".format(log_file))
         T=None
 
     return T
@@ -193,7 +197,9 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
                 if os.path.isfile(tmp_aln_file + ext):
                     os.remove(tmp_aln_file + ext)
     except:
-        print("TREE BUILDING FAILED")
+        print("ERROR: TREE BUILDING FAILED")
+        if os.path.isfile(log_file):
+            print("Please see the log file for more details: {}".format(log_file))
         T=None
     return T
 
@@ -415,7 +421,7 @@ def run(args):
         return 1
 
     end = time.time()
-    print("Building original tree took {} seconds".format(str(end-start)))
+    print("\nBuilding original tree took {} seconds".format(str(end-start)))
 
     if T:
         import json

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -57,8 +57,12 @@ def read_metadata(fname):
         meta_dict = {}
         for ii, val in metadata.iterrows():
             if hasattr(val, "strain"):
+                if val.strain in meta_dict:
+                    raise ValueError("Duplicate strain '{}'".format(val.strain))
                 meta_dict[val.strain] = val.to_dict()
             elif hasattr(val, "name"):
+                if val.name in meta_dict:
+                    raise ValueError("Duplicate name '{}'".format(val.name))
                 meta_dict[val.name] = val.to_dict()
             else:
                 print("ERROR: meta data file needs 'name' or 'strain' column")


### PR DESCRIPTION
A collaborator noticed that a bunch of sequences from Germany were missing from a big run - I'd never have noticed they were gone on my own given my unfamiliarity with the data, and the size of the run (about 70 missing from ~1400). (I'm also downsampling, so the final number isn't ~1400, either!)

Turns out due to a mess-up in metadata on their end, a bunch of sequences were being given the same strain name. When these are read in (in `filter` and `align`, they just overwrite each other in the dict, with no error. We also don't error if there are duplicate keys when reading in metadata (from `read_metadata` in `utils.py`). I think this would be a sensible thing to do.

For sequences this is pretty easy - I switched from using our own dict to using `Bio.SeqIO`'s function `to_dict` which raises a `ValueError` for duplicate keys. 

For metadata, I modified `read_metadata` so that it raises `ValueErrors` if there are duplicate keys. I added a catch to this in `filter` since I was working on it, to show a prettier error message, but this isn't necessary.

Should avoid having sneaky things like this happen in the background in future!