### PR TITLE
Include "build_url" in export v2

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -99,9 +99,9 @@
             "deprecated": true,
             "type": "array"
         },
-        "repository": {
-          "description": "Repository URL used to build dataset",
-          "$comment": "optional, usually will be a GitHub URL",
+        "build_url": {
+          "description": "URL with instructions to reproduce build, usually expected to be a GitHub repo URL",
+          "$comment": "optional",
           "type": "string"
         },
         "filters": {

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -99,6 +99,11 @@
             "deprecated": true,
             "type": "array"
         },
+        "repository": {
+          "description": "Repository URL used to build dataset",
+          "$comment": "optional, usually will be a GitHub URL",
+          "type": "string"
+        },
         "filters": {
             "type": "array",
             "uniqueItems": true,

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -26,6 +26,10 @@
                     "type" : "string",
                     "pattern": "^[0-9X]{4}-[0-9X]{2}-[0-9X]{2}$"
                 },
+                "repository" : {
+                    "description": "Auspice currently displays this for community pages in the sidebar",
+                    "type" : "string"
+                },
                 "maintainers": {
                     "description": "Who maintains this dataset?",
                     "$comment": "order similar to a publication",

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -26,8 +26,8 @@
                     "type" : "string",
                     "pattern": "^[0-9X]{4}-[0-9X]{2}-[0-9X]{2}$"
                 },
-                "repository" : {
-                    "description": "Auspice currently displays this for community pages in the sidebar",
+                "build_url" : {
+                    "description": "Auspice displays this at the top of the page as part of a byline",
                     "type" : "string"
                 },
                 "maintainers": {

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -670,6 +670,7 @@ def register_arguments_v2(subparsers):
     config.add_argument('--auspice-config', metavar="JSON", help="Auspice configuration file")
     config.add_argument('--title', type=str, metavar="title", help="Title to be displayed by auspice")
     config.add_argument('--maintainers', metavar="name", action="append", nargs='+', help="Analysis maintained by, in format 'Name <URL>' 'Name2 <URL>', ...")
+    config.add_argument('--repository', type=str, metavar="repository", help="Build repository to be displayed by Auspice")
     config.add_argument('--geo-resolutions', metavar="trait", nargs='+', help="Geographic traits to be displayed on map")
     config.add_argument('--color-by-metadata', metavar="trait", nargs='+', help="Metadata columns to include as coloring options")
     config.add_argument('--panels', metavar="panels", nargs='+', choices=['tree', 'map', 'entropy', 'frequencies'], help="Restrict panel display in auspice. Options are %(choices)s. Ignore this option to display all available panels.")
@@ -764,6 +765,12 @@ def set_title(data_json, config, cmd_line_title):
     elif config.get("title"):
         data_json['meta']['title'] = config.get("title")
 
+def set_repository(data_json, config, cmd_line_repository):
+    # repository is not necessary. Cmd line args override any config settings
+    if cmd_line_repository:
+        data_json['meta']['repository'] = cmd_line_repository
+    elif config.get("repository"):
+        data_json['meta']['repository'] = config.get("repository")
 
 def parse_node_data_and_metadata(T, node_data_files, metadata_file):
     node_data = read_node_data(node_data_files) # node_data_files is an array of multiple files (or a single file)
@@ -817,6 +824,7 @@ def run_v2(args):
     set_title(data_json, config, args.title)
     set_display_defaults(data_json, config)
     set_maintainers(data_json, config, args.maintainers)
+    set_repository(data_json, config, args.repository)
     set_annotations(data_json, node_data)
 
     set_colorings(

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -670,7 +670,7 @@ def register_arguments_v2(subparsers):
     config.add_argument('--auspice-config', metavar="JSON", help="Auspice configuration file")
     config.add_argument('--title', type=str, metavar="title", help="Title to be displayed by auspice")
     config.add_argument('--maintainers', metavar="name", action="append", nargs='+', help="Analysis maintained by, in format 'Name <URL>' 'Name2 <URL>', ...")
-    config.add_argument('--repository', type=str, metavar="repository", help="Build repository to be displayed by Auspice")
+    config.add_argument('--build-url', type=str, metavar="url", help="Build URL/repository to be displayed by Auspice")
     config.add_argument('--geo-resolutions', metavar="trait", nargs='+', help="Geographic traits to be displayed on map")
     config.add_argument('--color-by-metadata', metavar="trait", nargs='+', help="Metadata columns to include as coloring options")
     config.add_argument('--panels', metavar="panels", nargs='+', choices=['tree', 'map', 'entropy', 'frequencies'], help="Restrict panel display in auspice. Options are %(choices)s. Ignore this option to display all available panels.")
@@ -765,12 +765,12 @@ def set_title(data_json, config, cmd_line_title):
     elif config.get("title"):
         data_json['meta']['title'] = config.get("title")
 
-def set_repository(data_json, config, cmd_line_repository):
-    # repository is not necessary. Cmd line args override any config settings
-    if cmd_line_repository:
-        data_json['meta']['repository'] = cmd_line_repository
-    elif config.get("repository"):
-        data_json['meta']['repository'] = config.get("repository")
+def set_build_url(data_json, config, cmd_line_build_url):
+    # build_url is not necessary. Cmd line args override any config settings
+    if cmd_line_build_url:
+        data_json['meta']['build_url'] = cmd_line_build_url
+    elif config.get("build_url"):
+        data_json['meta']['build_url'] = config.get("build_url")
 
 def parse_node_data_and_metadata(T, node_data_files, metadata_file):
     node_data = read_node_data(node_data_files) # node_data_files is an array of multiple files (or a single file)
@@ -824,7 +824,7 @@ def run_v2(args):
     set_title(data_json, config, args.title)
     set_display_defaults(data_json, config)
     set_maintainers(data_json, config, args.maintainers)
-    set_repository(data_json, config, args.repository)
+    set_build_url(data_json, config, args.build_url)
     set_annotations(data_json, node_data)
 
     set_colorings(

--- a/docs/releases/migrating-v5-v6.md
+++ b/docs/releases/migrating-v5-v6.md
@@ -164,10 +164,10 @@ shell:
 ```
 You will need to use quotes in the same way even if you only have one maintainer!
 
-### Repository
+### Build URL
 
-Set the repository URL displayed by Auspice via `--repository`.
-If running directly from the command line, input your repository URL directly (ex: `--repository https://github.com/nextstrain/zika`).
+Set the build URL displayed by Auspice via `--build-url`.
+If running directly from the command line, input your build URL directly (ex: `--build-url https://github.com/nextstrain/zika`).
 
 ### Panels
 
@@ -277,9 +277,9 @@ Specify one or as many maintainers as you wish via the following structure (`url
 
 Previously this was the "maintainer" field in your v1 config file and used a different structure.
 
-#### repository
+#### build-url
 
-The repository URL to be displayed by Auspice, a new functionality in `augur export v2`, e.g. `"repository": "https://github.com/nextstrain/zika"`.
+The build / repository URL to be displayed by Auspice, a new functionality in `augur export v2`, e.g. `"build_url": "https://github.com/nextstrain/zika"`.
 This is an optional field.
 
 #### panels
@@ -355,7 +355,7 @@ Here is an example of how all of the above options would fit into a config file:
     {"name": "Jane Doe", "url": "www.janedoe.com"},
     {"name": "Ravi Kupra", "url": "www.ravikupra.co.uk"}
   ],
-  "repository": "https://github.com/nextstrain/zika",
+  "build_url": "https://github.com/nextstrain/zika",
   "colorings": [
     {
       "key": "age",

--- a/docs/releases/migrating-v5-v6.md
+++ b/docs/releases/migrating-v5-v6.md
@@ -164,6 +164,10 @@ shell:
 ```
 You will need to use quotes in the same way even if you only have one maintainer!
 
+### Repository
+
+Set the repository URL displayed by Auspice via `--repository`.
+If running directly from the command line, input your repository URL directly (ex: `--repository https://github.com/nextstrain/zika`).
 
 ### Panels
 
@@ -273,6 +277,11 @@ Specify one or as many maintainers as you wish via the following structure (`url
 
 Previously this was the "maintainer" field in your v1 config file and used a different structure.
 
+#### repository
+
+The repository URL to be displayed by Auspice, a new functionality in `augur export v2`, e.g. `"repository": "https://github.com/nextstrain/zika"`.
+This is an optional field.
+
 #### panels
 
 Optional and unchanged from previous versions of the config file, this defines the panels that Auspice will display.
@@ -346,6 +355,7 @@ Here is an example of how all of the above options would fit into a config file:
     {"name": "Jane Doe", "url": "www.janedoe.com"},
     {"name": "Ravi Kupra", "url": "www.ravikupra.co.uk"}
   ],
+  "repository": "https://github.com/nextstrain/zika",
   "colorings": [
     {
       "key": "age",

--- a/tests/builds/zika/config/auspice_config_v2.json
+++ b/tests/builds/zika/config/auspice_config_v2.json
@@ -1,5 +1,9 @@
 {
   "title": "Real-time tracking of Zika virus evolution",
+  "maintainers": [
+    {"name": "Trevor Bedford", "url": "http://bedford.io/team/trevor-bedford/"}
+  ],
+  "repository": "https://github.com/nextstrain/zika",    
   "colorings": [
     {
       "key": "gt",
@@ -33,9 +37,6 @@
     "map_triplicate": true,
     "color_by": "author"
   },
-  "maintainers": [
-    {"name": "Trevor Bedford", "url": "http://bedford.io/team/trevor-bedford/"}
-  ],
   "filters": [
     "country",
     "region",

--- a/tests/builds/zika/config/auspice_config_v2.json
+++ b/tests/builds/zika/config/auspice_config_v2.json
@@ -3,7 +3,7 @@
   "maintainers": [
     {"name": "Trevor Bedford", "url": "http://bedford.io/team/trevor-bedford/"}
   ],
-  "repository": "https://github.com/nextstrain/zika",    
+  "build_url": "https://github.com/nextstrain/zika",    
   "colorings": [
     {
       "key": "gt",


### PR DESCRIPTION
It's going to be useful to track and display the repository used for a build / analysis. Currently, we display this for "community" builds in the sidebar, but it would be useful to surface this information more generally. 

This PR:
* adds `--repository` to `augur export v2`
* imports `"repository"` from an Auspice config file
* updates schema-auspice-config-v2 and schema-export-v2 to accommodate the optional `"repository"` field
* updates documentation in migrating-v5-v6

This should enable better tracking of core build repositories (https://github.com/nextstrain/nextstrain.org/issues/41) and also allow display of repository directly in Auspice, ala:

![Byline](https://user-images.githubusercontent.com/1176109/68634196-7957c200-04a9-11ea-9e55-31242fb73337.png)

_PR edited to swap "repository" for "build_url"._