### PR TITLE
add `export v1` subcommand to augur v5

### DIFF
--- a/tests/builds/zika/Snakefile
+++ b/tests/builds/zika/Snakefile
@@ -189,7 +189,7 @@ rule export:
         auspice_seq = rules.all.input.auspice_seq
     shell:
         """
-        augur export \
+        augur export v1 \
             --tree {input.tree} \
             --metadata {input.metadata} \
             --node-data {input.branch_lengths} {input.traits} {input.nt_muts} {input.aa_muts} \


### PR DESCRIPTION
Adds a `augur export v1` subcommand to augur v5, which mimics the `augur export v1` subcommand present in augur v6. This is desirable as it allows us to write Snakefiles for augur builds which will work with both augur v5 & augur v6. (Note that it's not recommended to mix-and-match within a single run.)

Note that (augur v5's) `export v1` contains a subset of the arguments available to `export`. 

The zika test build is modified to use the `augur export v1` command.