### PR TITLE
Remove reference-related args from `export v2`

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -679,17 +679,6 @@ def register_arguments_v2(subparsers):
     )
     optional_settings.add_argument('--minify-json', action="store_true", help="export JSONs without indentation or line returns")
 
-
-    remove_pre_v6_release = v2.add_argument_group(
-        title="SOON TO BE REMOVED OPTIONS",
-        description="These options were available in augur v5 but are seemingly unused.\
-            Unless we discover otherwise, they will be removed before the v6 release. \
-            Note that they are still available via `augur export v1` to preserve the v5 behavior."
-    )
-    remove_pre_v6_release.add_argument('--output-sequence', metavar="JSON", help="(reconstructed) sequences for each node")
-    remove_pre_v6_release.add_argument('--reference', metavar="JSON", required=False, help="reference sequence for export to browser, only vcf")
-    remove_pre_v6_release.add_argument('--reference-translations', metavar="???", required=False, help="reference translations for export to browser, only vcf")
-
     return v2
 
 

--- a/tests/builds/tb/Snakefile
+++ b/tests/builds/tb/Snakefile
@@ -274,7 +274,6 @@ rule export_v2:
             --tree {input.tree} \
             --metadata {input.metadata} \
             --node-data {input.branch_lengths} {input.traits} {input.aa_muts} {input.nt_muts} {input.clades} \
-            --reference {input.ref} --reference-translations {input.translations} \
             --colors {input.color_defs} \
             --lat-longs {input.geo_info} \
             --output {output.main} \


### PR DESCRIPTION
These were not used in the code, and their intention seems to have been superseded by the presence of specific node-data via `augur ancestral` in commit 6949acf4b0020d13a7ab1526154318270f3a7776