### PR TITLE
Export Zero-value Metadata in `export v1`

### DIFF
--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -259,7 +259,8 @@ def add_tsv_metadata_to_nodes(nodes, meta_tsv, meta_json, extra_fields=['authors
         if strain not in meta_tsv:
             continue
         for field in fields:
-            if field not in node and field in meta_tsv[strain] and meta_tsv[strain][field]:
+            # Allow fields to have value of 0!
+            if field not in node and field in meta_tsv[strain] and meta_tsv[strain][field] is not None:
                 node[field] = meta_tsv[strain][field]
 
 


### PR DESCRIPTION
I just noticed that `export v1` isn't exporting continuous-type metadata if the value is 0.

This was because this was a test whether to copy data from metadata to the nodes:
```
if field not in node and field in meta_tsv[strain] and meta_tsv[strain][field]:
```
And fails if the value is 0. I've changed this, and in my own dataset, now have zero-values being exported.

This is a long-standing bug, as the `age` legend for my D68 runs has always started not-at-zero:
![image](https://user-images.githubusercontent.com/14290674/65428665-0f119200-de15-11e9-983c-d678a93fec43.png)
And I never thought much of it. However, there are 0 values in the data, and with `console.log` I can see these never make it to Auspice. 
Legend now:
![image](https://user-images.githubusercontent.com/14290674/65428738-310b1480-de15-11e9-88b0-5ac12714d905.png)
