### PR TITLE
Docs copy edit

### DIFF
--- a/docs/releases/auspice-compatibility.md
+++ b/docs/releases/auspice-compatibility.md
@@ -1,16 +1,16 @@
-# Compatibility between augur & auspice versions
+# Compatibility between Augur & Auspice versions
 
-From mid-2019, we're changing the format of the output file produced by `augur export` to allow us more flexibility going forward.
-This lines up with the version 2 release of `auspice` ([release notes](https://nextstrain.github.io/auspice/releases/v2)), which opens up exciting new possibilities. 
+From mid-2019, we're changing the format of the output file produced by `augur export` to allow more flexibility going forward.
+This lines up with the version 2 release of `auspice` ([release notes](https://nextstrain.github.io/auspice/releases/v2)), which opens up exciting new possibilities.
 
 We also recognise that we may need to adjust things again in the future. By setting up versions now, we'll be able to continue to expand `augur` and `auspice` while minimizing disruption to users.
 
-You can get more information on how to move to using `export v2` in `augur` 6.0 in our [handy guide](migrating-v5-v6.md).
+You can get more information on how to move to using `export v2` in `augur` v6.0 in our [handy guide](migrating-v5-v6.md).
 
-## Why Does Compatibility Matter?
+## Why does compatibility matter?
 
-To get great visualizations, the final step of the `augur` pipeline, `augur export` produces output as (a) JSON file(s)*.
-This/these file(s) are then read by `auspice` to produce trees, graphs, and maps. 
+To get great visualisations, the final step of the `augur` pipeline, `augur export` produces output as one or more JSON files*.
+The JSON(s) are then read by `auspice` to produce trees, graphs, and maps.
 
 *_This compatibility only refers to the JSON file(s) produced by `augur export`, not those produced by other `augur` steps._
 
@@ -40,7 +40,7 @@ But, we know that for a variety of reasons, you can't always do this straight aw
 **Auspice**
 
 | Auspice Version | Takes JSON |
-| -------------|---------------| 
+| -------------|---------------|
 | v1           | v1        |
 | v2          | v1 or v2 |
 

--- a/docs/releases/breaking.md
+++ b/docs/releases/breaking.md
@@ -1,6 +1,6 @@
 # Breaking Changes to `augur`
 
-This is a list of known 'breaking changes' to `augur`. These are changes that require users to modify existing scripts or calls to `augur` functions because the old usage is no longer supported. 'Depreciated' changes, which work for the moment but will no longer be supported in future, are also included. 
+This is a list of known 'breaking changes' to `augur`. These are changes that require users to modify existing scripts or calls to `augur` functions because the old usage is no longer supported. 'Deprecated' changes, which work for the moment but will no longer be supported in future, are also included.
 
 _Note this list only includes changes to `augur` code and may not cover breaking changes introduced due to changes in dependancy packages. We try to support these too, so please [open an issue](https://github.com/nextstrain/augur/issues/new) if you think you've found something we didn't catch._
 
@@ -24,7 +24,7 @@ Click on the `augur` function that used to work, and we'll try to get you up and
   To specify the JSON file to write ancestral mutations/sequences to, use the argument `--output-node-data` instead of `--output`.<br><br>
 
 * **Explanation:**<br>
-  `ancestral` now supports outputting a Fasta file of reconstructed ancestral sequences (for Fasta-input runs - this was already supported in VCF-format for VCF-input runs). Users can ask for this output and specify a file name using `--output-sequences`. Since there are now two types of output from `ancestral`, the arguments have become more descriptive.<br><br>
+  `ancestral` now supports outputting a FASTA file of reconstructed ancestral sequences (for FASTA-input runs - this was already supported in VCF-format for VCF-input runs). Users can ask for this output and specify a file name using `--output-sequences`. Since there are now two types of output from `ancestral`, the arguments have become more descriptive.<br><br>
 
 
 ## export

--- a/docs/releases/migrating-v5-v6.md
+++ b/docs/releases/migrating-v5-v6.md
@@ -9,20 +9,20 @@ TO DO:
 </span>
 
 
-Augur is a versitile bioinformatics toolkit in its own right, but it is developed in conjunction with [auspice](https://nextstrain.github.io/auspice), the interactive visualisation tool behind what you see on [nextstrain.org](https://nextstrain.org).
-Because of this, build pipelines often finish with `augur export` which produces JSONs that auspice to visualise.
+Augur is a versatile bioinformatics toolkit in its own right, but it is developed in conjunction with [Auspice](https://nextstrain.github.io/auspice), the interactive visualisation tool behind what you see on [nextstrain.org](https://nextstrain.org).
+Because of this, build pipelines often finish with `augur export` which produces JSONs that Auspice can visualise.
 
-As auspice grows and improves, the format of the JSON files is changing too, to allow more functionality and flexibility. This means augur's export function needs to change as well.
-This page details how the new `augur export v2` works & what you need to do to start using it.
+As Auspice grows and improves, the format of the JSON files is changing too, to allow more functionality and flexibility. This means Augur's export function needs to change as well.
+This page details how the new `augur export v2` works and what you need to do to start using it.
 
 Some important points:
-* 'Old' JSON files (v1, made with augur v5) still work with the new (v2) auspice for the time being - but may not be supported in future versions.
-* When you upgrade to augur v6, `augur export` will no longer work. You'll need to specify which version of auspice (v1 or v2) your JSON files should be.
+* 'Old' JSON files (v1, made with Augur v5) still work with the new (v2) Auspice for the time being - but may not be supported in future versions.
+* When you upgrade to Augur v6, `augur export` will no longer work. You'll need to specify which version of Auspice (v1 or v2) your JSON files should be.
 
 
 ---
 
-* [Compatability between augur & auspice versions](#compatability-between-augur-auspice-versions)
+* [Compatibility between Augur & Auspice versions](#compatability-between-augur-auspice-versions)
 * [Motivation behind changing JSON formats](#motivation-behind-changing-json-formats)
 * [I just need my old run to work _right now_!](#i-just-need-my-old-run-to-work-right-now)
 * [Terminology](#terminology)
@@ -31,23 +31,23 @@ Some important points:
 * [Prettifying metadata fields](#prettifying-metadata-fields)
 
 ---
-## Compatability between augur & auspice versions
+## Compatibility between Augur & Auspice versions
 
-Augur v5 simply used `augur export` to produce two JSONs (tree + meta) for auspice v1 - so we'll call these JSONs "v1" JSONs.
+Augur v5 simply used `augur export` to produce two JSONs (tree + meta) for Auspice v1 - so we'll call these JSONs "v1" JSONs.
 
-The new augur (v6) can still create "v1" JSONS, but can also create JSONs that work with the latest [auspice release](https://nextstrain.github.io/auspice/releases/v2) - auspice v2. The new format combines the tree and metadata into one JSON, which we'll call a "v2" JSON.
+The new Augur (v6) can still create "v1" JSONS, but can also create JSONs that work with the latest [Auspice release](https://nextstrain.github.io/auspice/releases/v2) - Auspice v2. The new format combines the tree and metadata into one JSON, which we'll call a "v2" JSON.
 
-[This page](auspice-compatibility) has the most up-to-date compatibility between different augur & auspice versions.
+[This page](Auspice-compatibility) has the most up-to-date compatibility information between different Augur and Auspice versions.
 
-> We understand how important backwards compatability is - so for the moment "v1" JSONs continue to work with auspice v2.
-However, we recommend switching to v2 JSONs - they have more features, are easier to work with, and future versions of auspice may not support v1 JSONs!
+> We understand how important backwards compatibility is - so for the time being "v1" JSONs will continue to work with Auspice v2.
+However, we recommend switching to v2 JSONs - they have more features, are easier to work with, and future versions of Auspice may not support v1 JSONs!
 
 
 ---
 
 ## Motivation behind changing JSON formats
 
-With the release of [auspice v2](https://nextstrain.github.io/auspice/releases/v2), we made some breaking changes to the JSON schema. 
+With the release of [Auspice v2](https://nextstrain.github.io/auspice/releases/v2), we made some breaking changes to the JSON schema.
 Why change formats? We were motivated by:
 
 * **Compactness**: Tree and Meta JSON files are now combined, so you only have to worry about one output file
@@ -61,25 +61,25 @@ Why change formats? We were motivated by:
 We completely understand you may not have time to make the change right this second, and that there's nothing more frustrating than having a run break right before a presentation or deadline!
 
 If you want to keep using the old version _for now_, replace `augur export` with `augur export v1` - everything else remains the same.
-You can use auspice v1 or auspice v2 (see [compatibility](auspice-compatibility)).
+You can use Auspice v1 or Auspice v2 (see [compatibility](auspice-compatibility)).
 
 To use the new version, use `augur export v2`.
-You'll need to make a few changes, but they are pretty simple, and you'll be future-proofing your runs.
+You'll need to make a few small changes, but you'll be future-proofing your runs.
 _(Future you will thank past you!)_
 
 ---
 ## What needs changing to use `augur export v2`?
 
-> _P.S. You can always get a full overview of the arguments for export v2 with `augur export v2 --help`_
+> _Helpful hint: You can always get a full overview of the arguments for export v2 with `augur export v2 --help`_
 
 **What's the same**
 
 You still pass in your tree, metadata, and node-data files with `--tree`, `--metadata`, and `--node-data` - just like in `export v1`.
-Similarly, you can pass in files containing colors and latitute and longitude data using `--colors` and `--lat-longs`, respectively.
+Similarly, you can pass in files containing colors, latitute, and longitude data using `--colors` and `--lat-longs`, respectively.
 
 **Different outputs**
 
-Instead of specifying two output files (`--output-tree` and `--output-meta`) you now just need to specify one with `--output`.
+Instead of specifying two output files (`--output-tree` and `--output-meta`) you now only need to specify one with `--output`.
 For example, if your old files were `auspice/virus_AB_tree.json` and `auspice/virus_AB_meta.json`, you might want to call the single output `auspice/virus_AB.json` - or if you want to tell it apart from your v1 export, you might call it `auspice/virus_ABv2.json`.
 
 
@@ -87,27 +87,27 @@ For example, if your old files were `auspice/virus_AB_tree.json` and `auspice/vi
 
 **Command Line Options instead of (or in addition to) a config file**
 
-One of the biggest changes in `augur export v2` is that you can pass much more in using the command-line, meaning 'config' files are no longer required. The 'config' or 'auspice config' file defines a number of visualisation settings such as title, default displays, and which colorings to use. However, it's been a source of pain for many users!
+One of the biggest changes in `augur export v2` is that you can pass much more in using the command-line, meaning 'config' files are no longer required. The 'config' or 'Auspice config' file defines a number of visualisation settings such as title, default displays, and which colorings to use. However, it's been a source of pain for many users!
 
-Many of these things can now be passed in by the command-line, but some options are only possible using the config file. And you can always continue to put most things in the config file if you prefer! If you want to use a [config file](#using-a-config-file-to-customise-the-visualisation), you can pass this in with `--auspice-config`, but the format of this has changed (see the link).
+Many of these things can now be passed in by the command-line, but some options are only possible using the config file. You can always continue to put most things in the config file if you prefer. If you want to use a [config file](#using-a-config-file-to-customise-the-visualisation), you can pass this in with `--auspice-config`, but the format of this has changed (see the link).
 
 It's important to note that generally _any command line options you use will override the same option in your config file_.
 
 **Coloring traits is smarter**
 
-Previously, anything you wanted to color by had to be in the config file. You always had to include a "gt" and "num_date" entry, and remember to add anything new to the file. 
+Previously, anything you wanted to color by had to be in the config file. You always had to include a "gt" and "num_date" entry, and remember to add anything new to the file.
 
-We've made this smarter - `augur export v2` now automatically detects some traits, and you can specify others easily on the command line. You can also control the color options in more detail using a config file.
+We've made this smarter - `augur export v2` now automatically detects some traits and you can specify others on the command line. You can also control the color options in more detail using a config file.
 
-We'll cover how coloring works on the [command line]() and how it works in [config files]() in more detail below. 
+We'll cover how coloring works on the [command line]() and how it works in [config files]() in more detail below.
 <span style="color:red">TODO: Can't make link to 'Traits' (in command-line section) or 'Colorings' (in config section) work as it's just bold, not a heading!</span>
 
 ---
 ## Terminology
 
 #### Traits
-Traits is the general term for certain data associated with nodes in the tree, for example "country" or "serotype" or "age".
-These may have been inferred for internal nodes by augur functions like `augur traits` (confusingly named!) and `augur clades`, or they may only be availiable for tips and provided by the metadata TSV file.
+Traits is the general term for certain data associated with nodes in the tree, for example "country", "serotype", or "age".
+These may have been inferred for internal nodes by Augur functions like `augur traits` (confusingly named!) and `augur clades`, or they may only be availiable for tips and provided by the metadata TSV file.
 
 ### Geographic Traits
 Certain traits have a geographic interpretation, e.g. "country".
@@ -121,7 +121,7 @@ Auspice will attempt to display these traits on a map (and provide a drop-down t
 ---
 ## Using command-line options to customise the visualisation
 
-As mentioned above, you can now replace most of the functionality of the "auspice config" file with command line options.
+As mentioned above, you can now replace most of the functionality of the "Auspice config" file with command line options.
 We hope that for most users this means the config file isn't necessary (but it's always there is you need its advanced functionality).
 
 > Remember that generally _any command line options you use will override the same option in your config file_.
@@ -129,9 +129,9 @@ We hope that for most users this means the config file isn't necessary (but it's
 
 **Title**
 
-Set the title displayed by auspice via `--title` (previously this was the "title" field in your v1 config file).
+Set the title displayed by Auspice via `--title` (previously this was the "title" field in your v1 config file).
 If running directly from the command line, put your title in quotes (ex: `--title "Phylodynamics of my Pathogen"`).
-If you are using snakemake and passing the value using `params`, you'll need to double-quote the title using single and double quotes. For example:
+If you are using Snakemake and passing the value using `params`, you'll need to double-quote the title using single and double quotes. For example:
 
 ```python
 params:
@@ -143,18 +143,18 @@ shell:
 
 **Maintainers**
 
-The maintainer(s) are displayed in the footer of auspice and may have associated links.
+The maintainer(s) are displayed in the footer of Auspice and may have associated links.
 These can be specified with `--maintainers` and you can now have more than one maintainer associated with your run.
 Previously this was set by the "maintainer" field in your v1 config file and was limited to a single entry.
 
-If running directly from the command line, put each maintainer in quotes (ex: `--maintainers "Jane Doe" "Ravi Kupra"`). 
+If running directly from the command line, put each maintainer in quotes (ex: `--maintainers "Jane Doe" "Ravi Kupra"`).
 If you have a URL associated with a maintainer (completely optional), then you can add them like so:
 
 ```
 --maintainers "Jane Doe <mailto:jane.doe@...>" "Ravi Kupra <https://github.com/ravikupra"
 ```
 
-If you are using snakemake and passing the value using `params`, you'll need to put the whole list in double quotes, and each person in single quotes. For example:
+If you are using Snakemake and passing the value using `params`, you'll need to put the whole list in double quotes, and each person in single quotes. For example:
 
 ```python
 params:
@@ -169,27 +169,27 @@ You will need to use quotes in the same way even if you only have one maintainer
 
 Auspice will, by default, try to show the tree, map, and entropy panels.
 You can customise this with the `--panels` option, which was previously the "panels" field in the your v1 config file.
-Options are "tree", "map", "entropy", and "frequencies". (e.g: `--panels tree map entropy`).
+Options are "tree", "map", "entropy", and "frequencies" (e.g: `--panels tree map entropy`).
 
-> If you want to display the frequencies panel, you must both specify "frequencies" here _and_ ensure a tip frequency file is available for `auspice` to access.
+> If you want to display the frequencies panel, you must specify "frequencies" _and_ ensure a tip frequency file is available for `auspice` to access.
 
 
 **Traits**
 
-_([What's a trait?](#traits))_ Traits will become coloring options in auspice. Some are automatically included, and some can be defined on the command line.
+_([What's a trait?](#traits))_ Traits will become coloring options in Auspice. Some are automatically included, and some can be defined on the command line.
 The following rules are followed for which traits will be exported:
 
 1. Genotype and date (if present) are always automatically included as coloring options - you don't need to include them.
 _(Previously these were "gt" and "numdate" in the "color_options" section of your v1 config file.)_
 
 2. Traits contained in the node-data JSONs handed to `augur export` (using `--node-data`) will automatically be included.
-These are often generated from the augur commands `traits`, `clades` or `seqtraits`. 
+These are often generated from the Augur commands `traits`, `clades` or `seqtraits`.
 
 3. Traits present in the metadata file can be included by specifying them with `metadata-color-by` (e.g: `--metadata-color-by country age host`). _(These must match column names of your metadata file.)_
 
 The changes hopefully make things a little easier to use -- previously, if you had run `augur clades`, you had to remember to add `clade_membership` to the config file, and if you'd run `augur seqtraits` you had to add every resulting option.
 Now, they'll be automatically included.
-If you don't want them as a coloring option, just don't pass in the files!
+If you don't want them as a coloring option, don't pass in the files.
 
 
 > _Note: You can't specify the title or type of a colouring option using just command-line - but `export v2` will make its best guess using the following rules:_
@@ -221,20 +221,20 @@ Currently, using command line arguments:
 ---
 ## Using a config file to customise the visualisation
 
-Traditionally you had to use an "auspice config file" to customise the visualisation.
+Traditionally you had to use an "Auspice config file" to customise the visualisation.
 This is still available as an option, but you can now choose between exporting using just the command-line, or using a combination of the command-line and config file.
 
 >_Anything you can specify using the command-line arguments above can be done using a config file instead._
 
 This section will detail the config file provided to `augur export v2` by the `--auspice-config` argument.
-The format of the new config file **differs slightly** to previous versions of augur.
+The format of the new config file **differs slightly** from previous versions of Augur.
 If you try to use a previous version of the config file it _should mostly_ still work, but will print out warnings where keys have changed.
 
 
 #### Config file priority
 It is important to remember that if you set an option both in the config file _and_ in the command line, **the command line option will override the config file option**.
-For example, if you set `"title"` in your config file as "A Title About Apples", and then import this config file using `--auspice-config` _and_ use `--title "Better Title Befitting Bears"`, the title displayed by auspice will be "Better Title Befitting Bears".
-To use the one in the config file, simply don't use `--title` in the command line!
+For example, if you set `"title"` in your config file as "A Title About Apples", and then import this config file using `--auspice-config` _and_ use `--title "Better Title Befitting Bears"`, the title displayed by Auspice will be "Better Title Befitting Bears".
+To use the one in the config file, don't use `--title` in the command line.
 
 
 There are a couple of exceptions to this:
@@ -250,7 +250,7 @@ The config file is a JSON file, and as such it's important that everything in yo
 These can be on a separate line at the very top and very bottom of your file.
 Syntax is important - if you are getting errors, ensure all your brackets and quotation marks match up, and that commas separate items in the same pair of brackets.
 
-Export v2 config files are generally very simliar to export v1, _but there are a few changes_. They are explained in detail below, or you can see [an example of converting a v1 config to v2](#updating-your-config-file). If you are familiar with JSON schemas, we have created one for the new config file [here](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-auspice-config-v2.json).
+Export v2 config files are generally very similar to export v1, _but there are a few changes_. They are explained in detail below, or you can see [an example of converting a v1 config to v2](#updating-your-config-file). If you are familiar with JSON schemas, we have created one for the new config file [here](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-auspice-config-v2.json).
 
 
 Here are the top-level keys of the config JSON in plain English:
@@ -278,24 +278,24 @@ Previously this was the "maintainer" field in your v1 config file and used a dif
 
 **Panels**
 
-Optional & unchanged from previous versions of the config file, this defines the panels which auspice will display.
-If not set, auspice will by default try to show the tree, map, and entropy panels, if data is available.
+Optional and unchanged from previous versions of the config file, this defines the panels that Auspice will display.
+If not set, Auspice will by default try to show the tree, map, and entropy panels, if data is available.
 Options are "tree", "map", "entropy", and "frequencies" (e.g: `"panels": ["tree", "map"]`).
 
-> If you want to display the frequencies panel, you must both specify "frequencies" here _and_ ensure a tip frequency file is available for `auspice` to access.
+> If you want to display the frequencies panel, you must specify "frequencies" _and_ ensure a tip frequency file is available for `auspice` to access.
 
 **Colorings**
 
-These are the traits which auspice should display as options to color the tree & map.
+These are the traits which Auspice should display as options to color the tree & map.
 In previous versions of the config file this was "color_options" and the current structure is very similar - but easier to understand!
 
 For each trait you include, you can define:
-* An optional "title" which will shown by auspice when referring to this trait -- for instance you may have a trait called "ab1" which you want to show as "Age bracket 1" in the drop-down menus, legend, and filter. 
+* An optional "title" which will shown by Auspice when referring to this trait -- for instance you may have a trait called "ab1" which you want to show as "Age bracket 1" in the drop-down menus, legend, and filter.
 * An optional, but recommended "type" which can be either 'ordinal', 'boolean', 'continuous', or 'categorical'. If you don't provide a type, augur will try to guess it (see how it guesses [here]()).
 
 <span style="color:red">TODO: Can't link to 'Traits' (in command-line section) (to show 'type' guessing rules) because it's just bold, not a header!</span>
 
-Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `augur seqtraits` output (like clade or drug resistance information) in your config file - if that information is present, it will automatically be included. To exclude it, simply don't pass in the corresponding file to `--node-data`.
+Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `Augur seqtraits` output (like clade or drug resistance information) in your config file - if that information is present, it will automatically be included. To exclude it, don't pass in the corresponding file to `--node-data`.
 
 > _Remember that if you are using `--metadata-color-by` on the command-line, only the traits given there will be color-by options!_
 _To include everything in your config file, don't use `--metadata-color-by`, but include all traits you want as coloring options in "colorings" in the config file._
@@ -309,7 +309,7 @@ You only need to also include it `"colorings"` in the config file if you want to
 
 **Geo_resolutions**
 
-This specifies the geographical traits you want auspice to use. You can pass this in the same way as in the v1 config file, or you can now specify a title to be displayed by option, using a slightly different structure.
+This specifies the geographical traits you want Auspice to use. You can pass this in the same way as in the v1 config file, or you can now specify a title to be displayed by option, using a slightly different structure.
 
 For example, for many users, these might be "country" and "region", i.e. `"geo_resolutions: ["country", "region"]`. If you want to give them new titles, use the format `"geo_resolutions": [{"key": "country", "title": "Areas"}, {"key": "region", "title": "Global"}]`.
 
@@ -318,7 +318,7 @@ You can also mix the two, if you just want a title for one location: `"geo_resol
 
 **Filters**
 
-This specifies which traits you can filter by in auspice.
+This specifies which traits you can filter by in Auspice.
 E.g. `"filters": ["country", "region", "symptom", "age"]`.
 If you don't include this option in your config file, all non-continuous traits that are coloring options will be included as filters.
 If you don't want any filter options, include this option with an empty list, i.e. `"filters": []`.
@@ -327,14 +327,14 @@ This is the same as the "filters" field in previous config files, but the behavi
 
 **Display_defaults**
 
-This allows you to specify the default view that users will see when they visualise the data in auspice.
+This allows you to specify the default view that users will see when they visualise the data in Auspice.
 There are five options you can set here -- note they are similar to those in the previous config files but we have now standardised them to snake_case:
 
 * `geo_resolution` - Sets which of the "geo_resolutions" should be shown. _Default is 'country'_
 * `color_by` - Sets what trait should be used for coloring. _Default is 'country'_
 * `distance_measure` - Sets whether tree branch lengths are in 'time' or 'divergence'.
 Options are `num_date` (time, default if available) or `div` (divergence).
-* `layout` - Sets how the tree is visualized.
+* `layout` - Sets how the tree is visualised.
 Options are `rect` (rectangular, default), `radial`, `unrooted`, and `clock`, corresponding to the four options normally shown on the left in Auspice.
 * `map_triplicate` - Sets whether the map is extended / wrapped around, which can be useful if transmissions are worldwide. Set to `true' or 'false'. _Default 'false'_
 
@@ -497,12 +497,12 @@ Export v2 config:
 
 <span style="color:red">TODO: add more/edit</span>
 
-In auspice v1, we automatically 'prettified' many metadata values. For example, a country value of 'new_zealand' would display as 'New Zealand', and a metadata column called 'age_range' would display as 'Age Range'. 
+In Auspice v1, we automatically 'prettified' many metadata values. For example, a country value of 'new_zealand' would display as 'New Zealand', and a metadata column called 'age_range' would display as 'Age Range'.
 
-This worked well most of the time, but meant that users couldn't intentionally keep underscores or lower-case values. It also meant we had to detect exception cases like turning 'usa' into 'USA' rather than 'Usa'. 
+This worked well most of the time, but meant that users couldn't intentionally keep underscores or lower-case values. It also meant we had to detect exception cases like turning 'usa' into 'USA' rather than 'Usa'.
 
-In auspice v2, all values are now displayed exactly as they arrive, allowing users to ensure every gene and abbreviation displays just as it should. However, this means that you should ensure your data looks exactly how you'd like it to display - change any 'new_zealand's in your metadata to 'New Zealand'! 
+In Auspice v2, all values are now displayed exactly as they arrive, allowing users to ensure every gene and abbreviation displays just as it should. However, this means that you should ensure your data looks exactly how you'd like it to display - change any 'new_zealand's in your metadata to 'New Zealand'!
 
-This also means we've become stricter about the format of the files that pass in color and lat-long information. Previously, it didn't matter if columns were separated by spaces or tabs - now, they must be separated by tabs. 
+This also means we've become stricter about the format of the files that pass in color and lat-long information. Previously, it didn't matter if columns were separated by spaces or tabs - now, they must be separated by tabs.
 
 <span style="color:red">TODO: link to FAQ section on how to add colors and lat-long</span>

--- a/docs/releases/v6.md
+++ b/docs/releases/v6.md
@@ -1,9 +1,9 @@
-# Augur v6 release notes
+# Augur v6 Release Notes
 
 Augur v6 was released on _TODO_.
-This release contains a number of changes from augur v5, including feature additions & bugfixes.
-The biggest change is related to how augur _exports_ files for visualisation by [auspice](https://nextstrain.github.io/auspice/).
-We've written [an extensive guide](migrating-v5-v6) explaining our motivations here, whats changed, how to upgrade, and how this interfaces with auspice.
+This release contains a number of changes from Augur v5, including feature additions and bugfixes.
+The biggest change is related to how Augur _exports_ files for visualisation by [Auspice](https://nextstrain.github.io/auspice/).
+We've written [an extensive guide](migrating-v5-v6) explaining our motivations here, whats changed, how to upgrade, and how this interfaces with Auspice.
 
 ---
 
@@ -12,10 +12,10 @@ We've written [an extensive guide](migrating-v5-v6) explaining our motivations h
 * [Change in `augur ancestral`s arguments](#change-in-augur-ancestrals-arguments)
 * [Import BEAST MCC trees](#import-beast-mcc-trees)
 * [Prettifying of strings](#prettifying-of-strings)
-* [Whitespace in colors & lat-longs TSVs](#whitespace-in-colors-lat-longs-tsvs)
+* [Whitespace in colors and lat-longs TSVs](#whitespace-in-colors-lat-longs-tsvs)
 * [Move to GFF-style annotations](#move-to-gff-style-annotations)
-* [Improvements & usage of JSON validation](#improvements-usage-of-json-validation)
-* [Removal of non-modular augur & old builds](#removal-of-non-modular-augur-old-builds)
+* [Improvements and usage of JSON validation](#improvements-usage-of-json-validation)
+* [Removal of non-modular Augur and old builds](#removal-of-non-modular-augur-old-builds)
 * [Test builds](#test-builds)
 * [Documentation improvements](#documentation-improvements)
 * [Miscellaneous](#miscellaneous)
@@ -26,7 +26,7 @@ We've written [an extensive guide](migrating-v5-v6) explaining our motivations h
 Probably the biggest (breaking) change you'll encounter is that `augur export` no longer works!
 See the [migration guide](migrating-v5-v6) for a detailed explanation of this.
 
-<span style='color: orange'>Breaking change:</span> `augur export` no longer works, and now requires a further positional argument to define which version of auspice you wish to target.
+<span style='color: orange'>Breaking change:</span> `augur export` no longer works, and now requires a further positional argument to define which version of Auspice you wish to target.
 `augur export v1` should behave the same as previous versions' `augur export`.
 
 
@@ -36,13 +36,13 @@ See the [migration guide](migrating-v5-v6) for a detailed explanation of this.
 
 ## Change in `augur ancestral`s arguments
 
-`augur ancestral`, which reconstructs mutations across a tree, now supports two forms of output, and the arguments have become more descriptive.
+`augur ancestral`, which reconstructs mutations across a tree, now supports two forms of output and the arguments have become more descriptive.
 
-1. JSON output, including mutations for each branch & (inferred) ancestral sequences. 
+1. JSON output, including mutations for each branch and (inferred) ancestral sequences.
 This is specified by the `--output-node-data` argument.
 
 2. FASTA output of reconstructed ancestral sequences.
-This had previously been available for VCF-inputs, but now works for any input. 
+This had previously been available for VCF-inputs, but now works for any input.
 Users can ask for this output and specify a file name using `--output-sequences`.
 
 <span style='color: orange'>Deprecation warning:</span> The argument `--output` is now deprecated. Please use `--output-node-data` instead.
@@ -51,31 +51,29 @@ Users can ask for this output and specify a file name using `--output-sequences`
 
 ## Prettifying of strings
 
-
-
-## Whitespace in colors & lat-longs TSVs
+## Whitespace in colors and lat-longs TSVs
 
 ## Move to GFF-style annotations
 
-Starting with augur v6 we use GFF coordinates: [one-origin, inclusive] as opposed to
-And strainds are represented by `+` or `-` rahter than `1` or `0`
-And we export the `seqid`, but don't use it in auspice.
+Starting with Augur v6 we now use GFF coordinates: [one-origin, inclusive] as opposed to BED coordinates.
+Strands are represented by `+` or `-` rather than `1` or `0`.
+Additionally, we export the `seqid`, but don't use it in Auspice.
 
-## Improvements & usage of JSON validation
+## Improvements and usage of JSON validation
 
-## Removal of non-modular augur & old builds
+## Removal of non-modular Augur and old builds
 Augur has been a dynamic, shapeshifting beast.
-It started as scripts for nextflu, took on more & more pathogens, was refactored into "prepare" and "process" steps, and refactored again into the "modular" augur we now have.
-Earlier incarnations of augur have now been removed from the GitHub repo (`./base/*`).
+It started as scripts for Nextflu, took on more and more pathogens, was refactored into "prepare" and "process" steps, and refactored again into the "modular" Augur we now have.
+Earlier incarnations of Augur have now been removed from the GitHub repo (`./base/*`).
 
-Parallaling the different incarnations of augur was a move to "builds" being their own self contained repos.
-We think this has been remarkable successful, and decouples the bioinformatics tooling from a pathogen build.
-With this release of augur we've now removed these builds from the augur GitHub repo, and the only builds that remain are the test ones...
+Paralleling the different incarnations of Augur was a move to "builds" being their own self-contained repos.
+We think this has been remarkably successful, and de-couples the bioinformatics tooling from a pathogen build.
+With this release of Augur we've now removed these builds from the Augur GitHub repo, and the only builds that remain are the test ones...
 
-## Test builds 
+## Test builds
 
-There have been a number of test builds in the augur repo and we have leaned heavily on them while we developed this version of augur as well as auspice v2.
-They are all self contained within `./tests/builds` and can all be run & examined in auspice via
+There have been a number of test builds in the Augur repo and we have leaned heavily on them while we developed this version of Augur as well as Auspice v2.
+They are all self contained within `./tests/builds` and can all be run and examined in Auspice via
 
 ```bash
 cd tests/builds
@@ -83,26 +81,26 @@ bash runner.sh # creates output in ./auspice
 auspice view --datasetDir auspice
 ```
 
-(See the [auspice docs](https://nextstrain.github.io/auspice) for auspice-specific questions.)
+(See the [Auspice docs](https://nextstrain.github.io/auspice) for Auspice-specific questions.)
 
 ## Documentation improvements
 
-Documentation has always been a bit hit-or-miss with nextstrain projects.
-We've tried to make these (augur's read-the-docs documentation) more comprehensive and with better flow.
-This entails new sections, with each augur command having its own page.
+Documentation has always been a bit hit-or-miss with Nextstrain projects.
+We've tried to make these (Augur's read-the-docs documentation) more comprehensive and with better flow.
+This entails new sections, with each Augur command having its own page.
 We've tried to use redirects to ensure that all the old links continue to work.
 
 ## Miscellaneous
 
 * `augur filter`: More interpretable output of how many sequences each stage has filtered out.
 
-* `augur sequence-traits`: Numerical output as originally intended, but required an auspice bugfix.
+* `augur sequence-traits`: Numerical output as originally intended, but required an Auspice bugfix.
 
-* `augur traits`: Explanation of what is considered missing data & how it is interpreted
+* `augur traits`: Explanation of what is considered missing data & how it is interpreted.
 
 * `augur traits`: GTR models are exported in the output JSON for better accountability & reproducibility.
 
-* Errors in formatting of input files (e.g. metadata files, auspice config files) weren't handled nicely, often resulting in hard-to-interpret stack traces.
+* Errors in formatting of input files (e.g. metadata files, Auspice config files) weren't handled nicely, often resulting in hard-to-interpret stack traces.
 We now try to catch these and print an error indicating the offending file.
 
-* Tests using python version 2 have now been removed.
+* Tests using Python version 2 have now been removed.


### PR DESCRIPTION
Copy edits on the augur v6 release docs! 

@jameshadfield in the release notes, there was this sentence that seemed to stop partway through: 
_"Starting with Augur v6 we use GFF coordinates: [one-origin, inclusive] as opposed to"_
I spoke with @huddlej and updated it to this, but please change if it should be something else: 
_"Starting with Augur v6 we use GFF coordinates: [one-origin, inclusive] as opposed to BED coordinates"_ 
