### PR TITLE
Accurate `exclude-where` Counts Dispaly for `augur filter`

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -158,7 +158,7 @@ def run(args):
 
     # exclude strain my metadata field like 'host=camel'
     # match using lowercase
-    num_excluded_by_metadata = 0
+    num_excluded_by_metadata = {}
     if args.exclude_where:
         for ex in args.exclude_where:
             try:
@@ -175,7 +175,7 @@ def run(args):
                         if meta_dict[seq_name].get(col,'unknown').lower() == val.lower():
                             to_exclude.add(seq_name)
                 tmp = [seq_name for seq_name in seq_keep if seq_name not in to_exclude]
-                num_excluded_by_metadata = len(seq_keep) - len(tmp)
+                num_excluded_by_metadata[ex] = len(seq_keep) - len(tmp)
                 seq_keep = tmp
 
     # filter by sequence length
@@ -343,7 +343,8 @@ def run(args):
     if args.exclude:
         print("\t%i of these were dropped because they were in %s" % (num_excluded_by_name, args.exclude))
     if args.exclude_where:
-        print("\t%i of these were dropped because of '%s'" % (num_excluded_by_metadata, args.exclude_where))
+        for key,val in num_excluded_by_metadata.items():
+            print("\t%i of these were dropped because of '%s'" % (val, key))
     if args.min_length:
         print("\t%i of these were dropped because they were shorter than minimum length of %sbp" % (num_excluded_by_length, args.min_length))
     if (args.min_date or args.max_date) and 'date' in meta_columns:


### PR DESCRIPTION
Someone pointed out on our workshop that the numbers in the updated output for `augur filter` didn't always sum up properly. 

Ex, for the call: 
```
augur filter --sequences "data/all_sequences.fasta" --metadata "data/all_meta_clinical.tsv" --output "data/fltrtst.fas" --exclude-where "country=greece" "samptype=CSF" "country=bulgaria"
```

You get the display:
```
11 sequences were dropped during filtering
        2 of these were dropped because of '['country=greece', 'samptype=CSF', 'country=bulgaria']'
50 sequences have been written out to data/fltrtst.fas
```

The overall numbers are correct - 11 sequences are dropped and that leaves 50 to write out. However, obviously, more than 2 were excluded due to the `--exclude-where` arguments provided.

The problem is that number excluded was being overwritten by every new argument from `--exclude-where`, so only the number excluded by the last one was shown. Simple fix. 

Now the display is:
```
11 sequences were dropped during filtering
        2 of these were dropped because of 'country=greece'
        7 of these were dropped because of 'samptype=CSF'
        2 of these were dropped because of 'country=bulgaria'
50 sequences have been written out to data/fltrtst.fas
```
