### PR TITLE
Swap 'import-beast' for 'import beast'

### DIFF
--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -3,41 +3,41 @@ The top-level augur command which dispatches to subcommands.
 """
 
 import argparse
-import re, os, sys
+import re
+import os
+import sys
+import importlib
 from types import SimpleNamespace
-from . import parse, filter, align, tree, refine, ancestral
-from . import traits, translate, mask, titers, frequencies, export
-from . import validate, sequence_traits, clades, version
-from . import reconstruct_sequences, lbi, distance, import_beast
 from .utils import first_line
 
 recursion_limit = os.environ.get("AUGUR_RECURSION_LIMIT")
 if recursion_limit:
     sys.setrecursionlimit(int(recursion_limit))
 
-COMMANDS = [
-    parse,
-    filter,
-    mask,
-    align,
-    tree,
-    refine,
-    ancestral,
-    translate,
-    reconstruct_sequences,
-    clades,
-    traits,
-    sequence_traits,
-    lbi,
-    distance,
-    titers,
-    frequencies,
-    export,
-    validate,
-    version,
-    import_beast
+command_strings = [
+    "parse",
+    "filter",
+    "mask",
+    "align",
+    "tree",
+    "refine",
+    "ancestral",
+    "translate",
+    "reconstruct_sequences",
+    "clades",
+    "traits",
+    "sequence_traits",
+    "lbi",
+    "distance",
+    "titers",
+    "frequencies",
+    "export",
+    "validate",
+    "version",
+    "import_beast"
 ]
 
+COMMANDS = [importlib.import_module('augur.' + c) for c in command_strings]
 
 def make_parser():
     parser = argparse.ArgumentParser(

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -34,7 +34,7 @@ command_strings = [
     "export",
     "validate",
     "version",
-    "import_beast"
+    "import"
 ]
 
 COMMANDS = [importlib.import_module('augur.' + c) for c in command_strings]

--- a/augur/import.py
+++ b/augur/import.py
@@ -1,0 +1,16 @@
+"""
+Import analyses into augur pipeline from other systems
+"""
+from .import_beast import run_beast, register_arguments_beast
+
+def register_arguments(parser):
+    metavar_msg ="Import analyses into augur pipeline from other systems " + \
+                 "Currently allows `augur import beast`"
+    subparsers = parser.add_subparsers(title="TYPE",
+                                       metavar=metavar_msg)
+    subparsers.required = True
+    register_arguments_beast(subparsers)
+
+def run(args):
+    if "beast" in args:
+        return run_beast(args)

--- a/augur/import.py
+++ b/augur/import.py
@@ -4,8 +4,7 @@ Import analyses into augur pipeline from other systems
 from .import_beast import run_beast, register_arguments_beast
 
 def register_arguments(parser):
-    metavar_msg ="Import analyses into augur pipeline from other systems " + \
-                 "Currently allows `augur import beast`"
+    metavar_msg = "Import analyses into augur pipeline from other systems"
     subparsers = parser.add_subparsers(title="TYPE",
                                        metavar=metavar_msg)
     subparsers.required = True

--- a/augur/import_beast.py
+++ b/augur/import_beast.py
@@ -2,30 +2,31 @@
 Parse a BEAST MCC tree for further analysis in augur or
 export for auspice v2+ (using `augur export v2` or greater).
 """
-
-from Bio import SeqIO, Phylo
-import re, sys, json
-import numpy as np
+import re
+import sys
+import json
 import datetime as dt
+from argparse import SUPPRESS
+import numpy as np
+from Bio import Phylo
 from treetime import TreeAnc
 from .utils import write_json
 
-
-def register_arguments(parser):
+def register_arguments_beast(subparsers):
     """
-    Arguments available to `augur import-beast` -- see `__init__.py`
+    Arguments available to `augur import beast`
     """
