### PR TITLE
schema updates

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -27,7 +27,7 @@
                 }
             }
         },
-        "geographic_info": {
+        "geo_resolutions": {
             "description": "Traits to be interpreted as 'geo resolution' options -- i.e. associated with lat/longs & made points on the map",
             "type": "array",
             "uniqueItems": true,

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -33,7 +33,20 @@
             "uniqueItems": true,
             "minItems": 1,
             "items": {
-                "type": "string"
+                "type": "object",
+                "description": "An indiviual geo resolution",
+                "additionalProperties": false,
+                "required": ["key"],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "description": "Trait key - must be specified on nodes (e.g. 'country')"
+                    },
+                    "title": {
+                      "type": "string",
+                      "description": "The title to display in the geo resolution dropdown. Optional -- if not provided then `key` will be used."
+                    }
+                }
             }
         },
         "maintainers": {

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -98,32 +98,40 @@
                     "uniqueItems": true,
                     "minItems": 1
                 },
-                "geographic_info": {
+                "geo_resolutions": {
                     "description": "The available options for the geographic resolution dropdown, and their lat/long information",
-                    "$comment": "Properties here specify the values of the geographic resolution dropdown in Auspice. They must be specified on the tree via node -> traits -> X",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "patternProperties": {
-                        "^[a-z]+$": {
-                            "description": "The deme names & lat/long info for this geographic resolution",
-                            "$comment": "Each value defined across the tree needs to be present here, else Auspice cannot display the deme appropriately",
-                            "type": "object",
-                            "patternProperties": {
-                                "^[a-z_]+$": {
-                                    "description": "Lat/long info for this deme",
-                                    "$comment": "one day this may define a shape / polygon",
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "latitude": {
-                                            "type": "number",
-                                            "minimum": -90,
-                                            "maximum": 90
-                                        },
-                                        "longitude": {
-                                            "type": "number",
-                                            "minimum": -180,
-                                            "maximum": 180
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "description": "Each object here is an indiviual geo resolution",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "A value of the geographic resolution dropdown in Auspice, e.g. 'country'. It must be specified on nodes."
+                            },
+                            "demes": {
+                                "type": "object",
+                                "description": "The deme names & lat/long info for this geographic resolution",
+                                "$comment": "Each value defined across the tree needs to be present here, else Auspice cannot display the deme appropriately",
+                                "patternProperties": {
+                                    "^[a-z_]+$": {
+                                        "description": "Lat/long info for this deme",
+                                        "$comment": "one day this may define a shape / polygon",
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "latitude": {
+                                                "type": "number",
+                                                "minimum": -90,
+                                                "maximum": 90
+                                            },
+                                            "longitude": {
+                                                "type": "number",
+                                                "minimum": -180,
+                                                "maximum": 180
+                                            }
                                         }
                                     }
                                 }

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -106,10 +106,15 @@
                         "type": "object",
                         "description": "Each object here is an indiviual geo resolution",
                         "additionalProperties": false,
+                        "required": ["key", "demes"],
                         "properties": {
-                            "name": {
+                            "key": {
                                 "type": "string",
-                                "description": "A value of the geographic resolution dropdown in Auspice, e.g. 'country'. It must be specified on nodes."
+                                "description": "Trait key - must be specified on nodes (e.g. 'country')"
+                            },
+                            "title": {
+                              "type": "string",
+                              "description": "The title to display in the geo resolution dropdown. Optional -- if not provided then `key` will be used."
                             },
                             "demes": {
                                 "type": "object",

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -146,41 +146,40 @@
                 },
                 "colorings": {
                     "description": "Available colorBys for Auspice",
-                    "$comment": "Property names here match those found on node.traits, where node.traits[propertyName] defines the value of that coloring for that node",
-                    "$comment": "Property names are not displayed by auspice - use 'title' for this",
-                    "$comment": "Exceptions: property names 'num_date', 'gt' (genotype), 'authors' or 'citekey'",
-                    "$comment": "as their info is defined as a prop on the node itself (not node.traits)",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "patternProperties": {
-                        "^[A-Za-z0-9_-]+$": {
-                            "type": "object",
-                            "required": ["title", "type"],
-                            "properties": {
-                                "title": {
-                                    "description": "Text to be displayed in the \"color by\" dropdown and the tree legend",
-                                    "$comment": "string is parsed unchanged by Auspice",
-                                    "type": "string"
-                                },
-                                "type": {
-                                    "description": "Dictates how the color scale should be constructed",
-                                    "$comment": "The trait values (defined on tree nodes) must be numeric for continuous types, True / False for boolean, string or numeric for ordinal / categorical",
-                                    "type": "string",
-                                    "enum": ["continuous", "ordinal", "categorical", "boolean"]
-                                },
-                                "scale": {
-                                    "description": "Provided mapping between trait values & hex values",
-                                    "$comment": "TODO: If type is continuous or ordinal, values between those provided here are interpolated",
-                                    "$comment": "If type is categorical, values not present here are grey",
-                                    "$comment": "TODO: If type is boolean, use \"1\" (true) and \"0\" (false) as properties",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "description": "Each object here is an indiviual coloring, which will populate the sidebar dropdown in auspice",
+                        "required": ["key", "type"],
+                        "properties": {
+                            "key": {
+                                "description": "They key used to access the value of this coloring on each node",
+                                "type": "string"
+                            },
+                            "title": {
+                                "description": "Text to be displayed in the \"color by\" dropdown and the tree legend",
+                                "$comment": "string is parsed unchanged by Auspice",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Dictates how the color scale should be constructed",
+                                "$comment": "The trait values (defined on tree nodes) must be numeric for continuous types, True / False for boolean, string or numeric for ordinal / categorical",
+                                "type": "string",
+                                "enum": ["continuous", "ordinal", "categorical", "boolean"]
+                            },
+                            "scale": {
+                                "description": "Provided mapping between trait values & hex values",
+                                "$comment": "TODO: If type is continuous or ordinal, values between those provided here are interpolated",
+                                "$comment": "If type is categorical, values not present here are grey",
+                                "$comment": "TODO: If type is boolean, use \"1\" (true) and \"0\" (false) as properties",
+                                "type": "array",
+                                "items": {
                                     "type": "array",
-                                    "items": {
-                                        "type": "array",
-                                        "items": [
-                                            {"type": "string", "description": "value of trait (should exist on >= 1 nodes)"},
-                                            {"type": "string", "description": "color hex value", "pattern": "^#[0-9A-Fa-f]{6}$"}
-                                        ]
-                                    }
+                                    "items": [
+                                        {"type": "string", "description": "value of trait (should exist on >= 1 nodes)"},
+                                        {"type": "string", "description": "color hex value", "pattern": "^#[0-9A-Fa-f]{6}$"}
+                                    ]
                                 }
                             }
                         }

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -579,7 +579,7 @@ def register_arguments_v2(subparsers):
     config.add_argument('--title', type=str, metavar="title", help="Title to be displayed by auspice")
     config.add_argument('--maintainers', metavar="name", nargs='+', help="Analysis maintained by")
     config.add_argument('--maintainer-urls', metavar="url", nargs='+', help="URL of maintainers")
-    config.add_argument('--geography-traits', metavar="trait", nargs='+', help="What location traits are used to plot on map")
+    config.add_argument('--geo-resolutions', metavar="trait", nargs='+', help="What location traits are used to plot on map")
     config.add_argument('--color-by-metadata', metavar="trait", nargs='+', help="Metadata columns to include as coloring options")
     #config.add_argument('--extra-traits', metavar="trait", nargs='+', help="Metadata columns not run through 'traits' to be added to tree")
     config.add_argument('--panels', metavar="panels", nargs='+', choices=['tree', 'map', 'entropy', 'frequencies'], help="Restrict panel display in auspice. Options are %(choices)s. Ignore this option to display all available panels.")
@@ -709,8 +709,8 @@ def run_v2(args):
     auto_color_bys = traits.copy()
 
     # Add any specified geo traits - otherwise won't work!
-    if args.geography_traits:
-        traits.extend(args.geography_traits)
+    if args.geo_resolutions:
+        traits.extend(args.geo_resolutions)
         traits = list(set(traits)) #ensure no duplicates
 
     # GET COLORBYS
@@ -757,7 +757,7 @@ def run_v2(args):
     else: # if not specified, include all boolean and categorical colorbys
         auspice_json['meta']['filters'] = [key for key,value in auspice_json['meta']["colorings"].items() if value['type'] in ['categorical', 'boolean']]
 
-    geo_resolutions = process_geo_resolutions(config, args.geography_traits, read_lat_longs(args.lat_longs), node_metadata)
+    geo_resolutions = process_geo_resolutions(config, args.geo_resolutions, read_lat_longs(args.lat_longs), node_metadata)
     if geo_resolutions:
         auspice_json['meta']["geo_resolutions"] = geo_resolutions
 

--- a/augur/validate_export.py
+++ b/augur/validate_export.py
@@ -17,7 +17,7 @@ def collectTreeAttrsV2(root, warn):
     def recurse(node):
         nonlocal num_nodes, num_terminal
         num_nodes += 1
-        traits = node["traits"].keys()
+        traits = node.get("traits", {}).keys()
         for property in traits:
             # Process author info from node not traits
             if property == "authors":

--- a/augur/validate_export.py
+++ b/augur/validate_export.py
@@ -85,7 +85,7 @@ def verifyMainJSONIsInternallyConsistent(data, ValidateError):
 
     if "geo_resolutions" in data["meta"]:
         for geo_res in data["meta"]["geo_resolutions"]:
-            geoName = geo_res["name"]
+            geoName = geo_res["key"]
             deme_to_lat_longs = geo_res["demes"]
             if geoName not in treeTraits:
                 warn("The geographic resolution \"{}\" does not appear on any tree nodes.".format(geoName))

--- a/augur/validate_export.py
+++ b/augur/validate_export.py
@@ -83,18 +83,22 @@ def verifyMainJSONIsInternallyConsistent(data, ValidateError):
 
     treeTraits, _ = collectTreeAttrsV2(data["tree"], warn)
 
-    if "geographic_info" in data["meta"]:
-        for geoName in data["meta"]["geographic_info"]:
+    if "geo_resolutions" in data["meta"]:
+        for geo_res in data["meta"]["geo_resolutions"]:
+            geoName = geo_res["name"]
+            deme_to_lat_longs = geo_res["demes"]
             if geoName not in treeTraits:
-                warn("The geographic resolution \"{}\" does not appear as an attr on any tree nodes.".format(geoName))
-            else:
-                for geoValue in data["meta"]["geographic_info"][geoName]:
-                    if geoValue not in treeTraits[geoName]["values"]:
-                        warn("\"{}\", a value of the geographic resolution \"{}\", does not appear as a value of attr->{} on any tree nodes.".format(geoValue, geoName, geoName))
-                for geoValue in treeTraits[geoName]["values"]:
-                    if geoValue not in data["meta"]["geographic_info"][geoName]:
-                        warn("\"{}\", a value of the geographic resolution \"{}\", appears in the tree but not in the metadata.".format(geoValue, geoName))
-                        warn("\tThis will cause transmissions & demes involving this location not to be displayed in Auspice")
+                warn("The geographic resolution \"{}\" does not appear on any tree nodes.".format(geoName))
+                continue
+            # pass 1: check the demes in "geo_resolutions" are found on the tree
+            for geoValue in deme_to_lat_longs.keys():
+                if geoValue not in treeTraits[geoName]["values"]:
+                    warn("\"{}\", a value of the geographic resolution \"{}\", does not appear on any tree nodes.".format(geoValue, geoName))
+            # pass 1: check the demes across the tree are represented in "geo_resolutions"
+            for geoValue in treeTraits[geoName]["values"]:
+                if geoValue not in deme_to_lat_longs:
+                    warn("\"{}\", a value of the geographic resolution \"{}\", appears in the tree but not in the metadata.".format(geoValue, geoName))
+                    warn("\tThis will cause transmissions & demes involving this location not to be displayed in Auspice")
     else:
         if "map" in data["meta"]["panels"]:
             warn("Map panel was requested but no geographic_info was provided")

--- a/docs/exportv.md
+++ b/docs/exportv.md
@@ -97,8 +97,8 @@ Remember that generally **any command line options you use will override the sam
 * _(Previously the "panels" field in the your v1 config file.)_
 
 ##### Geography
-* Specify how you'd like to position samples on the map using `--geography-traits`. 
-* For many users, these might be "country" and "region". (ex: `--geography-traits country region`)
+* Specify how you'd like to position samples on the map using `--geo-resolutions`. 
+* For many users, these might be "country" and "region". (ex: `--geo-resolutions country region`)
 * _(Previously the "geo" field in your v1 config file.)_
 
 #### Traits

--- a/tests/builds/tb/Snakefile
+++ b/tests/builds/tb/Snakefile
@@ -248,7 +248,7 @@ rule export_v2:
             --title {params.title} \
             --maintainers {params.auth} \
             --maintainer-urls {params.url} \
-            --geography-traits {params.geo}
+            --geo-resolutions {params.geo}
         """
 
 rule clean:

--- a/tests/builds/tb/data/config_v2.json
+++ b/tests/builds/tb/data/config_v2.json
@@ -17,7 +17,7 @@
   }
  },
  "geo_resolutions": [
-   "location"
+   {"key": "location"}
  ],
  "filters": [
   "location",

--- a/tests/builds/tb/data/config_v2.json
+++ b/tests/builds/tb/data/config_v2.json
@@ -16,7 +16,7 @@
     "type": "categorical"
   }
  },
- "geographic_info": [
+ "geo_resolutions": [
    "location"
  ],
  "filters": [

--- a/tests/builds/tb_drm/Snakefile
+++ b/tests/builds/tb_drm/Snakefile
@@ -215,7 +215,7 @@ rule exportv2:
             --title {params.title} \
             --maintainers {params.auth} \
             --maintainer-urls {params.url} \
-            --geography-traits {params.geo}
+            --geo-resolutions {params.geo}
         """
 
 rule clean:

--- a/tests/builds/zika/config/auspice_config_v2.json
+++ b/tests/builds/zika/config/auspice_config_v2.json
@@ -21,8 +21,8 @@
     }
   },
   "geo_resolutions": [
-    "country",
-    "region"
+    {"key": "country", "title": "Country Custom Title"},
+    {"key": "region"}
   ],
   "maintainers": [
     ["Trevor Bedford", "http://bedford.io/team/trevor-bedford/"]

--- a/tests/builds/zika/config/auspice_config_v2.json
+++ b/tests/builds/zika/config/auspice_config_v2.json
@@ -20,7 +20,7 @@
         "type": "ordinal"
     }
   },
-  "geographic_info": [
+  "geo_resolutions": [
     "country",
     "region"
   ],


### PR DESCRIPTION
This PR implements a few requested schema changes & improves* the logic of `augur export v2`. Testing will need to use [this auspice branch](https://github.com/nextstrain/auspice/tree/config). I'll merge into v6 quickly so edits can be PRs on top of the v6 branch.

## Schema changes
As per #344, this moves the geographic (deme) information to the `geo_resolutions` property. As suggested in #344, this is now a list in order to guarantee correct ordering. It is also possible to specify a custom title, similar to `colorings`.

Mimicking this, `colorings` is also a list to guarantee ordering. See #344.

## `augur export v2` code cleanup
Over the past few months `export_v2.py` had seen many contributions as we implemented a slew of new features. Implementing the schema changes made me realise it had become overly confusing. This PR cleans it up by shifting things into named functions, and trying to contain each bit of logic into a single place / function. It's not perfect, but I believe much more readable and understandable. There are still areas of potential confusion, which I have tried to comment the best I can. These include:
* the interplay between node-data JSONs, command line colorings & config colorings, now contained in [this function](https://github.com/nextstrain/augur/blob/e80e376b0d5c3858b2f70541b25c7e3cd078d77b/augur/export_v2.py#L231)
* properties which are (depending on context) not available as colorings -- [see here](https://github.com/nextstrain/augur/blob/e80e376b0d5c3858b2f70541b25c7e3cd078d77b/augur/export_v2.py#L535)
* The creation of maintainers [here](https://github.com/nextstrain/augur/blob/e80e376b0d5c3858b2f70541b25c7e3cd078d77b/augur/export_v2.py#L693) - see #327 

I've tested and see no regressions, and apologise if I have overlooked anything.

cc @emmahodcroft 


