### PR TITLE
Warn if v5 `export` Using a v6 Translate File

### DIFF
--- a/augur/export.py
+++ b/augur/export.py
@@ -188,7 +188,23 @@ def process_annotations(node_data):
     # treetime adds "annotations" to node_data
     if "annotations" not in node_data: # if haven't run tree through treetime
         return None
-    return node_data["annotations"]
+    v6_type_file = False
+    annotations = {}
+    for name, info in node_data["annotations"].items():
+        if info['strand'] in ['+','-']:
+            v6_type_file = True
+            annotations[name] = {
+                "start": info["start"]-1,
+                "end": info["end"],
+                "strand": 0 if info["strand"] == "-" else 1
+            }
+    if v6_type_file:
+        print("\nWARNING - The supplied amino acid mutations file appears to have been made"
+            " in a NEWER version of augur. We have attempted to convert it, but recommend re-running"
+            " the 'translate' step with this augur version, then running 'export' again.")
+        return annotations
+    else:
+        return node_data["annotations"]
 
 def process_panels(user_panels, meta_json, nextflu=False):
     try:


### PR DESCRIPTION
Address first part of issue #379 . Possibly less useful, as unlikely may people switch from `v6` back to `v5`. Can take or leave this as we see fit. 

Adds a check to `export` to look for v6-style `translate` files.

If the AA muts file seems to have been made with v6 `augur translate` (it has `strand` values of + or - rather than 0 or 1), then it will modify the provided `start` number and `strand` values to match the `v5` format.

It also prints a warning to the user saying it looks like the file is from a newer `augur` version, that we've tried to convert it, but that we recommend them re-running `translate` and then running `export` again.