-    parser.add_argument('--mcc', required=True, help="BEAST MCC tree")
-    parser.add_argument('--most-recent-tip-date', default=0, type=float, help='Numeric date of most recent tip in tree (--tip-date-regex, --tip-date-format and --tip-date-delimeter are ignored if this is set)')
-    parser.add_argument('--tip-date-regex', default=r'[0-9]{4}(\-[0-9]{2})*(\-[0-9]{2})*$', type=str, help='regex to extract dates from tip names')
-    parser.add_argument('--tip-date-format', default="%Y-%m-%d", type=str, help='Format of date (if extracted by regex)')
-    parser.add_argument('--tip-date-delimeter', default="-", type=str, help='delimeter used in tip-date-format. Used to match partial dates.')
-    parser.add_argument('--verbose', action="store_true", help="Display verbose output. Only useful for debugging.")
-    parser.add_argument('--recursion-limit', default=False, type=int, help="Set a custom recursion limit (dangerous!)")
-    parser.add_argument('--output-tree', required=True, type=str, help='file name to write tree to')
-    parser.add_argument('--output-node-data', required=True, type=str, help='file name to write (temporal) branch lengths & BEAST traits as node data')
-
-
+    beast_parser = subparsers.add_parser('beast', help="Import beast analysis")
+    beast_parser.add_argument("--beast", help=SUPPRESS, default=True) # used to disambiguate subcommands
+    beast_parser.add_argument('--mcc', required=True, help="BEAST MCC tree")
+    beast_parser.add_argument('--most-recent-tip-date', default=0, type=float, help='Numeric date of most recent tip in tree (--tip-date-regex, --tip-date-format and --tip-date-delimeter are ignored if this is set)')
+    beast_parser.add_argument('--tip-date-regex', default=r'[0-9]{4}(\-[0-9]{2})*(\-[0-9]{2})*$', type=str, help='regex to extract dates from tip names')
+    beast_parser.add_argument('--tip-date-format', default="%Y-%m-%d", type=str, help='Format of date (if extracted by regex)')
+    beast_parser.add_argument('--tip-date-delimeter', default="-", type=str, help='delimeter used in tip-date-format. Used to match partial dates.')
+    beast_parser.add_argument('--verbose', action="store_true", help="Display verbose output. Only useful for debugging.")
+    beast_parser.add_argument('--recursion-limit', default=False, type=int, help="Set a custom recursion limit (dangerous!)")
+    beast_parser.add_argument('--output-tree', required=True, type=str, help='file name to write tree to')
+    beast_parser.add_argument('--output-node-data', required=True, type=str, help='file name to write (temporal) branch lengths & BEAST traits as node data')
 
 def parse_beast_tree(data, tipMap, verbose=False):
     """
@@ -570,7 +571,7 @@ def print_what_to_do_next(nodes, mcc_path, tree_path, node_data_path):
 
 
 
-def run(args):
+def run_beast(args):
     '''
     BEAST MCC tree to newick and node-data JSON for further augur processing / export
     '''
@@ -583,7 +584,7 @@ def run(args):
 
     # node data is the dict that will be exported as json
     node_data = {
-        'comment': "Imported from a BEAST MCC tree using `augur import-beast`",
+        'comment': "Imported from a BEAST MCC tree using `augur import beast`",
         'mcc_file': args.mcc
     }
 

--- a/docs/faq/import-beast.md
+++ b/docs/faq/import-beast.md
@@ -1,6 +1,6 @@
 ## Importing BEAST MCC trees into augur
 
-This documentation details how to import BEAST MCC trees using `augur import-beast`.
+This documentation details how to import BEAST MCC trees using `augur import beast`.
 Currently this is most useful for producing auspice-compatable output using `augur export`, however in the future we will provide instructions on how to perform additional analysis using other augur tools.
 
 > BEAST 1 & 2 are extremely versitile tools.
@@ -8,14 +8,14 @@ We have tested augur on a number of BEAST runs, using both BEAST & BEAST 2, howe
 Please [get in touch](mailto:hello@nextstrain.org) if you encounter any issues.
 
 ### Steps
-1. Parse the BEAST tree using `augur import-beast`. Most of the options are explained below, but run with `--help` to see them all.
+1. Parse the BEAST tree using `augur import beast`. Most of the options are explained below, but run with `--help` to see them all.
 This produces a newick tree file and a node-data JSON file containing BEAST traits as well as (temporal) branch lengths.
 
 2. It may be necessary to modify the format of the traits written to the node-data JSON. These are extracted directly from the BEAST-created annotations in the NEXUS file. For example, if you have encoded location or host as integers, then you should map these back to their true values now.
 
 3. Create an `auspice-config.json` file, which is needed for various display options in auspice.
 A template is provided as terminal output from step (1), however there is not enough information in the MCC tree to do this automatically.
-Pay particular attention to the color-variable types, which can either be "continuous" or "discrete". 
+Pay particular attention to the color-variable types, which can either be "continuous" or "discrete".
 
 4. Extra metadata can be included here -- either as an additional node-data JSON file, or in TSV format.
 Any additional metadata must be both specified in the `auspice-config.json` file and provided to `augur export`.
@@ -34,7 +34,7 @@ Helpfully for us, the sample-date is often encoded in the tip name -- for instan
 
 If the dates are not encoded in the tip names, or no tip-names are used, then you will need to provide the date of the most recent tip (in decimal format) via the `--most-recent-tip-date` argument.
 
-If the dates are provided in the tip names, then we use a regex to extract this (`--tip-date-regex`, the default finds "YYYY-MM-DD" at the end of the tip name). The date format may also be specified if needed via `--tip-date-format`, which is interpreted by the python datetime module,  [see here](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior) for help with these formats. 
+If the dates are provided in the tip names, then we use a regex to extract this (`--tip-date-regex`, the default finds "YYYY-MM-DD" at the end of the tip name). The date format may also be specified if needed via `--tip-date-format`, which is interpreted by the python datetime module,  [see here](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior) for help with these formats.
 
 
 ### BEAST inferred traits
@@ -53,7 +53,7 @@ posterior           273         0
 
 ### Examples
 ```
-augur import-beast --mcc data/MERS_CoV_mcc.tree --output-tree results/mers.new
+augur import beast --mcc data/MERS_CoV_mcc.tree --output-tree results/mers.new
     --output-node-data results/beast_data.json
 augur export v1 --tree results/mers.new --node-data results/beast_data.json
     --auspice-config config/auspice_config.json
@@ -61,7 +61,9 @@ augur export v1 --tree results/mers.new --node-data results/beast_data.json
 ```
 
 ```
-augur import-beast --mcc data/beast.mcc.nex --output-tree results/mers.new
+augur import beast --mcc data/beast.mcc.nex --output-tree results/mers.new
     --output-node-data results/beast_data.json
     --most-recent-tip-date 2018.43
 ```
+
+A full [example build can be found here](https://github.com/nextstrain/augur/tree/master/tests/builds/beast_mers).

--- a/docs/usage/cli/cli.rst
+++ b/docs/usage/cli/cli.rst
@@ -28,4 +28,4 @@ We're in the process of adding examples and more extensive documentation for eac
 	export
 	validate
 	version
-	import-beast
+	import

--- a/docs/usage/cli/import.rst
+++ b/docs/usage/cli/import.rst
@@ -1,10 +1,9 @@
 ===========================
-augur import-beast
+augur import
 ===========================
 
 .. argparse::
     :module: augur
     :func: make_parser
     :prog: augur
-    :path: import-beast
-        
+    :path: import

--- a/tests/builds/beast_mers/Snakefile
+++ b/tests/builds/beast_mers/Snakefile
@@ -17,7 +17,7 @@ rule import_beast:
         tree = "results/tree.new"
     shell:
         """
-        augur import-beast \
+        augur import beast \
             --mcc {input.mcc_tree} \
             --output-tree {output.tree} \
             --output-node-data {output.node_data}


### PR DESCRIPTION
We had previously used the command `augur import-beast`. This PR changes this to `augur import beast` to match use of subcommands for `augur export v1` and `augur export v2`. 

Most things should be pretty straight forward here, however, I did have to use the `importlib` module to import `'import'` instead of `import` because `import` is a reserved word in Python. I do think this cleaned up `__init__.py` slightly.