### PR TITLE
Fix Missing Variable Bug in Exportv2, Prettify Validate Warning

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -306,7 +306,7 @@ def set_geo_resolutions(data_json, config, command_line_traits, lat_long_mapping
             try:
                 deme_to_lat_longs[deme] = lat_long_mapping[(trait_info["key"].lower(), deme_search_value)]
             except KeyError:
-                warn("{}->{} did not have an associated lat/long value (matching performed in lower case). Auspice won't be able to display this location.".format(trait, deme))
+                warn("{}->{} did not have an associated lat/long value (matching performed in lower case). Auspice won't be able to display this location.".format(trait_info["key"], deme))
 
         if deme_to_lat_longs:
             data = {"key": trait_info["key"], "demes": deme_to_lat_longs}
@@ -314,7 +314,7 @@ def set_geo_resolutions(data_json, config, command_line_traits, lat_long_mapping
                 data["title"] = trait_info["title"]
             geo_resolutions.append(data)
         else:
-            warn("Geo resolution \"{}\" had no demes with supplied lat/longs and will be excluded from the exported \"geo_resolutions\".".format(trait))
+            warn("Geo resolution \"{}\" had no demes with supplied lat/longs and will be excluded from the exported \"geo_resolutions\".".format(trait_info["key"]))
 
     if geo_resolutions:
         data_json['meta']["geo_resolutions"] = geo_resolutions

--- a/augur/validate_export.py
+++ b/augur/validate_export.py
@@ -96,8 +96,8 @@ def verifyMainJSONIsInternallyConsistent(data, ValidateError):
             # pass 1: check the demes across the tree are represented in "geo_resolutions"
             for geoValue in treeTraits[geoName]["values"]:
                 if geoValue not in deme_to_lat_longs:
-                    warn("\"{}\", a value of the geographic resolution \"{}\", appears in the tree but not in the metadata.".format(geoValue, geoName))
-                    warn("\tThis will cause transmissions & demes involving this location not to be displayed in Auspice")
+                    warn("\"{}\", a value of the geographic resolution \"{}\", appears in the tree but not in the metadata."
+                        "\n\t\tThis will cause transmissions & demes involving this location not to be displayed in Auspice".format(geoValue, geoName))
     else:
         if "map" in data["meta"]["panels"]:
             warn("Map panel was requested but no geographic_info was provided")


### PR DESCRIPTION
Two warnings in `set_geo_resolutions` in `export_v2.py` had old variables that no longer existed. This would cause errors if those warnings tried to be displayed. I updated variables used.

(Note, we don't have any test for these kinds of warnings - I spotted this just thanks to pylint while doing something entirely different - happened to pull while `export_v2.py` open in my editor, and the two red dots appeared. (But I did test them for real before/after fixing.))

Also the warning output by `validate_export.py` was formatted a bit weird - I don't think we want two `warn` statements here (and def not one indented):
![image](https://user-images.githubusercontent.com/14290674/63943247-8733a480-ca6f-11e9-8d4d-c94b55ac59cd.png)

I changed it, now it shows:
![image](https://user-images.githubusercontent.com/14290674/63943269-9581c080-ca6f-11e9-8c44-210314f77ade.png)
