### PR TITLE
Detect Tab-Delim Lat-long Files

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -299,7 +299,7 @@ def read_lat_longs(overrides=None, use_defaults=True):
     def add_line_to_coordinates(line):
         if line.startswith('#'):
             return
-        fields = line.strip().split()
+        fields = line.strip().split() if not '\t' in line else line.strip().split('\t')
         if len(fields) == 4:
             geo_field, loc = fields[0].lower(), fields[1].lower()
             lat, long = float(fields[2]), float(fields[3])


### PR DESCRIPTION
This won't solve the whole tab-delim problem but I am currently working with a dataset where some location names have spaces, and need to match them up to self-generated GPS locations. 

Partially following @trs idea, I've added a line (in `v6`) to `read_lat_longs` in `util.py` which splits by tab if it detects tab in the line, else continues to split by whitespace (as was default until now). 

This allows traits to include spaces.

Shouldn't affect anything else. 