### PR TITLE
Fix weighted frequencies when weight keys are unrepresented

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda env create -f environment.yml
-  - source activate augur
+  - wget http://data.nextstrain.org/nextstrain.yml -O nextstrain.yml;
+  - conda env create -f nextstrain.yml
+  - source activate nextstrain
 install:
   - pip3 install -e .[dev]
 script:


### PR DESCRIPTION
Fixes a bug in weighted KDE estimation of tree frequencies when one or more weight attributes is not represented by any tips on the tree. For example, when a tree is missing any samples from Africa but the frequencies are being weighted by region, the total of the estimated frequencies will not sum to 1.

This PR adds unit tests to confirm the original issue and adds logic to KDE frequency estimation to correct the issue. This PR also updates the Travis CI config to source the canonical Nextstrain environment.

Closes #268.