### PR TITLE
Better `geo`-related Export in `v2`

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -320,10 +320,21 @@ def set_geo_resolutions(data_json, config, command_line_traits, lat_long_mapping
         # straight overwrite -- not an extension of those which may be provided in the config
         traits = [{"key": x} for x in command_line_traits]
     elif config.get("geo_resolutions"):
-        traits = config.get("geo_resolutions")
+        config_geo = config.get("geo_resolutions")
+        # If is set up correctly as dict with "key", take it as-is
+        if all( (isinstance(entry, dict) and "key" in entry.keys()) for entry in config_geo):
+            traits = config.get("geo_resolutions")
+        # If is a list of strings, or mix of strings and dicts with "key", we can do this!
+        elif all( (isinstance(entry, dict) and "key" in entry.keys()) or isinstance(entry, str) for entry in config_geo):
+            traits = [entry if isinstance(entry, dict) else {"key": entry} for entry in config_geo]
+        else:
+            print("WARNING: [config file] 'geo_resolutions' is not in an acceptible format. The field is now list of strings, or list of dicts each with format {\"key\":\"country\"}")
+            print("\t It is being ignored - this run will have no geo_resolutions.\n")
+            return False
+
     elif config.get("geo"):
         traits = [{"key": x} for x in config.get("geo")]
-        deprecated("[config file] 'geo' has been replaced with 'geo_resolutions'. The field is now list of dicts each with format {'key':country}")
+        deprecated("[config file] 'geo' has been replaced with 'geo_resolutions'. The field is now list of strings, or list of dicts each with format {\"key\":\"country\"}")
     else:
         return False
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -308,7 +308,8 @@ def set_geo_resolutions(data_json, config, command_line_traits, lat_long_mapping
 
     def _transfer_geo_data(node):
         for g in geo_resolutions:
-            if g['key'] in node_attrs[node["name"]] and g['key'] not in node['node_attrs']:
+            if g['key'] in node_attrs[node["name"]] and g['key'] not in node['node_attrs'] \
+                and is_valid(node_attrs[node["name"]][g['key']]): # don't add if not valid!
                 node['node_attrs'][g['key']] = {"value":node_attrs[node["name"]][g['key']]}
 
         if "children" in node:
@@ -331,7 +332,6 @@ def set_geo_resolutions(data_json, config, command_line_traits, lat_long_mapping
             print("WARNING: [config file] 'geo_resolutions' is not in an acceptible format. The field is now list of strings, or list of dicts each with format {\"key\":\"country\"}")
             print("\t It is being ignored - this run will have no geo_resolutions.\n")
             return False
-
     elif config.get("geo"):
         traits = [{"key": x} for x in config.get("geo")]
         deprecated("[config file] 'geo' has been replaced with 'geo_resolutions'. The field is now list of strings, or list of dicts each with format {\"key\":\"country\"}")


### PR DESCRIPTION
I suppose I hadn't tried out the new `geo_resolutions` thing in `export v2`, but I just tried to quickly make a `v2` run from a `v1` config file, and was surprised at the message 
```
[config file] 'geo' has been replaced with 'geo_resolutions'. The field is now list of dicts each with format {'key':country}
```

Though I understand we want to pass as a list to preserve ordering, and allow users to have their own titles, it seems unnecessary to *require* this. If people just want basic `geo` functionality, I think we should allow them to just have a list of traits, as previously.

So there's some checks to allow a list of dicts with key, list of strings (which is converted to dict with key), or a mix of those. Anything else is ignored and the users is warned.

Example of formats accepted:
```
  "geo_resolutions": [
    {"key": "country", "title": "AwesomeCountry"}, {"key": "region"}
  ],
```
```
  "geo_resolutions": [
    {"key": "country"}, "region"
  ],
```
```
  "geo_resolutions": [
    "country", "region"
  ],
```
This should be updated in the docs.

Secondly, I discovered that though we're really careful about not exporting a trait if the node has an 'unknown' value (checked by `is_valid`) when transferring colorby values, we completely forget about this when we transfer the geo data! :)

This was leading to this error:
![image](https://user-images.githubusercontent.com/14290674/65264946-06b51080-db10-11e9-8151-31b239e8235c.png)

I've now added a check to the geo data transfer, so this shouldn't happen anymore.
