### PR TITLE
Use New `--maintainers` Argument

### DIFF
--- a/tests/builds/tb/Snakefile
+++ b/tests/builds/tb/Snakefile
@@ -229,8 +229,7 @@ rule export_v2:
         seq = rules.all.input.auspice_v2_seq
     params:
         title = '\'TB outbreak in Nunavik, Canada\'',
-        auth = "'Emma Hodcroft' 'John Brown'",
-        url = 'https://neherlab.org/emma-hodcroft.html http://www.google.com',
+        maints = "'Emma Hodcroft <https://neherlab.org/emma-hodcroft.html>' 'John Brown <http://www.google.com>'",
         geo = 'location',
         # extra_traits = 'host',
         # panels = 'tree map entropy frequencies'
@@ -246,8 +245,7 @@ rule export_v2:
             --output-main {output.main} \
             --output-sequence {output.seq} \
             --title {params.title} \
-            --maintainers {params.auth} \
-            --maintainer-urls {params.url} \
+            --maintainers {params.maints} \
             --geo-resolutions {params.geo}
         """
 

--- a/tests/builds/tb_drm/Snakefile
+++ b/tests/builds/tb_drm/Snakefile
@@ -198,8 +198,7 @@ rule exportv2:
         main = rules.all.input.auspice_main
     params:
         title = '\'TB with DRMs\'',
-        auth = "'Emma Hodcroft' 'John Brown'",
-        url = 'https://neherlab.org/emma-hodcroft.html http://www.google.com',
+        maints = "'Emma Hodcroft <https://neherlab.org/emma-hodcroft.html>' 'John Brown <http://www.google.com>'",
         geo = 'country',
         # extra_traits = 'host',
         # panels = 'tree map entropy frequencies'
@@ -213,8 +212,7 @@ rule exportv2:
             --lat-longs {input.geo_info} \
             --output-main {output.main} \
             --title {params.title} \
-            --maintainers {params.auth} \
-            --maintainer-urls {params.url} \
+            --maintainers {params.maints} \
             --geo-resolutions {params.geo}
         """
 


### PR DESCRIPTION
In response to discussions in issue #327 , this changes how "maintainers" and URLs are supplied via command-line argument. Nothing changes about how they are supplied via 'config'. 

Following @trvrb & @tsibley 's suggestions, there is now one argument `--maintainers`. It can be used to supply either a list of names and urls, like so:
```
--maintainers 'Nan Lin <url.com>' 'Otim Abiyo <url1.com>'
```

Or be used multiple times, like so:
```
--maintainers 'Nan Lin <url.com>'
--maintainers 'Otim Abiyo <url1.com>'
```

Or a combination of the two:
```
--maintainers 'Nan Lin <url.com>' 'Otim Abiyo <url1.com>'
--maintainers 'Maria Jose Fernandez <url2.com>'
```

URLs do not need to be provided. 

If passed in via `snakemake` `param`, they should be enclosed first in double-quotes, then in single quotes, like:
```
params:
      maints = "'Nan Lin <url.com>' 'Otim Abiyo <url1.com>'"
```