### PR TITLE
Fix weighted frequencies when weight keys are unrepresented

### DIFF
--- a/tests/python3/test_frequencies.py
+++ b/tests/python3/test_frequencies.py
@@ -1,18 +1,19 @@
 """
 Unit tests for frequency estimation
 """
-import json
-import sys
-from pathlib import Path
-import numpy as np
-import pytest
 import Bio
-
-from augur.frequency_estimators import get_pivots, TreeKdeFrequencies, AlignmentKdeFrequencies
-from augur.utils import json_to_tree
+import json
+import numpy as np
+from pathlib import Path
+import pytest
+import sys
+import os
 
 # we assume (and assert) that this script is running from the tests/ directory
 sys.path.append(str(Path(__file__).parent.parent.parent))
+
+from augur.frequency_estimators import get_pivots, TreeKdeFrequencies, AlignmentKdeFrequencies
+from augur.utils import json_to_tree
 
 # Define regions to use for testing weighted frequencies.
 REGIONS = [
@@ -95,6 +96,9 @@ class TestTreeKdeFrequencies(object):
         assert hasattr(kde_frequencies, "frequencies")
         assert list(frequencies.values())[0].shape == kde_frequencies.pivots.shape
 
+        # Frequencies should sum to 1 at all pivots.
+        assert np.allclose(np.array(list(frequencies.values())).sum(axis=0), np.ones_like(kde_frequencies.pivots))
+
     def test_estimate_with_time_interval(self, tree):
         """Test frequency estimation with a given time interval.
         """
@@ -124,6 +128,9 @@ class TestTreeKdeFrequencies(object):
         assert hasattr(kde_frequencies, "frequencies")
         assert list(frequencies.values())[0].shape == kde_frequencies.pivots.shape
 
+        # Frequencies should sum to 1 at all pivots.
+        assert np.allclose(np.array(list(frequencies.values())).sum(axis=0), np.ones_like(kde_frequencies.pivots))
+
         # Estimate unweighted frequencies to compare with weighted frequencies.
         unweighted_kde_frequencies = TreeKdeFrequencies()
         unweighted_frequencies = unweighted_kde_frequencies.estimate(tree)
@@ -135,6 +142,36 @@ class TestTreeKdeFrequencies(object):
             frequencies[clade_to_test.name],
             unweighted_frequencies[clade_to_test.name]
         )
+
+    def test_weighted_estimate_with_unrepresented_weights(self, tree):
+        """Test frequency estimation with weighted tips when any of the weight
+        attributes is unrepresented.
+
+        In this case, normalization of frequencies to the proportions
+        represented by the weights should be followed by a second normalization
+        to sum to 1.
+        """
+        # Drop all tips sampled from Africa from the tree. Despite dropping a
+        # populous region, the estimated frequencies should still sum to 1
+        # below.
+        tips_from_africa = [
+            tip
+            for tip in tree.find_clades(terminal=True)
+            if tip.attr["region"] == "africa"
+        ]
+        for tip in tips_from_africa:
+            tree.prune(tip)
+
+        # Estimate weighted frequencies.
+        weights = {region[0]: region[1] for region in REGIONS}
+        kde_frequencies = TreeKdeFrequencies(
+            weights=weights,
+            weights_attribute="region"
+        )
+        frequencies = kde_frequencies.estimate(tree)
+
+        # Frequencies should sum to 1 at all pivots.
+        assert np.allclose(np.array(list(frequencies.values())).sum(axis=0), np.ones_like(kde_frequencies.pivots))
 
     def test_only_tip_estimates(self, tree):
         """Test frequency estimation for only tips in a given tree.


### PR DESCRIPTION
This is a rebase of @huddlej's PR #418 onto the new v6 `master` branch.

>Fixes a bug in weighted KDE estimation of tree frequencies when one or more weight attributes is not represented by any tips on the tree. For example, when a tree is missing any samples from Africa but the frequencies are being weighted by region, the total of the estimated frequencies will not sum to 1.

>This PR adds unit tests to confirm the original issue and adds logic to KDE frequency estimation to correct the issue. This PR also updates the Travis CI config to source the canonical Nextstrain environment.

Closes #268.