### PR TITLE
Remove conda-forge from channels

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: augur
 channels:
 - bioconda
 - defaults
-- conda-forge
 dependencies:
 - python=3.6
 - mafft


### PR DESCRIPTION
Travis CI was spending >10 minutes on `conda env create -f environment.yml` and erroring out: https://travis-ci.com/nextstrain/augur/builds/136393004#L1767. We don't actually need `conda-forge` (per @huddlej). By just removing it from the list of channels, we reduce this step to ~1 min: https://travis-ci.com/nextstrain/augur/builds/136405192#L1608 and the entire Travis build takes just 4 min.

It looks like everything still installs correctly and all tests pass.