### PR TITLE
Handle missing weight attributes in KDE frequency estimation

### DIFF
--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -8,7 +8,7 @@ from Bio import Phylo, AlignIO
 from Bio.Align import MultipleSeqAlignment
 
 from .frequency_estimators import get_pivots, alignment_frequencies, tree_frequencies
-from .frequency_estimators import AlignmentKdeFrequencies, TreeKdeFrequencies
+from .frequency_estimators import AlignmentKdeFrequencies, TreeKdeFrequencies, TreeKdeFrequenciesError
 from .utils import read_metadata, read_node_data, write_json, get_numerical_dates
 
 
@@ -162,7 +162,12 @@ def run(args):
                 include_internal_nodes=args.include_internal_nodes,
                 censored=args.censored
             )
-            frequencies = kde_frequencies.estimate(tree)
+
+            try:
+                frequencies = kde_frequencies.estimate(tree)
+            except TreeKdeFrequenciesError as e:
+                print("ERROR: %s" % str(e), file=sys.stderr)
+                return 1
 
             # Export frequencies in auspice-format by strain name.
             frequency_dict = {"pivots": list(kde_frequencies.pivots)}

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -12,6 +12,12 @@ debug = False
 log_thres = 10.0
 
 
+class TreeKdeFrequenciesError(Exception):
+    """Represents an error estimating KDE frequencies for a tree.
+    """
+    pass
+
+
 def get_pivots(observations, pivot_interval, start_date=None, end_date=None):
     """Calculate pivots for a given list of floating point observation dates and
     interval between pivots.
@@ -1142,6 +1148,13 @@ class TreeKdeFrequencies(KdeFrequencies):
                 weight_total = sum(self.weights.values())
                 for key, value in self.weights.items():
                     self.weights[key] = value / weight_total
+
+            # Confirm that one or more weights are represented by tips in the
+            # tree. If there are no more weights, raise an exception because
+            # this likely represents a data error (either in the tree
+            # annotations or the weight definitions).
+            if len(self.weights) == 0:
+                raise TreeKdeFrequenciesError("None of the provided weight attributes were represented by tips in the given tree. Doublecheck weight attribute definitions and their representations in the tree.")
 
             # Estimate frequencies for all tips within each weight attribute
             # group.

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -1166,7 +1166,7 @@ class TreeKdeFrequencies(KdeFrequencies):
                 # Find tips with the current weight attribute.
                 tips = [(tip.name, tip.attr["num_date"])
                         for tip in tree.get_terminals()
-                        if tip.attr[self.weights_attribute].lower() == weight_key and self.tip_passes_filters(tip)]
+                        if tip.attr[self.weights_attribute] == weight_key and self.tip_passes_filters(tip)]
                 frequencies.update(self.estimate_tip_frequencies_to_proportion(tips, proportion))
         else:
             tips = [(tip.name, tip.attr["num_date"])


### PR DESCRIPTION
Throw an exception if the user has requested weighted KDE frequencies with
weights that do not match any of the tips in the given tree. This commit
explicitly checks for an empty dictionary of weights after filtering for
representation by tips and raise an exception with a meaningful error
message (instead of allowing the code to continue running and throwing a less
meaningful ValueError when no valid weights remain). This commit also adds a
unit test for this behavior.

Closes #425.