### PR TITLE
JSON version

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -9,7 +9,7 @@
         "version" : {
             "description": "JSON schema version",
             "type" : "string",
-            "pattern": "^[0-9]+[.][0-9]+$"
+            "pattern": "^v[0-9]+$"
         },
         "meta": {
             "type": "object",

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -792,7 +792,7 @@ def parse_node_data_and_metadata(T, node_data_files, metadata_file):
 
 def run_v2(args):
     configure_warnings()
-    data_json = {"version": "2.0", "meta": {"updated": time.strftime('%Y-%m-%d')}}
+    data_json = {"version": "v2", "meta": {"updated": time.strftime('%Y-%m-%d')}}
 
     # parse input files
     T = Phylo.read(args.tree, 'newick')


### PR DESCRIPTION
The exported JSON had set "version" to "2.0". We have decided to explicitly pin the JSON "version" to the version of auspice that reads this JSON. I thought that having a JSON of "2.0" could cause confusion if it's read by auspice version "2.2.0". 

By versioning JSON as "v2" it avoids this confusion.

This PR closes #335.

There is a companion PR in auspice to set version to "v2" when converting v1 to v2 JSONs here: https://github.com/nextstrain/auspice/pull/814.