### PR TITLE
Add flag to explicitly request root sequence from augur export v2

### DIFF
--- a/docs/releases/migrating-v5-v6.md
+++ b/docs/releases/migrating-v5-v6.md
@@ -78,7 +78,9 @@ Similarly, you can pass in files containing colors, latitude, and longitude data
 Instead of specifying two output files (`--output-tree` and `--output-meta`) you now only need to specify one with `--output`.
 For example, if your old files were `auspice/virus_AB_tree.json` and `auspice/virus_AB_meta.json`, you might want to call the single output `auspice/virus_AB.json` - or if you want to tell it apart from your v1 export, you might call it `auspice/virus_ABv2.json`.
 
-<span style="color:red">_TODO: the new option to export a reference sequence. Currently unused by Auspice_</span>
+To export the reference sequence relative to which mutations have been identified, specify the `--include-root-sequence` flag.
+This flag replaces the `--output-sequence` argument and writes a JSON whose name is relative to the stem of the main output JSON.
+For example, if the main output is called `auspice/virus_AB.json`, the root sequence will be saved to `auspice/virus_AB_root-sequence.json`.
 
 ### Other changed arguments
 


### PR DESCRIPTION
Adds a flag, `--include-root-sequence`, that allows users to request the export
of an additional JSON containing the root sequence per gene. This is the
sequence that mutations in the main auspice JSON are relative to.

This commit also:

  - adds a check for the existence of reference sequences in the
    given node data and issues a warning if the user has requested the root
    sequence and none is provided
  - replaces string slicing of output filenames with the corresponding pathlib
    logic to make this logic less ambiguous and more future-proof