### PR TITLE
Coloring order in config JSON & config schema validation

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -1,7 +1,9 @@
 {
     "type" : "object",
+    "version": "v2",
     "$schema": "http://json-schema.org/draft-06/schema#",
     "title": "Auspice config file to be supplied to `augur export v2`",
+    "$comment": "This schema includes deprecated-but-handled-by-augur-export-v1 properties, but their schema definitions are somewhat incomplete",
     "additionalProperties": false,
     "required": [],
     "properties" : {
@@ -36,27 +38,46 @@
                 }
             }
         },
+        "color_options": {
+            "description": "DEPRECATED v1 syntax for defining colorings",
+            "deprecated": true,
+            "type": "object"
+        },
         "geo_resolutions": {
             "description": "Traits to be interpreted as 'geo resolution' options -- i.e. associated with lat/longs & made points on the map",
+            "$comment": "Note that array entries can be different structures & you can mix & match",
             "type": "array",
             "uniqueItems": true,
             "minItems": 1,
             "items": {
-                "type": "object",
-                "description": "An indiviual geo resolution",
-                "additionalProperties": false,
-                "required": ["key"],
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "description": "Trait key - must be specified on nodes (e.g. 'country')"
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "description": "An indiviual geo resolution",
+                        "additionalProperties": false,
+                        "required": ["key"],
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "description": "Trait key - must be specified on nodes (e.g. 'country')"
+                            },
+                            "title": {
+                                "type": "string",
+                                "description": "The title to display in the geo resolution dropdown. Optional -- if not provided then `key` will be used."
+                            }
+                        }
                     },
-                    "title": {
-                      "type": "string",
-                      "description": "The title to display in the geo resolution dropdown. Optional -- if not provided then `key` will be used."
+                    {
+                        "type": "string",
+                        "description": "An indiviual geo resolution key"
                     }
-                }
+                ]
             }
+        },
+        "geo": {
+            "description": "DEPRECATED v1 syntax for defining geo_resolutions",
+            "deprecated": true,
+            "type": "array"
         },
         "maintainers": {
             "type": "array",
@@ -72,10 +93,15 @@
                 }
             }
         },
+        "maintainer": {
+            "description": "DEPRECATED v1 syntax for defining maintainers (but you could only define one!)",
+            "deprecated": true,
+            "type": "array"
+        },
         "filters": {
             "type": "array",
             "uniqueItems": true,
-            "minItems": 1,
+            "minItems": 0,
             "items": {
                 "type": "string"
             }
@@ -90,7 +116,7 @@
                 "geo_resolution": {
                     "type": "string"
                 },
-                "colorBy": {
+                "color_by": {
                     "type": "string"
                 },
                 "distance_measure": {
@@ -102,6 +128,17 @@
                     "enum": ["rect", "radial", "unrooted", "clock"]
                 }
             }
+        },
+        "defaults": {
+            "description": "DEPRECATED v1 syntax for defining auspice view defaults",
+            "deprecated": true,
+            "type": "object"
+        },
+        "updated": {
+            "description": "DEPRECATED v1 (or older) syntax for defining when the build was updated",
+            "$comment": "unused in augur v6",
+            "deprecated": true,
+            "type": "string"
         },
         "panels": {
             "type": "array",

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -11,16 +11,25 @@
         },
         "colorings": {
             "description": "Set traits to be available as color-dropdown options",
-            "type" : "object",
-            "additionalProperties": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
                 "type": "object",
+                "description": "An indiviual color-by for auspice",
                 "additionalProperties": false,
-                "required": [],
+                "required": ["key"],
                 "properties": {
+                    "key": {
+                        "description": "They key used to access the value of this coloring on each node",
+                        "type": "string"
+                    },
                     "title": {
+                        "description": "Text to be displayed in the \"color by\" dropdown and legends",
+                        "$comment": "string is parsed unchanged by Auspice",
                         "type": "string"
                     },
                     "type": {
+                        "description": "Defines how the color scale should be constructed",
                         "type": "string",
                         "enum": ["continuous", "ordinal", "categorical", "boolean"]
                     }

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -80,7 +80,7 @@
                 "type": "string"
             }
         },
-        "defaults": {
+        "display_defaults": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -101,6 +101,16 @@
                     "type": "string",
                     "enum": ["rect", "radial", "unrooted", "clock"]
                 }
