### PR TITLE
export v2: footer description option

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -30,6 +30,11 @@
                     "description": "Auspice displays this at the top of the page as part of a byline",
                     "type" : "string"
                 },
+                "description" : {
+                    "description": "Auspice displays this currently in the footer.",
+                    "$comment": "Generally a description of the phylogeny and/or acknowledgements in Markdown format.",
+                    "type": "string"
+                },
                 "maintainers": {
                     "description": "Who maintains this dataset?",
                     "$comment": "order similar to a publication",

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -773,15 +773,12 @@ def set_description(data_json, cmd_line_description_file):
     Read Markdown file provided by *cmd_line_description_file* and set
     `meta.description` in *data_json* to the text provided.
     """
-    if not cmd_line_description_file.endswith('.md'):
-        fatal("Provided description file needs to be a Markdown file.")
-
-    if not os.path.isfile(cmd_line_description_file):
-        fatal("Provided description file {} does not exist".format(cmd_line_description_file))
-
-    with open(cmd_line_description_file) as description_file:
-        markdown_text = ''.join(description_file.readlines())
-        data_json['meta']['description'] = markdown_text
+    try:
+        with open(cmd_line_description_file) as description_file:
+            markdown_text = description_file.read()
+            data_json['meta']['description'] = markdown_text
+    except FileNotFoundError:
+        fatal("Provided desciption file {} does not exist".format(cmd_line_description_file))
 
 def parse_node_data_and_metadata(T, node_data_files, metadata_file):
     node_data = read_node_data(node_data_files) # node_data_files is an array of multiple files (or a single file)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -2,7 +2,7 @@
 Export JSON files suitable for visualization with auspice.
 """
 from pathlib import Path
-import sys
+import os, sys
 import time
 from collections import defaultdict
 import warnings
@@ -676,6 +676,7 @@ def register_arguments_v2(subparsers):
     config.add_argument('--title', type=str, metavar="title", help="Title to be displayed by auspice")
     config.add_argument('--maintainers', metavar="name", action="append", nargs='+', help="Analysis maintained by, in format 'Name <URL>' 'Name2 <URL>', ...")
     config.add_argument('--build-url', type=str, metavar="url", help="Build URL/repository to be displayed by Auspice")
+    config.add_argument('--description', metavar="description.md", help="Markdown file with description of build and/or acknowledgements to be displayed by Auspice")
     config.add_argument('--geo-resolutions', metavar="trait", nargs='+', help="Geographic traits to be displayed on map")
     config.add_argument('--color-by-metadata', metavar="trait", nargs='+', help="Metadata columns to include as coloring options")
     config.add_argument('--panels', metavar="panels", nargs='+', choices=['tree', 'map', 'entropy', 'frequencies'], help="Restrict panel display in auspice. Options are %(choices)s. Ignore this option to display all available panels.")
@@ -767,6 +768,21 @@ def set_build_url(data_json, config, cmd_line_build_url):
     elif config.get("build_url"):
         data_json['meta']['build_url'] = config.get("build_url")
 
+def set_description(data_json, cmd_line_description_file):
+    """
+    Read Markdown file provided by *cmd_line_description_file* and set
+    `meta.description` in *data_json* to the text provided.
+    """
+    if not cmd_line_description_file.endswith('.md'):
+        fatal("Provided description file needs to be a Markdown file.")
+
+    if not os.path.isfile(cmd_line_description_file):
+        return warning("Provided description file {} does not exist".format(cmd_line_description_file))
+
+    with open(cmd_line_description_file) as description_file:
+        markdown_text = ''.join(description_file.readlines())
+        data_json['meta']['description'] = markdown_text
+
 def parse_node_data_and_metadata(T, node_data_files, metadata_file):
     node_data = read_node_data(node_data_files) # node_data_files is an array of multiple files (or a single file)
     metadata, _ = read_metadata(metadata_file) # metadata={} if file isn't read / doeesn't exist
@@ -826,6 +842,8 @@ def run_v2(args):
     set_maintainers(data_json, config, args.maintainers)
     set_build_url(data_json, config, args.build_url)
     set_annotations(data_json, node_data)
+    if args.description:
+        set_description(data_json, args.description)
 
     set_colorings(
         data_json=data_json,

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -777,7 +777,7 @@ def set_description(data_json, cmd_line_description_file):
         fatal("Provided description file needs to be a Markdown file.")
 
     if not os.path.isfile(cmd_line_description_file):
-        return warning("Provided description file {} does not exist".format(cmd_line_description_file))
+        fatal("Provided description file {} does not exist".format(cmd_line_description_file))
 
     with open(cmd_line_description_file) as description_file:
         markdown_text = ''.join(description_file.readlines())

--- a/docs/releases/migrating-v5-v6.md
+++ b/docs/releases/migrating-v5-v6.md
@@ -173,6 +173,10 @@ You will need to use quotes in the same way even if you only have one maintainer
 Set the build URL displayed by Auspice via `--build-url`.
 If running directly from the command line, input your build URL directly (ex: `--build-url https://github.com/nextstrain/zika`).
 
+### Description
+Set the description and/or acknowledgments in the footer of Auspice via `--description`.
+This option expects a Markdown file containing description to be displayed.
+
 ### Panels
 
 Auspice will, by default, try to show the tree, map, and entropy panels.

--- a/tests/builds/various_export_settings/Snakefile
+++ b/tests/builds/various_export_settings/Snakefile
@@ -6,11 +6,13 @@ rule all:
         time_only = "auspice/v2_time-only-tree.json",
         div_only = "auspice/v2_div-only-tree.json",
         bool_metadata = "auspice/v2_boolean-metadata.json",
-        default_layout = "auspice/v2_default-layout.json"
+        default_layout = "auspice/v2_default-layout.json",
+        footer = "auspice/v2_custom-footer.json"
 rule files:
     params:
         hidden_nodes = "data/hidden_nodes.json",
-        boolean_metadata = "data/metadata_boolean.tsv"
+        boolean_metadata = "data/metadata_boolean.tsv",
+        footer_description = "config/footer-description.md"
 files = rules.files.params
 
 rule refine_with_temporal_information:
@@ -181,6 +183,26 @@ rule export_with_default_layout:
             --metadata {input.metadata} \
             --colors {input.colors} \
             --auspice-config {input.config} \
+            --output {output.auspice}
+        """
+
+rule export_with_custom_footer_description:
+    message: "Exporting (v2) with custom footer description"
+    input:
+        tree = {rules.refine_with_temporal_information.output.tree},
+        branch_lengths = {rules.refine_with_temporal_information.output.node_data},
+        metadata = {rules.parse.output.metadata},
+        footer = {files.footer_description}
+    output:
+        auspice = rules.all.input.footer,
+    shell:
+        """
+        augur export v2 \
+            --tree {input.tree} \
+            --node-data {input.branch_lengths} \
+            --metadata {input.metadata} \
+            --description {input.footer} \
+            --title "Custom footer" \
             --output {output.auspice}
         """
 

--- a/tests/builds/various_export_settings/config/footer-description.md
+++ b/tests/builds/various_export_settings/config/footer-description.md
@@ -18,24 +18,27 @@
 
 <script>alert("Do bad things")</script>
 
+---
+horizontal
+***
+rule
+___
+
+Inline `code` with back-ticks around it.
+
+```
+Code block
+Does not include syntax highlighting
+```
+
 This work is made possible by the open sharing of genetic data by research groups from all over the world.
 We gratefully acknowledge their contributions.
 
-Markdown Image without HTML and style renders as a centered image:
+Markdown image renders as a centered image:
 
-![Markdown img](https://nextstrain.org/static/nextstrain-logo-small.ea8c3e13.png)
-![Markdown img](https://nextstrain.org/static/nextstrain-logo-small.ea8c3e13.png)
+[![Markdown img](https://nextstrain.org/static/nextstrain-logo-small.ea8c3e13.png)](https://nextstrain.org)
 
-Custom HTML with style to customize display of images:
+Multiple images with one or no line breaks are centered together:
 
-<div style="display: flex; justify-content: space-between;">
-    <div style="flex: 5;"></div>
-    <a key={5} href="https://gisaid.org" target="_blank" rel="noreferrer noopener" style="display: flex; flex-direction: column; justify-content: center;">
-        <img alt="gisaid-logo" width="120" src="https://www.gisaid.org/fileadmin/gisaid/img/schild.png"/>
-    </a>
-    <div style="flex: 1;"></div>
-    <a key={6} href="http://www.who.int/influenza/gisrs_laboratory/en/" target="_blank" rel="noreferrer noopener">
-        <img alt="gisrs-logo" width="120" src="https://www.who.int/influenza/gip-anniversary/GISRS_insignia_web_resize_.jpg"/>
-    </a>
-    <div style="flex: 5;"></div>
-</div>
+[![Markdown img](https://nextstrain.org/static/nextstrain-logo-small.ea8c3e13.png)](https://nextstrain.org)[![Markdown img](https://nextstrain.org/static/nextstrain-logo-small.ea8c3e13.png)](https://nextstrain.org)
+

--- a/tests/builds/various_export_settings/config/footer-description.md
+++ b/tests/builds/various_export_settings/config/footer-description.md
@@ -1,0 +1,41 @@
+# H1 Header
+## H2 Header
+### H3 Header
+#### H4 Header
+##### H5 Header
+###### H6 Header
+
+* bullet
+* point
+* list
+
+1. numerical
+1. list
+
+[internal link](http://localhost:4000/v2/custom-footer?l=radial) should remain in same tab.
+
+[external link](https://github.com) should open in a new tab.
+
+<script>alert("Do bad things")</script>
+
+This work is made possible by the open sharing of genetic data by research groups from all over the world.
+We gratefully acknowledge their contributions.
+
+Markdown Image without HTML and style renders as a centered image:
+
+![Markdown img](https://nextstrain.org/static/nextstrain-logo-small.ea8c3e13.png)
+![Markdown img](https://nextstrain.org/static/nextstrain-logo-small.ea8c3e13.png)
+
+Custom HTML with style to customize display of images:
+
+<div style="display: flex; justify-content: space-between;">
+    <div style="flex: 5;"></div>
+    <a key={5} href="https://gisaid.org" target="_blank" rel="noreferrer noopener" style="display: flex; flex-direction: column; justify-content: center;">
+        <img alt="gisaid-logo" width="120" src="https://www.gisaid.org/fileadmin/gisaid/img/schild.png"/>
+    </a>
+    <div style="flex: 1;"></div>
+    <a key={6} href="http://www.who.int/influenza/gisrs_laboratory/en/" target="_blank" rel="noreferrer noopener">
+        <img alt="gisrs-logo" width="120" src="https://www.who.int/influenza/gip-anniversary/GISRS_insignia_web_resize_.jpg"/>
+    </a>
+    <div style="flex: 5;"></div>
+</div>


### PR DESCRIPTION
For `export v2` add a `--description` option that takes a Markdown file and adds the text to the JSON in `meta.description`. 

This PR is dependent on https://github.com/nextstrain/auspice/pull/834 to render the footer text in Auspice. 