### PR TITLE
Modify how maintainers are defined in the config JSON

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -50,17 +50,18 @@
             }
         },
         "maintainers": {
+            "description": "Who maintains this dataset?",
+            "$comment": "order similar to a publication",
             "type": "array",
             "uniqueItems": true,
             "minItems": 1,
             "items": {
-                "type": "array",
-                "uniqueItems": true,
-                "minItems": 2,
-                "maxItems": 2,
-                "items": {
-                    "type": "string"
-                }
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "url": {"type": "string"}
+                },
+                "required": ["name"]
             }
         },
         "filters": {

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -15,7 +15,7 @@
             "type": "object",
             "$comment": "Metadata associated with phylogeny",
             "additionalProperties": false,
-            "required": ["title", "updated", "maintainers", "panels"],
+            "required": ["title", "updated", "panels"],
             "properties" : {
                 "title" : {
                     "description": "Auspice displays this at the top of the page",

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -37,7 +37,8 @@
                         "properties": {
                             "name": {"type": "string"},
                             "url": {"type": "string"}
-                        }
+                        },
+                        "required": ["name"]
                     }
                 },
                 "genome_annotations": {

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -742,13 +742,13 @@ def set_maintainers(data_json, config, cmd_line_maintainers):
                     tmp_dict['url'] = url
                 maintainers.append(tmp_dict)
         data_json['meta']['maintainers'] = maintainers
-    elif config.get("maintainer"): #v1-type specification
+    elif config.get("maintainer"): # v1-type specification
         data_json['meta']["maintainers"] = [{ "name": config["maintainer"][0], "url": config["maintainer"][1]}]
-    elif config.get("maintainers"): #v2-type specification (proposed by Emma)
-        data_json['meta']['maintainers'] = [{'name': n[0], 'url': n[1]} for n in config['maintainers']]
+    elif config.get("maintainers"): # see schema for details
+        data_json['meta']['maintainers'] = config['maintainers']
     else:
         warn("you didn't provide information on who is maintaining this analysis.")
-        data_json['meta']["maintainers"] = [{ "name": "unspecified", "url": "unspecified"}]
+        data_json['meta']["maintainers"] = [{ "name": "unspecified" }]
 
 
 def set_title(data_json, config, cmd_line_title):

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -747,8 +747,7 @@ def set_maintainers(data_json, config, cmd_line_maintainers):
     elif config.get("maintainers"): # see schema for details
         data_json['meta']['maintainers'] = config['maintainers']
     else:
-        warn("you didn't provide information on who is maintaining this analysis.")
-        data_json['meta']["maintainers"] = [{ "name": "unspecified" }]
+        warn("You didn't provide information on who is maintaining this analysis.")
 
 
 def set_title(data_json, config, cmd_line_title):

--- a/docs/releases/migrating-v5-v6.md
+++ b/docs/releases/migrating-v5-v6.md
@@ -262,16 +262,15 @@ E.g. `"title": "Phylodynamics of my Pathogen"`.
 #### maintainers
 
 You can now have more than one maintainer associated with your run!
-Specify maintainers and their websites using `"maintainers"` and listing the name and URL in pairs:
+Specify one or as many maintainers as you wish via the following structure (`url`s are optional):
 
 ```
 "maintainers": [
-  ["Jane Doe", "www.janedoe.com"],
-  ["Ravi Kupra","www.ravikupra.co.uk"]
+  {"name": "Jane Doe", "url": "www.janedoe.com"},
+  {"name": "Ravi Kupra", "url": "www.ravikupra.co.uk"}
 ]
 ```
 
-If you only have one maintainer, you still need to use the same format of two sets of square brackets: `"maintainers": [["Hanna Kukk", "www.hkukk.ee"]]`.
 Previously this was the "maintainer" field in your v1 config file and used a different structure.
 
 #### panels
@@ -343,8 +342,8 @@ Here is an example of how all of the above options would fit into a config file:
 {
   "title": "Phylodynamics of my Pathogen",
   "maintainers": [
-    ["Jane Doe", "www.janedoe.com"],
-    ["Ravi Kupra","www.ravikupra.co.uk"]
+    {"name": "Jane Doe", "url": "www.janedoe.com"},
+    {"name": "Ravi Kupra", "url": "www.ravikupra.co.uk"}
   ],
   "colorings": {
     "age": {
@@ -474,8 +473,8 @@ Export v2 config:
       "region"
     ],
   "maintainers": [
-    ["Hanna Kukk", "http://vamuzlab.org"],
-    ["Mohammad Fahir", "http://mfahir.co.uk"]
+    {"name": "Hanna Kukk", "url": "http://vamuzlab.org"},
+    {"name": "Mohammad Fahir", "url": "http://mfahir.co.uk"}
   ],
   "filters": [
     "country", "region"

--- a/tests/builds/tb/data/config_v2.json
+++ b/tests/builds/tb/data/config_v2.json
@@ -27,7 +27,7 @@
  "maintainers": [
    {
      "name": "Emma Hodcroft",
-     "href": "https://neherlab.org/emma-hodcroft.html"
+     "url": "https://neherlab.org/emma-hodcroft.html"
    }
  ]
 }

--- a/tests/builds/various_export_settings/config/default-layout.json
+++ b/tests/builds/various_export_settings/config/default-layout.json
@@ -17,7 +17,7 @@
     "tree"
   ],
   "maintainers": [
-    ["Trevor Bedford", "http://bedford.io/team/trevor-bedford/"]
+    {"name": "Trevor Bedford", "url": "http://bedford.io/team/trevor-bedford/"}
   ],
   "filters": [],
   "defaults": {

--- a/tests/builds/zika/config/auspice_config_v2.json
+++ b/tests/builds/zika/config/auspice_config_v2.json
@@ -29,7 +29,7 @@
     "color_by": "author"
   },
   "maintainers": [
-    ["Trevor Bedford", "http://bedford.io/team/trevor-bedford/"]
+    {"name": "Trevor Bedford", "url": "http://bedford.io/team/trevor-bedford/"}
   ],
   "filters": [
     "country",


### PR DESCRIPTION
Moves the config JSON definition of `maintainers` to the same structure as the exported JSON -- see #400 for background information as to why this is desirable.

Additionally, this PR removes `maintainers` as a required key in exported JSONs -- this is not necessary for auspice to work. Note that `export v2` prints a warning if this is not supplied, as we want to push users to provide this.