+            }
+        },
+        "panels": {
+            "type": "array",
+            "description": "Which panels should auspice display",
+            "$comment": "optional",
+            "minItems": 1,
+            "items": {
+                "type": "string",
+                "enum": ["tree", "map", "frequencies", "entropy"]
             }
         }
     }

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -170,9 +170,6 @@
                             },
                             "scale": {
                                 "description": "Provided mapping between trait values & hex values",
-                                "$comment": "TODO: If type is continuous or ordinal, values between those provided here are interpolated",
-                                "$comment": "If type is categorical, values not present here are grey",
-                                "$comment": "TODO: If type is boolean, use \"1\" (true) and \"0\" (false) as properties",
                                 "type": "array",
                                 "items": {
                                     "type": "array",

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -73,7 +73,7 @@ def validate(jsonToValidate, schema):
 
 def auspice_config_v2(config_json, **kwargs):
     schema = load_json_schema("schema-auspice-config-v2.json")
-    jsonToValidate = load_json(config_json)
+    jsonToValidate = load_json(config_json) if isinstance(config_json, str) else config_json
     validate(jsonToValidate, schema)
 
 def export_v2(json_v2, **kwargs):

--- a/docs/releases/migrating-v5-v6.md
+++ b/docs/releases/migrating-v5-v6.md
@@ -284,14 +284,15 @@ Options are "tree", "map", "entropy", and "frequencies" (e.g: `"panels": ["tree"
 
 #### colorings
 
-These are the traits which Auspice should display as options to color the tree & map.
-In previous versions of the config file this was "color_options" and the current structure is very similar - but easier to understand!
+These are a list of the traits which Auspice should display as options to color the tree & map.
+In previous versions of the config file this was "color_options" and the current structure is similar, but hopefully easier to understand!
 
 For each trait you include, you can define:
+* A required "key", which is used to lookup the values via node-data JSONs or other provided metadata.
 * An optional "title" which will shown by Auspice when referring to this trait -- for instance you may have a trait called "ab1" which you want to show as "Age bracket 1" in the drop-down menus, legend, and filter.
-* An optional, but recommended "type" which can be either 'ordinal', 'boolean', 'continuous', or 'categorical'. If you don't provide a type, augur will try to guess it (see how it guesses [here](#id1)).
+* An optional, but highly recommended "type" which can be either 'ordinal', 'boolean', 'continuous', or 'categorical'. If you don't provide a type, augur will try to guess it (see how it guesses [here](#id1)).
 
-Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `Augur seqtraits` output (like clade or drug resistance information) in your config file - if that information is present, it will automatically be included. To exclude it, don't pass in the corresponding file to `--node-data`.
+Unless you want to change the name displayed, you _no longer_ need to include `gt`, `num_date`, `clade_membership`, or `augur seqtraits` output (like clade or drug resistance information) in your config file - if that information is present, it will automatically be included. To exclude it, don't pass in the corresponding file to `--node-data`.
 
 > _Remember that if you are using `--metadata-color-by` on the command-line, only the traits given there will be color-by options!_
 _To include everything in your config file, don't use `--metadata-color-by`, but include all traits you want as coloring options in "colorings" in the config file._
@@ -346,21 +347,25 @@ Here is an example of how all of the above options would fit into a config file:
     ["Jane Doe", "www.janedoe.com"],
     ["Ravi Kupra","www.ravikupra.co.uk"]
   ],
-  "colorings": {
-    "age": {
+  "colorings": [
+    {
+      "key": "age",
       "title": "Host age",
       "type": "continuous"
     },
-    "hospitalized": {
+    {
+      "key": "hospitalized",
       "type": "boolean"
     },
-    "country": {
+    {
+      "key": "country",
       "type": "categorical"
     },
-    "region": {
+    {
+      "key": "region",
       "type": "categorical"
     }
-  },
+  ],
   "geo_resolutions": [
     {"key":"country", "title": "Areas"},
     "region"
@@ -453,22 +458,26 @@ Export v2 config:
     <div class="highlight-default notranslate"><div class="highlight"><pre>
 {
   "title": "Phylodynamics of Virus A",
-  "colorings": {<br><br><br><br><br><br><br><br><br><br><br><br>
-    "age": {
+  "colorings": [<br><br><br><br><br><br><br><br><br><br><br><br>
+    {
+      "key": "age",<br>
       "title": "Host age",<br>
       "type": "continuous"<br>
     },
-    "host": {
+    {
+      "key": "host",<br>
       "title": "Animal",<br>
       "type": "categorical"<br>
     },
-    "country": {
+    {
+      "key": "country",<br>
       "type": "categorical"
     },
-    "region": {
+    {
+      "key": "region",<br>
       "type": "categorical"
     }<br><br><br><br><br><br>
-  },
+  ],
   "geo_resolutions": [
       "country",
       "region"

--- a/tests/builds/tb/data/config_v2.json
+++ b/tests/builds/tb/data/config_v2.json
@@ -1,21 +1,25 @@
 {
  "title": "TB outbreak in Nunavik, Canada",
- "colorings": {
-  "gt": {
-   "title": "Genotype",
-   "type": "ordinal"
+ "colorings": [
+  {
+    "key": "gt",
+    "title": "Genotype",
+    "type": "ordinal"
   },
-  "num_date": {
-   "title": "Sampling date",
-   "type": "continuous"
+  {
+    "key": "num_date",
+    "title": "Sampling date",
+    "type": "continuous"
   },
-  "location": {
+  {
+    "key": "location",
     "type": "categorical"
   },
-  "cluster": {
+  {
+    "key": "cluster",
     "type": "categorical"
   }
- },
+ ],
  "geo_resolutions": [
    {"key": "location"}
  ],

--- a/tests/builds/tb_drm/data/v2_config.json
+++ b/tests/builds/tb_drm/data/v2_config.json
@@ -1,30 +1,36 @@
 {
   "title": "TB with DRMs",
-  "colorings": {
-    "gt": {
+  "colorings": [
+    {
+      "key": "gt",
       "title": "Genotype",
       "type": "categorical"
     },
-    "num_date": {
+    {
+      "key": "num_date",
       "title": "Sampling date",
       "type": "continuous"
     },
-    "Drug_Resistance": {
+    {
+      "key": "Drug_Resistance",
       "title": "Drug Resistance (ordinal)", 
       "type": "ordinal"
     },
-    "Ethambutol": {
+    {
+      "key": "Ethambutol",
       "title": "Ethambutol Resistance (categorical)", 
       "type": "categorical"
     },
-    "Rifampicin": {
+    {
+      "key": "Rifampicin",
       "title": "Rifampicin Resistance (ordinal)", 
       "type": "ordinal"
      },
-    "country": {
+    {
+      "key": "country",
       "type": "categorical"
     }
-  },
+  ],
   "panels": ["tree", "map"],
   "maintainers": [
     ["Emma Hodcroft", "https://neherlab.org/emma-hodcroft.html"]

--- a/tests/builds/various_export_settings/config/default-layout.json
+++ b/tests/builds/various_export_settings/config/default-layout.json
@@ -1,18 +1,21 @@
 {
   "title": "Default layout should be clock",
-  "colorings": {
-    "gt": {
+  "colorings": [
+    {
+      "key": "gt",
       "title": "Genotype",
       "type": "categorical"
     },
-    "num_date": {
+    {
+      "key": "num_date",
       "title": "Sampling date",
       "type": "continuous"
     },
-    "country": {
+    {
+      "key": "country",
       "type": "ordinal"
     }
-  },
+  ],
   "panels": [
     "tree"
   ],

--- a/tests/builds/zika/config/auspice_config_v2.json
+++ b/tests/builds/zika/config/auspice_config_v2.json
@@ -40,5 +40,11 @@
     "country",
     "region",
     "author"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
   ]
 }

--- a/tests/builds/zika/config/auspice_config_v2.json
+++ b/tests/builds/zika/config/auspice_config_v2.json
@@ -27,7 +27,7 @@
   ],
   "geo_resolutions": [
     {"key": "country", "title": "Country Custom Title"},
-    {"key": "region"}
+    "region"
   ],
   "display_defaults": {
     "map_triplicate": true,

--- a/tests/builds/zika/config/auspice_config_v2.json
+++ b/tests/builds/zika/config/auspice_config_v2.json
@@ -1,25 +1,30 @@
 {
   "title": "Real-time tracking of Zika virus evolution",
-  "colorings": {
-    "gt": {
+  "colorings": [
+    {
+      "key": "gt",
       "title": "Genotype",
       "type": "categorical"
     },
-    "num_date": {
+    {
+      "key": "num_date",
       "title": "Sampling date",
       "type": "continuous"
     },
-    "author": {
+    {
+      "key": "author",
       "title": "Authors",
       "type": "categorical"
     },
-    "country": {
+    {
+        "key": "country",
         "type": "ordinal"
     },
-    "region": {
+    {
+        "key": "region",
         "type": "ordinal"
     }
-  },
+  ],
   "geo_resolutions": [
     {"key": "country", "title": "Country Custom Title"},
     {"key": "region"}


### PR DESCRIPTION
This PR modifies how colorings are defined in the config JSON file for `export v2` to mirror how they are exported. See #401 for background.

Additionally, it updates the JSON schema for the config file to include deprecated fields (i.e v1 fields) which are correctly parsed by `augur export v2`. This allows us to validate the schema within `augur export v2` which we now do. 