### PR TITLE
Support v2 auspice JSONs in json_to_tree

### DIFF
--- a/tests/data/zika.json
+++ b/tests/data/zika.json
@@ -1,0 +1,3325 @@
+{
+  "meta": {
+    "build_url": "https://github.com/nextstrain/zika-tutorial",
+    "colorings": [
+      {
+        "key": "gt",
+        "title": "Genotype",
+        "type": "categorical"
+      },
+      {
+        "key": "num_date",
+        "title": "Date",
+        "type": "continuous"
+      },
+      {
+        "key": "author",
+        "title": "Author",
+        "type": "categorical"
+      },
+      {
+        "key": "country",
+        "scale": [
+          [
+            "Thailand",
+            "#511EA8"
+          ],
+          [
+            "Singapore",
+            "#4334BF"
+          ],
+          [
+            "French Polynesia",
+            "#4041C7"
+          ],
+          [
+            "American Samoa",
+            "#3F50CC"
+          ],
+          [
+            "Brazil",
+            "#56A0AF"
+          ],
+          [
+            "Ecuador",
+            "#63AC99"
+          ],
+          [
+            "Colombia",
+            "#6BB18E"
+          ],
+          [
+            "Venezuela",
+            "#86BB6E"
+          ],
+          [
+            "Panama",
+            "#A4BE56"
+          ],
+          [
+            "Nicaragua",
+            "#AFBD4F"
+          ],
+          [
+            "Honduras",
+            "#B9BC4A"
+          ],
+          [
+            "Guatemala",
+            "#CCB742"
+          ],
+          [
+            "Puerto Rico",
+            "#E68234"
+          ],
+          [
+            "Dominican Republic",
+            "#E4632E"
+          ],
+          [
+            "USA",
+            "#DC2F24"
+          ]
+        ],
+        "title": "Country",
+        "type": "categorical"
+      },
+      {
+        "key": "region",
+        "scale": [
+          [
+            "Southeast Asia",
+            "#4274CE"
+          ],
+          [
+            "Oceania",
+            "#88BB6C"
+          ],
+          [
+            "South America",
+            "#E56C2F"
+          ],
+          [
+            "North America",
+            "#DC2F24"
+          ]
+        ],
+        "title": "Region",
+        "type": "categorical"
+      }
+    ],
+    "display_defaults": {
+      "map_triplicate": true
+    },
+    "filters": [
+      "country",
+      "region",
+      "author"
+    ],
+    "genome_annotations": {
+      "2K": {
+        "end": 6897,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 6829,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "CA": {
+        "end": 456,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 91,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "ENV": {
+        "end": 2472,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 961,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "MP": {
+        "end": 960,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 736,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "NS1": {
+        "end": 3528,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 2473,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "NS2A": {
+        "end": 4206,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 3529,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "NS2B": {
+        "end": 4596,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 4207,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "NS3": {
+        "end": 6447,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 4597,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "NS4A": {
+        "end": 6828,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 6448,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "NS4B": {
+        "end": 7650,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 6898,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "NS5": {
+        "end": 10359,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 7651,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "PRO": {
+        "end": 735,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 457,
+        "strand": "+",
+        "type": "CDS"
+      },
+      "nuc": {
+        "end": 10769,
+        "seqid": "config/zika_outgroup.gb",
+        "start": 1,
+        "strand": "+",
+        "type": "source"
+      }
+    },
+    "geo_resolutions": [
+      {
+        "demes": {
+          "American Samoa": {
+            "latitude": -14.27806,
+            "longitude": -170.7025
+          },
+          "Brazil": {
+            "latitude": -10.3333332,
+            "longitude": -53.1999999
+          },
+          "Colombia": {
+            "latitude": 2.893108,
+            "longitude": -73.7845142
+          },
+          "Dominican Republic": {
+            "latitude": 18.50012,
+            "longitude": -69.98857
+          },
+          "Ecuador": {
+            "latitude": -1.3397667,
+            "longitude": -79.3666964
+          },
+          "French Polynesia": {
+            "latitude": -17.6797,
+            "longitude": -149.4068
+          },
+          "Guatemala": {
+            "latitude": 15.6356088,
+            "longitude": -89.8988086
+          },
+          "Honduras": {
+            "latitude": 15.0610686,
+            "longitude": -84.5978533
+          },
+          "Nicaragua": {
+            "latitude": 13.0,
+            "longitude": -85.0
+          },
+          "Panama": {
+            "latitude": 8.3096067,
+            "longitude": -81.3066245
+          },
+          "Puerto Rico": {
+            "latitude": 18.2459121,
+            "longitude": -66.4164147
+          },
+          "Singapore": {
+            "latitude": 1.2904527,
+            "longitude": 103.852038
+          },
+          "Thailand": {
+            "latitude": 14.8971921,
+            "longitude": 100.83273
+          },
+          "USA": {
+            "latitude": 39.7837304,
+            "longitude": -100.4458824
+          },
+          "Venezuela": {
+            "latitude": 8.0,
+            "longitude": -66.0
+          }
+        },
+        "key": "country"
+      },
+      {
+        "demes": {
+          "North America": {
+            "latitude": 28.2367447,
+            "longitude": -97.738017
+          },
+          "Oceania": {
+            "latitude": -25.0562891,
+            "longitude": 152.008576
+          },
+          "South America": {
+            "latitude": -13.083583,
+            "longitude": -58.470721
+          },
+          "Southeast Asia": {
+            "latitude": 3.020567,
+            "longitude": 112.390683
+          }
+        },
+        "key": "region"
+      }
+    ],
+    "maintainers": [
+      {
+        "name": "Trevor Bedford",
+        "url": "http://bedford.io/team/trevor-bedford/"
+      }
+    ],
+    "panels": [
+      "tree",
+      "map"
+    ],
+    "title": "Tutorial Nextstrain build for Zika virus",
+    "updated": "2020-01-21"
+  },
+  "tree": {
+    "branch_attrs": {
+      "mutations": {}
+    },
+    "children": [
+      {
+        "branch_attrs": {
+          "labels": {
+            "aa": "NS3: H584Y; PRO: N17S"
+          },
+          "mutations": {
+            "NS3": [
+              "H584Y"
+            ],
+            "PRO": [
+              "N17S"
+            ],
+            "nuc": [
+              "A255G",
+              "A506G",
+              "T541C",
+              "G636A",
+              "A786G",
+              "A798G",
+              "T1224C",
+              "C1287A",
+              "T1389C",
+              "T1974C",
+              "C2175T",
+              "T2388C",
+              "G2508A",
+              "G2715A",
+              "T2782C",
+              "A3015T",
+              "T3120C",
+              "T3237C",
+              "C3882T",
+              "T3972C",
+              "T4068C",
+              "C4311T",
+              "G4437A",
+              "G4506A",
+              "T4716C",
+              "T4983C",
+              "T5043C",
+              "C5271T",
+              "A5358G",
+              "C5370T",
+              "A5619G",
+              "T5658C",
+              "C6039T",
+              "C6346T",
+              "A6489G",
+              "G6564A",
+              "A6667C",
+              "T7033C",
+              "C7635T",
+              "T8295A",
+              "T9000C",
+              "T9423G",
+              "G9438A",
+              "T9483C",
+              "G9735A",
+              "C9792T",
+              "A9936G",
+              "G10191A",
+              "G10272A",
+              "T10460C"
+            ]
+          }
+        },
+        "children": [
+          {
+            "branch_attrs": {
+              "labels": {
+                "aa": "NS1: K206R; NS2A: I80V; NS4B: A112T; NS5: N402K, N556H"
+              },
+              "mutations": {
+                "NS1": [
+                  "K206R"
+                ],
+                "NS2A": [
+                  "I80V"
+                ],
+                "NS4B": [
+                  "A112T"
+                ],
+                "NS5": [
+                  "N402K",
+                  "N556H"
+                ],
+                "nuc": [
+                  "T210C",
+                  "C405T",
+                  "C759T",
+                  "T876C",
+                  "T1041C",
+                  "G1869C",
+                  "G2529A",
+                  "A3089G",
+                  "A3162G",
+                  "G3270A",
+                  "A3750G",
+                  "C3757T",
+                  "A3766G",
+                  "C5496T",
+                  "A5832G",
+                  "A6144G",
+                  "C6264T",
+                  "T6993C",
+                  "T7170C",
+                  "G7231A",
+                  "T7320A",
+                  "C7461T",
+                  "C7672T",
+                  "T8052C",
+                  "T8190C",
+                  "C8856A",
+                  "A9316C",
+                  "G9327A"
+                ]
+              }
+            },
+            "name": "Thailand/1610acTw",
+            "node_attrs": {
+              "accession": "MF692778",
+              "author": {
+                "author": "Lin et al",
+                "journal": "Unpublished",
+                "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                "title": "Imported Zika virus strains, Taiwan, 2016",
+                "value": "Lin et al"
+              },
+              "country": {
+                "confidence": {
+                  "Thailand": 0.9999999999999999
+                },
+                "entropy": -9.99866855976916e-13,
+                "value": "Thailand"
+              },
+              "div": 0.006062745778482157,
+              "num_date": {
+                "confidence": [
+                  2016.7632394437605,
+                  2016.8350444900752
+                ],
+                "value": 2016.8350444900752
+              },
+              "region": {
+                "confidence": {
+                  "Southeast Asia": 0.9999999999999999
+                },
+                "entropy": -9.99866855976916e-13,
+                "value": "Southeast Asia"
+              },
+              "url": "https://www.ncbi.nlm.nih.gov/nuccore/MF692778"
+            }
+          },
+          {
+            "branch_attrs": {
+              "labels": {
+                "aa": "NS1: V194A; PRO: T74A"
+              },
+              "mutations": {
+                "NS1": [
+                  "V194A"
+                ],
+                "PRO": [
+                  "T74A"
+                ],
+                "nuc": [
+                  "A676G",
+                  "C1221T",
+                  "T1848C",
+                  "T3053C",
+                  "A3360G",
+                  "T3928C",
+                  "G4152A",
+                  "A5727G",
+                  "T6087C"
+                ]
+              }
+            },
+            "children": [
+              {
+                "branch_attrs": {
+                  "labels": {
+                    "aa": "PRO: G79V"
+                  },
+                  "mutations": {
+                    "PRO": [
+                      "G79V"
+                    ],
+                    "nuc": [
+                      "G692T",
+                      "C4716T",
+                      "G4767A",
+                      "G6489A",
+                      "A7821G",
+                      "A10335G"
+                    ]
+                  }
+                },
+                "name": "SG_018",
+                "node_attrs": {
+                  "accession": "KY241688",
+                  "author": {
+                    "author": "Ho et al",
+                    "journal": "Lancet Infect Dis (2017) In press",
+                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                    "title": "Outbreak of Zika virus infection in Singapore: an epidemiological, entomological, virological, and clinical analysis",
+                    "value": "Ho et al"
+                  },
+                  "country": {
+                    "confidence": {
+                      "Singapore": 1.0
+                    },
+                    "entropy": -1.000088900581841e-12,
+                    "value": "Singapore"
+                  },
+                  "div": 0.004848114488178502,
+                  "num_date": {
+                    "confidence": [
+                      2016.7036276522929,
+                      2016.7036276522929
+                    ],
+                    "value": 2016.7036276522929
+                  },
+                  "region": {
+                    "confidence": {
+                      "Southeast Asia": 1.0
+                    },
+                    "entropy": -1.000088900581841e-12,
+                    "value": "Southeast Asia"
+                  },
+                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY241688"
+                }
+              },
+              {
+                "branch_attrs": {
+                  "mutations": {
+                    "nuc": [
+                      "C4503T",
+                      "T6393C"
+                    ]
+                  }
+                },
+                "children": [
+                  {
+                    "branch_attrs": {
+                      "labels": {
+                        "aa": "PRO: A74T"
+                      },
+                      "mutations": {
+                        "PRO": [
+                          "A74T"
+                        ],
+                        "nuc": [
+                          "G676A",
+                          "C8016T",
+                          "T8433C"
+                        ]
+                      }
+                    },
+                    "name": "SG_056",
+                    "node_attrs": {
+                      "accession": "KY241726",
+                      "author": {
+                        "author": "Ho et al",
+                        "journal": "Lancet Infect Dis (2017) In press",
+                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                        "title": "Outbreak of Zika virus infection in Singapore: an epidemiological, entomological, virological, and clinical analysis",
+                        "value": "Ho et al"
+                      },
+                      "country": {
+                        "confidence": {
+                          "Singapore": 1.0
+                        },
+                        "entropy": -1.000088900581841e-12,
+                        "value": "Singapore"
+                      },
+                      "div": 0.004754911970176468,
+                      "num_date": {
+                        "confidence": [
+                          2016.6598220396988,
+                          2016.6598220396988
+                        ],
+                        "value": 2016.6598220396988
+                      },
+                      "region": {
+                        "confidence": {
+                          "Southeast Asia": 1.0
+                        },
+                        "entropy": -1.000088900581841e-12,
+                        "value": "Southeast Asia"
+                      },
+                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY241726"
+                    }
+                  },
+                  {
+                    "branch_attrs": {
+                      "mutations": {
+                        "nuc": [
+                          "T891C",
+                          "T7500A",
+                          "T7843C"
+                        ]
+                      }
+                    },
+                    "name": "SG_027",
+                    "node_attrs": {
+                      "accession": "KY241697",
+                      "author": {
+                        "author": "Ho et al",
+                        "journal": "Lancet Infect Dis (2017) In press",
+                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                        "title": "Outbreak of Zika virus infection in Singapore: an epidemiological, entomological, virological, and clinical analysis",
+                        "value": "Ho et al"
+                      },
+                      "country": {
+                        "confidence": {
+                          "Singapore": 1.0
+                        },
+                        "entropy": -1.000088900581841e-12,
+                        "value": "Singapore"
+                      },
+                      "div": 0.004754946479460192,
+                      "num_date": {
+                        "confidence": [
+                          2016.6570841889118,
+                          2016.6570841889118
+                        ],
+                        "value": 2016.6570841889118
+                      },
+                      "region": {
+                        "confidence": {
+                          "Southeast Asia": 1.0
+                        },
+                        "entropy": -1.000088900581841e-12,
+                        "value": "Southeast Asia"
+                      },
+                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY241697"
+                    }
+                  },
+                  {
+                    "branch_attrs": {
+                      "mutations": {}
+                    },
+                    "name": "SG_074",
+                    "node_attrs": {
+                      "accession": "KY241744",
+                      "author": {
+                        "author": "Ho et al",
+                        "journal": "Lancet Infect Dis (2017) In press",
+                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                        "title": "Outbreak of Zika virus infection in Singapore: an epidemiological, entomological, virological, and clinical analysis",
+                        "value": "Ho et al"
+                      },
+                      "country": {
+                        "confidence": {
+                          "Singapore": 1.0
+                        },
+                        "entropy": -1.000088900581841e-12,
+                        "value": "Singapore"
+                      },
+                      "div": 0.004475742593493351,
+                      "num_date": {
+                        "confidence": [
+                          2016.6598220396988,
+                          2016.6598220396988
+                        ],
+                        "value": 2016.6598220396988
+                      },
+                      "region": {
+                        "confidence": {
+                          "Southeast Asia": 1.0
+                        },
+                        "entropy": -1.000088900581841e-12,
+                        "value": "Southeast Asia"
+                      },
+                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY241744"
+                    }
+                  }
+                ],
+                "name": "NODE_0000016",
+                "node_attrs": {
+                  "country": {
+                    "confidence": {
+                      "Singapore": 0.9999932253017484
+                    },
+                    "entropy": 9.865735249916702e-05,
+                    "value": "Singapore"
+                  },
+                  "div": 0.004475742593493351,
+                  "num_date": {
+                    "confidence": [
+                      2016.2323577118088,
+                      2016.5804886634542
+                    ],
+                    "value": 2016.4951975467675
+                  },
+                  "region": {
+                    "confidence": {
+                      "Southeast Asia": 0.9999990287502224
+                    },
+                    "entropy": 1.5156989710741505e-05,
+                    "value": "Southeast Asia"
+                  }
+                }
+              }
+            ],
+            "name": "NODE_0000015",
+            "node_attrs": {
+              "country": {
+                "confidence": {
+                  "French Polynesia": 0.0013225477641056462,
+                  "Singapore": 0.9903426132497476,
+                  "Thailand": 0.0060327163474586665
+                },
+                "entropy": 0.06884860953541636,
+                "value": "Singapore"
+              },
+              "div": 0.004289642209177104,
+              "num_date": {
+                "confidence": [
+                  2015.735255867066,
+                  2016.3793853319605
+                ],
+                "value": 2016.2295383141993
+              },
+              "region": {
+                "confidence": {
+                  "Southeast Asia": 0.9996664079056886
+                },
+                "entropy": 0.003159805758690683,
+                "value": "Southeast Asia"
+              }
+            }
+          }
+        ],
+        "name": "NODE_0000014",
+        "node_attrs": {
+          "country": {
+            "confidence": {
+              "American Samoa": 0.018376325602819488,
+              "French Polynesia": 0.05643588012182809,
+              "Singapore": 0.5700566347615479,
+              "Thailand": 0.2856391818018074
+            },
+            "entropy": 1.2657757704417625,
+            "value": "Singapore"
+          },
+          "div": 0.0034517963150515955,
+          "num_date": {
+            "confidence": [
+              2014.734171263111,
+              2015.8379709962574
+            ],
+            "value": 2015.2873904498272
+          },
+          "region": {
+            "confidence": {
+              "Oceania": 0.011566463645665737,
+              "Southeast Asia": 0.9871665071168743
+            },
+            "entropy": 0.07365657838133624,
+            "value": "Southeast Asia"
+          }
+        }
+      },
+      {
+        "branch_attrs": {
+          "mutations": {}
+        },
+        "children": [
+          {
+            "branch_attrs": {
+              "labels": {
+                "aa": "CA: S109N; ENV: K419R; NS1: R324Q; NS5: N624S, K670R"
+              },
+              "mutations": {
+                "CA": [
+                  "S109N"
+                ],
+                "ENV": [
+                  "K419R"
+                ],
+                "NS1": [
+                  "R324Q"
+                ],
+                "NS5": [
+                  "N624S",
+                  "K670R"
+                ],
+                "nuc": [
+                  "T249C",
+                  "G416A",
+                  "C789T",
+                  "T2032C",
+                  "T2076C",
+                  "A2216G",
+                  "T3321C",
+                  "G3443A",
+                  "C4428T",
+                  "T4602A",
+                  "A4671G",
+                  "T4740C",
+                  "T5286C",
+                  "T5676C",
+                  "T6405C",
+                  "C6475T",
+                  "T7026C",
+                  "G7230A",
+                  "C8145T",
+                  "T8652C",
+                  "C8748T",
+                  "A9521G",
+                  "T9595C",
+                  "A9659G",
+                  "A9768G",
+                  "C10596T"
+                ]
+              }
+            },
+            "children": [
+              {
+                "branch_attrs": {
+                  "mutations": {}
+                },
+                "name": "ZKC2/2016",
+                "node_attrs": {
+                  "accession": "KX253996",
+                  "author": {
+                    "author": "Wu et al",
+                    "journal": "Submitted (18-MAY-2016) Center for Diseases Control and Prevention of Guangdong Province; National Institute of Viral Disease Control and Prevention, China",
+                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                    "title": "Direct Submission",
+                    "value": "Wu et al"
+                  },
+                  "country": {
+                    "confidence": {
+                      "American Samoa": 1.0
+                    },
+                    "entropy": -1.000088900581841e-12,
+                    "value": "American Samoa"
+                  },
+                  "div": 0.003634074655722747,
+                  "num_date": {
+                    "confidence": [
+                      2016.1286789869953,
+                      2016.1286789869953
+                    ],
+                    "value": 2016.1286789869953
+                  },
+                  "region": {
+                    "confidence": {
+                      "Oceania": 1.0
+                    },
+                    "entropy": -1.000088900581841e-12,
+                    "value": "Oceania"
+                  },
+                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX253996"
+                }
+              },
+              {
+                "branch_attrs": {
+                  "mutations": {}
+                },
+                "name": "SMGC_1",
+                "node_attrs": {
+                  "accession": "KX266255",
+                  "author": {
+                    "author": "Bi et al",
+                    "journal": "Chin. Sci. Bull. 61 (22), 2463-2474 (2016)",
+                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                    "title": "Genetic and Biological Characterization for Zika Viruses Imported through Shenzhen Port",
+                    "value": "Bi et al"
+                  },
+                  "country": {
+                    "confidence": {
+                      "American Samoa": 1.0
+                    },
+                    "entropy": -1.000088900581841e-12,
+                    "value": "American Samoa"
+                  },
+                  "div": 0.003634074655722747,
+                  "num_date": {
+                    "confidence": [
+                      2016.123203285421,
+                      2016.123203285421
+                    ],
+                    "value": 2016.123203285421
+                  },
+                  "region": {
+                    "confidence": {
+                      "Oceania": 1.0
+                    },
+                    "entropy": -1.000088900581841e-12,
+                    "value": "Oceania"
+                  },
+                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX266255"
+                }
+              }
+            ],
+            "name": "NODE_0000013",
+            "node_attrs": {
+              "country": {
+                "confidence": {
+                  "American Samoa": 0.992460628497695,
+                  "French Polynesia": 0.004612063325374456
+                },
+                "entropy": 0.05677871395364968,
+                "value": "American Samoa"
+              },
+              "div": 0.003634074655722747,
+              "num_date": {
+                "confidence": [
+                  2016.0179883157218,
+                  2016.123203285421
+                ],
+                "value": 2016.123203285421
+              },
+              "region": {
+                "confidence": {
+                  "Oceania": 0.999699833680312
+                },
+                "entropy": 0.0029856512155387194,
+                "value": "Oceania"
+              }
+            }
+          },
+          {
+            "branch_attrs": {
+              "mutations": {
+                "nuc": [
+                  "G9711A"
+                ]
+              }
+            },
+            "children": [
+              {
+                "branch_attrs": {
+                  "mutations": {
+                    "nuc": [
+                      "C3433T",
+                      "A3639G",
+                      "G8478A"
+                    ]
+                  }
+                },
+                "name": "1_0087_PF",
+                "node_attrs": {
+                  "accession": "KX447509",
+                  "author": {
+                    "author": "Pettersson et al",
+                    "journal": "MBio 7 (5), e01239-16 (2016)",
+                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/27729507",
+                    "title": "How Did Zika Virus Emerge in the Pacific Islands and Latin America?",
+                    "value": "Pettersson et al"
+                  },
+                  "country": {
+                    "confidence": {
+                      "French Polynesia": 1.0
+                    },
+                    "entropy": -1.000088900581841e-12,
+                    "value": "French Polynesia"
+                  },
+                  "div": 0.0015829073375906743,
+                  "num_date": {
+                    "confidence": [
+                      2013.9270203623398,
+                      2013.9993155373031
+                    ],
+                    "value": 2013.9993155373031
+                  },
+                  "region": {
+                    "confidence": {
+                      "Oceania": 1.0
+                    },
+                    "entropy": -1.000088900581841e-12,
+                    "value": "Oceania"
+                  },
+                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX447509"
+                }
+              },
+              {
+                "branch_attrs": {
+                  "mutations": {
+                    "nuc": [
+                      "G1158A"
+                    ]
+                  }
+                },
+                "children": [
+                  {
+                    "branch_attrs": {
+                      "mutations": {
+                        "nuc": [
+                          "G765A",
+                          "G1827A",
+                          "T1974C"
+                        ]
+                      }
+                    },
+                    "name": "1_0181_PF",
+                    "node_attrs": {
+                      "accession": "KX447512",
+                      "author": {
+                        "author": "Pettersson et al",
+                        "journal": "MBio 7 (5), e01239-16 (2016)",
+                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/27729507",
+                        "title": "How Did Zika Virus Emerge in the Pacific Islands and Latin America?",
+                        "value": "Pettersson et al"
+                      },
+                      "country": {
+                        "confidence": {
+                          "French Polynesia": 1.0
+                        },
+                        "entropy": -1.000088900581841e-12,
+                        "value": "French Polynesia"
+                      },
+                      "div": 0.0016759332255144677,
+                      "num_date": {
+                        "confidence": [
+                          2013.930472049502,
+                          2013.9993155373031
+                        ],
+                        "value": 2013.9993155373031
+                      },
+                      "region": {
+                        "confidence": {
+                          "Oceania": 0.9999999999999999
+                        },
+                        "entropy": -9.99866855976916e-13,
+                        "value": "Oceania"
+                      },
+                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX447512"
+                    }
+                  },
+                  {
+                    "branch_attrs": {
+                      "mutations": {
+                        "nuc": [
+                          "A4227G",
+                          "C8748T"
+                        ]
+                      }
+                    },
+                    "name": "1_0199_PF",
+                    "node_attrs": {
+                      "accession": "KX447519",
+                      "author": {
+                        "author": "Pettersson et al",
+                        "journal": "MBio 7 (5), e01239-16 (2016)",
+                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/27729507",
+                        "title": "How Did Zika Virus Emerge in the Pacific Islands and Latin America?",
+                        "value": "Pettersson et al"
+                      },
+                      "country": {
+                        "confidence": {
+                          "French Polynesia": 1.0
+                        },
+                        "entropy": -1.000088900581841e-12,
+                        "value": "French Polynesia"
+                      },
+                      "div": 0.0015828804246597191,
+                      "num_date": {
+                        "confidence": [
+                          2013.8612195431779,
+                          2013.914442162902
+                        ],
+                        "value": 2013.914442162902
+                      },
+                      "region": {
+                        "confidence": {
+                          "Oceania": 0.9999999999999999
+                        },
+                        "entropy": -9.99866855976916e-13,
+                        "value": "Oceania"
+                      },
+                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX447519"
+                    }
+                  },
+                  {
+                    "branch_attrs": {
+                      "labels": {
+                        "aa": "NS5: M114V"
+                      },
+                      "mutations": {
+                        "NS5": [
+                          "M114V"
+                        ],
+                        "nuc": [
+                          "T2637C",
+                          "T3501C",
+                          "T7500C",
+                          "A7990G",
+                          "C8391T",
+                          "G9417A",
+                          "G10375A"
+                        ]
+                      }
+                    },
+                    "children": [
+                      {
+                        "branch_attrs": {
+                          "mutations": {
+                            "nuc": [
+                              "A5298G"
+                            ]
+                          }
+                        },
+                        "children": [
+                          {
+                            "branch_attrs": {
+                              "labels": {
+                                "aa": "CA: I80T; NS5: A91V"
+                              },
+                              "mutations": {
+                                "CA": [
+                                  "I80T"
+                                ],
+                                "NS5": [
+                                  "A91V"
+                                ],
+                                "nuc": [
+                                  "T329C",
+                                  "T762C",
+                                  "G1170T",
+                                  "G1458A",
+                                  "A1482G",
+                                  "C1887T",
+                                  "C2838T",
+                                  "T3549C",
+                                  "T3576C",
+                                  "C4866T",
+                                  "T5070C",
+                                  "T5139C",
+                                  "T6612A",
+                                  "T6654C",
+                                  "T7077C",
+                                  "T7134C",
+                                  "C7488T",
+                                  "C7922T",
+                                  "T8835C",
+                                  "T9000C",
+                                  "C9225T",
+                                  "C9279T"
+                                ]
+                              }
+                            },
+                            "name": "PRVABC59",
+                            "node_attrs": {
+                              "accession": "KU501215",
+                              "author": {
+                                "author": "Lanciotti et al",
+                                "journal": "Emerging Infect. Dis. 22 (5), 933-935 (2016)",
+                                "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/27088323",
+                                "title": "Phylogeny of Zika Virus in Western Hemisphere, 2015",
+                                "value": "Lanciotti et al"
+                              },
+                              "country": {
+                                "confidence": {
+                                  "Puerto Rico": 1.0
+                                },
+                                "entropy": -1.000088900581841e-12,
+                                "value": "Puerto Rico"
+                              },
+                              "div": 0.0041912661823382096,
+                              "num_date": {
+                                "confidence": [
+                                  2015.9263725823025,
+                                  2015.9993155373031
+                                ],
+                                "value": 2015.9993155373031
+                              },
+                              "region": {
+                                "confidence": {
+                                  "North America": 1.0
+                                },
+                                "entropy": -1.000088900581841e-12,
+                                "value": "North America"
+                              },
+                              "url": "https://www.ncbi.nlm.nih.gov/nuccore/KU501215"
+                            }
+                          },
+                          {
+                            "branch_attrs": {
+                              "mutations": {
+                                "nuc": [
+                                  "G4767A"
+                                ]
+                              }
+                            },
+                            "children": [
+                              {
+                                "branch_attrs": {
+                                  "labels": {
+                                    "aa": "ENV: S368G, I448V; NS5: P247S, K560R"
+                                  },
+                                  "mutations": {
+                                    "ENV": [
+                                      "S368G",
+                                      "I448V"
+                                    ],
+                                    "NS5": [
+                                      "P247S",
+                                      "K560R"
+                                    ],
+                                    "nuc": [
+                                      "A2062G",
+                                      "G2205A",
+                                      "A2302G",
+                                      "T2452C",
+                                      "T3036C",
+                                      "G3690A",
+                                      "T3928C",
+                                      "T6243C",
+                                      "G6627A",
+                                      "T7551C",
+                                      "T8028C",
+                                      "C8389T",
+                                      "C9069T",
+                                      "A9329G",
+                                      "T9432C"
+                                    ]
+                                  }
+                                },
+                                "name": "Brazil/2016/ZBRC16",
+                                "node_attrs": {
+                                  "accession": "KY558991",
+                                  "author": {
+                                    "author": "Faria et al",
+                                    "journal": "Nature 546 (7658), 406-410 (2017)",
+                                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538727",
+                                    "title": "Establishment and cryptic transmission of Zika virus in Brazil and the Americas",
+                                    "value": "Faria et al"
+                                  },
+                                  "country": {
+                                    "confidence": {
+                                      "Brazil": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "Brazil"
+                                  },
+                                  "div": 0.0036311576744931296,
+                                  "num_date": {
+                                    "confidence": [
+                                      2016.0520191649555,
+                                      2016.0520191649555
+                                    ],
+                                    "value": 2016.0520191649555
+                                  },
+                                  "region": {
+                                    "confidence": {
+                                      "South America": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "South America"
+                                  },
+                                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY558991"
+                                }
+                              },
+                              {
+                                "branch_attrs": {
+                                  "labels": {
+                                    "aa": "NS1: G100A; NS3: M572L; NS5: R525C"
+                                  },
+                                  "mutations": {
+                                    "NS1": [
+                                      "G100A"
+                                    ],
+                                    "NS3": [
+                                      "M572L"
+                                    ],
+                                    "NS5": [
+                                      "R525C"
+                                    ],
+                                    "nuc": [
+                                      "G2771C",
+                                      "G3600A",
+                                      "G3846A",
+                                      "G5178A",
+                                      "A6310C",
+                                      "T6708C",
+                                      "C6720T",
+                                      "C9223T"
+                                    ]
+                                  }
+                                },
+                                "children": [
+                                  {
+                                    "branch_attrs": {
+                                      "labels": {
+                                        "aa": "ENV: V56I; NS5: K174R"
+                                      },
+                                      "mutations": {
+                                        "ENV": [
+                                          "V56I"
+                                        ],
+                                        "NS5": [
+                                          "K174R"
+                                        ],
+                                        "nuc": [
+                                          "G1126A",
+                                          "A1689G",
+                                          "A2313T",
+                                          "C6475T",
+                                          "G6966A",
+                                          "C7749T",
+                                          "T8094C",
+                                          "A8171G",
+                                          "G9438A"
+                                        ]
+                                      }
+                                    },
+                                    "name": "V8375",
+                                    "node_attrs": {
+                                      "accession": "KU501217",
+                                      "author": {
+                                        "author": "Lanciotti et al",
+                                        "journal": "Emerging Infect. Dis. 22 (5), 933-935 (2016)",
+                                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/27088323",
+                                        "title": "Phylogeny of Zika Virus in Western Hemisphere, 2015",
+                                        "value": "Lanciotti et al"
+                                      },
+                                      "country": {
+                                        "confidence": {
+                                          "Guatemala": 1.0
+                                        },
+                                        "entropy": -1.000088900581841e-12,
+                                        "value": "Guatemala"
+                                      },
+                                      "div": 0.0038166819893839504,
+                                      "num_date": {
+                                        "confidence": [
+                                          2015.8350444900752,
+                                          2015.8350444900752
+                                        ],
+                                        "value": 2015.8350444900752
+                                      },
+                                      "region": {
+                                        "confidence": {
+                                          "North America": 1.0
+                                        },
+                                        "entropy": -1.000088900581841e-12,
+                                        "value": "North America"
+                                      },
+                                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KU501217"
+                                    }
+                                  },
+                                  {
+                                    "branch_attrs": {
+                                      "mutations": {}
+                                    },
+                                    "children": [
+                                      {
+                                        "branch_attrs": {
+                                          "mutations": {
+                                            "nuc": [
+                                              "T4716C",
+                                              "T4888C",
+                                              "A6945G",
+                                              "T9516C"
+                                            ]
+                                          }
+                                        },
+                                        "name": "HND/2016/HU_ME59",
+                                        "node_attrs": {
+                                          "accession": "KY785418",
+                                          "author": {
+                                            "author": "Metsky et al",
+                                            "journal": "Nature 546 (7658), 411-415 (2017)",
+                                            "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538734",
+                                            "title": "Zika virus evolution and spread in the Americas",
+                                            "value": "Metsky et al"
+                                          },
+                                          "country": {
+                                            "confidence": {
+                                              "Honduras": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "Honduras"
+                                          },
+                                          "div": 0.0033511723642750133,
+                                          "num_date": {
+                                            "confidence": [
+                                              2016.3668720054757,
+                                              2016.3668720054757
+                                            ],
+                                            "value": 2016.3668720054757
+                                          },
+                                          "region": {
+                                            "confidence": {
+                                              "North America": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "North America"
+                                          },
+                                          "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY785418"
+                                        }
+                                      },
+                                      {
+                                        "branch_attrs": {
+                                          "labels": {
+                                            "aa": "NS2B: S5G; NS4B: I176L"
+                                          },
+                                          "mutations": {
+                                            "NS2B": [
+                                              "S5G"
+                                            ],
+                                            "NS4B": [
+                                              "I176L"
+                                            ],
+                                            "nuc": [
+                                              "T1449C",
+                                              "A4219G",
+                                              "A6444G",
+                                              "A6846G",
+                                              "A7423T",
+                                              "G8064A"
+                                            ]
+                                          }
+                                        },
+                                        "name": "Nica1_16",
+                                        "node_attrs": {
+                                          "accession": "KX421195",
+                                          "author": {
+                                            "author": "Tabata et al",
+                                            "journal": "Cell Host Microbe 20 (2), 155-166 (2016)",
+                                            "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/27443522",
+                                            "title": "Zika Virus Targets Different Primary Human Placental Cells, Suggesting Two Routes for Vertical Transmission",
+                                            "value": "Tabata et al"
+                                          },
+                                          "country": {
+                                            "confidence": {
+                                              "Nicaragua": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "Nicaragua"
+                                          },
+                                          "div": 0.0035373565968549563,
+                                          "num_date": {
+                                            "confidence": [
+                                              2016.0520191649555,
+                                              2016.0520191649555
+                                            ],
+                                            "value": 2016.0520191649555
+                                          },
+                                          "region": {
+                                            "confidence": {
+                                              "North America": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "North America"
+                                          },
+                                          "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX421195"
+                                        }
+                                      }
+                                    ],
+                                    "name": "NODE_0000035",
+                                    "node_attrs": {
+                                      "country": {
+                                        "confidence": {
+                                          "Brazil": 0.07258773439818494,
+                                          "Guatemala": 0.1235109172721121,
+                                          "Honduras": 0.42231346864283265,
+                                          "Nicaragua": 0.3352632040769463
+                                        },
+                                        "entropy": 1.4320177514771812,
+                                        "value": "Honduras"
+                                      },
+                                      "div": 0.0029790233816087207,
+                                      "num_date": {
+                                        "confidence": [
+                                          2015.4139336079654,
+                                          2015.8130158254037
+                                        ],
+                                        "value": 2015.5986176280699
+                                      },
+                                      "region": {
+                                        "confidence": {
+                                          "North America": 0.9970568164812601,
+                                          "South America": 0.0028985678416992822
+                                        },
+                                        "entropy": 0.020354464094882462,
+                                        "value": "North America"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "name": "NODE_0000021",
+                                "node_attrs": {
+                                  "country": {
+                                    "confidence": {
+                                      "Brazil": 0.2970086442622381,
+                                      "Guatemala": 0.4337171147187142,
+                                      "Honduras": 0.12488819775825626,
+                                      "Nicaragua": 0.0876697221097824
+                                    },
+                                    "entropy": 1.4912018052816578,
+                                    "value": "Guatemala"
+                                  },
+                                  "div": 0.0029790233816087207,
+                                  "num_date": {
+                                    "confidence": [
+                                      2015.283169359869,
+                                      2015.6242686822109
+                                    ],
+                                    "value": 2015.5187345444351
+                                  },
+                                  "region": {
+                                    "confidence": {
+                                      "North America": 0.9586617809504462,
+                                      "South America": 0.04108511614977397
+                                    },
+                                    "entropy": 0.17388750137214623,
+                                    "value": "North America"
+                                  }
+                                }
+                              }
+                            ],
+                            "name": "NODE_0000020",
+                            "node_attrs": {
+                              "country": {
+                                "confidence": {
+                                  "Brazil": 0.9124803041817018,
+                                  "Guatemala": 0.0370547562136477,
+                                  "Honduras": 0.009197018376985222,
+                                  "Puerto Rico": 0.02066181545527249
+                                },
+                                "entropy": 0.4523168522401672,
+                                "value": "Brazil"
+                              },
+                              "div": 0.002234338501222154,
+                              "num_date": {
+                                "confidence": [
+                                  2014.507703450436,
+                                  2015.1192558524997
+                                ],
+                                "value": 2014.818127947071
+                              },
+                              "region": {
+                                "confidence": {
+                                  "North America": 0.40905887928180185,
+                                  "South America": 0.5903277945718371
+                                },
+                                "entropy": 0.6817233798420169,
+                                "value": "South America"
+                              }
+                            }
+                          }
+                        ],
+                        "name": "NODE_0000019",
+                        "node_attrs": {
+                          "country": {
+                            "confidence": {
+                              "Brazil": 0.914408772587392,
+                              "French Polynesia": 0.006296551111378701,
+                              "Guatemala": 0.012903163382688479,
+                              "Puerto Rico": 0.05049262021340235
+                            },
+                            "entropy": 0.42203557146255816,
+                            "value": "Brazil"
+                          },
+                          "div": 0.0021413097543174623,
+                          "num_date": {
+                            "confidence": [
+                              2014.4659117626684,
+                              2014.9687184697136
+                            ],
+                            "value": 2014.6910466498791
+                          },
+                          "region": {
+                            "confidence": {
+                              "North America": 0.39086594504077976,
+                              "South America": 0.6082446060441037
+                            },
+                            "entropy": 0.6763055661103404,
+                            "value": "South America"
+                          }
+                        }
+                      },
+                      {
+                        "branch_attrs": {
+                          "mutations": {
+                            "nuc": [
+                              "C2517T",
+                              "T3972C"
+                            ]
+                          }
+                        },
+                        "children": [
+                          {
+                            "branch_attrs": {
+                              "mutations": {
+                                "nuc": [
+                                  "A1800C",
+                                  "A1851G",
+                                  "C2562T",
+                                  "C6600T",
+                                  "C7437T",
+                                  "G8031A",
+                                  "C8271T",
+                                  "A9936G"
+                                ]
+                              }
+                            },
+                            "name": "Brazil/2015/ZBRC301",
+                            "node_attrs": {
+                              "accession": "KY558995",
+                              "author": {
+                                "author": "Faria et al",
+                                "journal": "Nature 546 (7658), 406-410 (2017)",
+                                "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538727",
+                                "title": "Establishment and cryptic transmission of Zika virus in Brazil and the Americas",
+                                "value": "Faria et al"
+                              },
+                              "country": {
+                                "confidence": {
+                                  "Brazil": 1.0
+                                },
+                                "entropy": -1.000088900581841e-12,
+                                "value": "Brazil"
+                              },
+                              "div": 0.002978960245113952,
+                              "num_date": {
+                                "confidence": [
+                                  2015.3641341546886,
+                                  2015.3641341546886
+                                ],
+                                "value": 2015.3641341546886
+                              },
+                              "region": {
+                                "confidence": {
+                                  "South America": 1.0
+                                },
+                                "entropy": -1.000088900581841e-12,
+                                "value": "South America"
+                              },
+                              "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY558995"
+                            }
+                          },
+                          {
+                            "branch_attrs": {
+                              "mutations": {
+                                "nuc": [
+                                  "C7488T"
+                                ]
+                              }
+                            },
+                            "children": [
+                              {
+                                "branch_attrs": {
+                                  "labels": {
+                                    "aa": "CA: A106T"
+                                  },
+                                  "mutations": {
+                                    "CA": [
+                                      "A106T"
+                                    ],
+                                    "nuc": [
+                                      "G406A"
+                                    ]
+                                  }
+                                },
+                                "name": "Brazil/2015/ZBRC303",
+                                "node_attrs": {
+                                  "accession": "KY558997",
+                                  "author": {
+                                    "author": "Faria et al",
+                                    "journal": "Nature 546 (7658), 406-410 (2017)",
+                                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538727",
+                                    "title": "Establishment and cryptic transmission of Zika virus in Brazil and the Americas",
+                                    "value": "Faria et al"
+                                  },
+                                  "country": {
+                                    "confidence": {
+                                      "Brazil": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "Brazil"
+                                  },
+                                  "div": 0.002420405693213413,
+                                  "num_date": {
+                                    "confidence": [
+                                      2015.3668720054757,
+                                      2015.3668720054757
+                                    ],
+                                    "value": 2015.3668720054757
+                                  },
+                                  "region": {
+                                    "confidence": {
+                                      "South America": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "South America"
+                                  },
+                                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY558997"
+                                }
+                              },
+                              {
+                                "branch_attrs": {
+                                  "mutations": {
+                                    "nuc": [
+                                      "T876C",
+                                      "C2646T",
+                                      "A4341G",
+                                      "C5988T",
+                                      "T6618C",
+                                      "A7116G",
+                                      "T7506C",
+                                      "G8040A",
+                                      "A8820G",
+                                      "C9066T",
+                                      "T9717C"
+                                    ]
+                                  }
+                                },
+                                "name": "BRA/2016/FC_6706",
+                                "node_attrs": {
+                                  "accession": "KY785433",
+                                  "author": {
+                                    "author": "Metsky et al",
+                                    "journal": "Nature 546 (7658), 411-415 (2017)",
+                                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538734",
+                                    "title": "Zika virus evolution and spread in the Americas",
+                                    "value": "Metsky et al"
+                                  },
+                                  "country": {
+                                    "confidence": {
+                                      "Brazil": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "Brazil"
+                                  },
+                                  "div": 0.003351408405582982,
+                                  "num_date": {
+                                    "confidence": [
+                                      2016.2710472279261,
+                                      2016.2710472279261
+                                    ],
+                                    "value": 2016.2710472279261
+                                  },
+                                  "region": {
+                                    "confidence": {
+                                      "South America": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "South America"
+                                  },
+                                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY785433"
+                                }
+                              }
+                            ],
+                            "name": "NODE_0000005",
+                            "node_attrs": {
+                              "country": {
+                                "confidence": {
+                                  "Brazil": 0.9998027079363071
+                                },
+                                "entropy": 0.002350951391275563,
+                                "value": "Brazil"
+                              },
+                              "div": 0.0023273784912966502,
+                              "num_date": {
+                                "confidence": [
+                                  2014.9194223022832,
+                                  2015.3446823985967
+                                ],
+                                "value": 2015.2348626967755
+                              },
+                              "region": {
+                                "confidence": {
+                                  "South America": 0.9997791384096577
+                                },
+                                "entropy": 0.0021706373934097956,
+                                "value": "South America"
+                              }
+                            }
+                          },
+                          {
+                            "branch_attrs": {
+                              "labels": {
+                                "aa": "CA: D107E; NS1: R324W; NS5: T833A"
+                              },
+                              "mutations": {
+                                "CA": [
+                                  "D107E"
+                                ],
+                                "NS1": [
+                                  "R324W"
+                                ],
+                                "NS5": [
+                                  "T833A"
+                                ],
+                                "nuc": [
+                                  "A3C",
+                                  "T411A",
+                                  "T738C",
+                                  "C858T",
+                                  "G864T",
+                                  "C1381T",
+                                  "C3442T",
+                                  "A3894G",
+                                  "C5991T",
+                                  "C9279T",
+                                  "A10147G"
+                                ]
+                              }
+                            },
+                            "children": [
+                              {
+                                "branch_attrs": {
+                                  "labels": {
+                                    "aa": "PRO: N17K"
+                                  },
+                                  "mutations": {
+                                    "PRO": [
+                                      "N17K"
+                                    ],
+                                    "nuc": [
+                                      "C507A",
+                                      "C1233T",
+                                      "C2163T",
+                                      "T7843C",
+                                      "T10332C"
+                                    ]
+                                  }
+                                },
+                                "name": "Colombia/2016/ZC204Se",
+                                "node_attrs": {
+                                  "accession": "KY317939",
+                                  "author": {
+                                    "author": "Quick et al",
+                                    "journal": "Nat Protoc 12 (6), 1261-1276 (2017)",
+                                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538739",
+                                    "title": "Multiplex PCR method for MinION and Illumina sequencing of Zika and other virus genomes directly from clinical samples",
+                                    "value": "Quick et al"
+                                  },
+                                  "country": {
+                                    "confidence": {
+                                      "Colombia": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "Colombia"
+                                  },
+                                  "div": 0.0037238272340562747,
+                                  "num_date": {
+                                    "confidence": [
+                                      2016.0164271047229,
+                                      2016.0164271047229
+                                    ],
+                                    "value": 2016.0164271047229
+                                  },
+                                  "region": {
+                                    "confidence": {
+                                      "South America": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "South America"
+                                  },
+                                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY317939"
+                                }
+                              },
+                              {
+                                "branch_attrs": {
+                                  "mutations": {
+                                    "nuc": [
+                                      "T1029C",
+                                      "T3705C"
+                                    ]
+                                  }
+                                },
+                                "children": [
+                                  {
+                                    "branch_attrs": {
+                                      "labels": {
+                                        "aa": "NS2B: M32I"
+                                      },
+                                      "mutations": {
+                                        "NS2B": [
+                                          "M32I"
+                                        ],
+                                        "nuc": [
+                                          "G23A",
+                                          "A35T",
+                                          "G40A",
+                                          "T2538C",
+                                          "A3750G",
+                                          "G3771A",
+                                          "G4302A",
+                                          "C7056T",
+                                          "T10344C"
+                                        ]
+                                      }
+                                    },
+                                    "name": "PAN/CDC_259359_V1_V3/2015",
+                                    "node_attrs": {
+                                      "accession": "KX156774",
+                                      "author": {
+                                        "author": "Shabman et al",
+                                        "journal": "Submitted (29-APR-2016) J. Craig Venter Institute, 9704 Medical Center Drive, Rockville, MD 20850, USA",
+                                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                                        "title": "Direct Submission",
+                                        "value": "Shabman et al"
+                                      },
+                                      "country": {
+                                        "confidence": {
+                                          "Panama": 1.0
+                                        },
+                                        "entropy": -1.000088900581841e-12,
+                                        "value": "Panama"
+                                      },
+                                      "div": 0.004282330080250469,
+                                      "num_date": {
+                                        "confidence": [
+                                          2015.9637234770705,
+                                          2015.9637234770705
+                                        ],
+                                        "value": 2015.9637234770705
+                                      },
+                                      "region": {
+                                        "confidence": {
+                                          "North America": 1.0
+                                        },
+                                        "entropy": -1.000088900581841e-12,
+                                        "value": "North America"
+                                      },
+                                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX156774"
+                                    }
+                                  },
+                                  {
+                                    "branch_attrs": {
+                                      "mutations": {
+                                        "nuc": [
+                                          "G2895A",
+                                          "T3804C",
+                                          "C4311T",
+                                          "T4605G",
+                                          "C6643T",
+                                          "T8862G"
+                                        ]
+                                      }
+                                    },
+                                    "children": [
+                                      {
+                                        "branch_attrs": {
+                                          "labels": {
+                                            "aa": "CA: E76D; NS1: T301P; NS5: A833T"
+                                          },
+                                          "mutations": {
+                                            "CA": [
+                                              "E76D"
+                                            ],
+                                            "NS1": [
+                                              "T301P"
+                                            ],
+                                            "NS5": [
+                                              "A833T"
+                                            ],
+                                            "nuc": [
+                                              "G318T",
+                                              "G438T",
+                                              "C1233T",
+                                              "C1416T",
+                                              "A3373C",
+                                              "C8016T",
+                                              "G10147A"
+                                            ]
+                                          }
+                                        },
+                                        "name": "VEN/UF_1/2016",
+                                        "node_attrs": {
+                                          "accession": "KX702400",
+                                          "author": {
+                                            "author": "Blohm et al",
+                                            "journal": "Genome Announc 5 (17), e00231-17 (2017)",
+                                            "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28450510",
+                                            "title": "Complete Genome Sequences of Identical Zika virus Isolates in a Nursing Mother and Her Infant",
+                                            "value": "Blohm et al"
+                                          },
+                                          "country": {
+                                            "confidence": {
+                                              "Venezuela": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "Venezuela"
+                                          },
+                                          "div": 0.004654593679820323,
+                                          "num_date": {
+                                            "confidence": [
+                                              2016.2327173169062,
+                                              2016.2327173169062
+                                            ],
+                                            "value": 2016.2327173169062
+                                          },
+                                          "region": {
+                                            "confidence": {
+                                              "South America": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "South America"
+                                          },
+                                          "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX702400"
+                                        }
+                                      },
+                                      {
+                                        "branch_attrs": {
+                                          "mutations": {
+                                            "nuc": [
+                                              "T1506C"
+                                            ]
+                                          }
+                                        },
+                                        "children": [
+                                          {
+                                            "branch_attrs": {
+                                              "labels": {
+                                                "aa": "CA: I80T; ENV: D83E"
+                                              },
+                                              "mutations": {
+                                                "CA": [
+                                                  "I80T"
+                                                ],
+                                                "ENV": [
+                                                  "D83E"
+                                                ],
+                                                "nuc": [
+                                                  "T329C",
+                                                  "C1209G"
+                                                ]
+                                              }
+                                            },
+                                            "name": "COL/FLR_00024/2015",
+                                            "node_attrs": {
+                                              "accession": "MF574569",
+                                              "author": {
+                                                "author": "Pickett et al",
+                                                "journal": "Submitted J. Craig Venter Institute, 9704 Medical Center Drive, Rockville, MD 20850, USA",
+                                                "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                                                "title": "Direct Submission",
+                                                "value": "Pickett et al"
+                                              },
+                                              "country": {
+                                                "confidence": {
+                                                  "Colombia": 1.0
+                                                },
+                                                "entropy": -1.000088900581841e-12,
+                                                "value": "Colombia"
+                                              },
+                                              "div": 0.004282181917199624,
+                                              "num_date": {
+                                                "confidence": [
+                                                  2015.9171800136892,
+                                                  2015.9993155373031
+                                                ],
+                                                "value": 2015.9758118273248
+                                              },
+                                              "region": {
+                                                "confidence": {
+                                                  "South America": 1.0
+                                                },
+                                                "entropy": -1.000088900581841e-12,
+                                                "value": "South America"
+                                              },
+                                              "url": "https://www.ncbi.nlm.nih.gov/nuccore/MF574569"
+                                            }
+                                          },
+                                          {
+                                            "branch_attrs": {
+                                              "labels": {
+                                                "aa": "NS1: L169I, G292E"
+                                              },
+                                              "mutations": {
+                                                "NS1": [
+                                                  "L169I",
+                                                  "G292E"
+                                                ],
+                                                "nuc": [
+                                                  "C2977A",
+                                                  "G3347A",
+                                                  "G5655A",
+                                                  "T8445C"
+                                                ]
+                                              }
+                                            },
+                                            "name": "COL/FLR_00008/2015",
+                                            "node_attrs": {
+                                              "accession": "MF574562",
+                                              "author": {
+                                                "author": "Pickett et al",
+                                                "journal": "Submitted J. Craig Venter Institute, 9704 Medical Center Drive, Rockville, MD 20850, USA",
+                                                "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/",
+                                                "title": "Direct Submission",
+                                                "value": "Pickett et al"
+                                              },
+                                              "country": {
+                                                "confidence": {
+                                                  "Colombia": 1.0
+                                                },
+                                                "entropy": -1.000088900581841e-12,
+                                                "value": "Colombia"
+                                              },
+                                              "div": 0.0044683151459958504,
+                                              "num_date": {
+                                                "confidence": [
+                                                  2015.9320001197314,
+                                                  2015.9993155373031
+                                                ],
+                                                "value": 2015.9993155373031
+                                              },
+                                              "region": {
+                                                "confidence": {
+                                                  "South America": 1.0
+                                                },
+                                                "entropy": -1.000088900581841e-12,
+                                                "value": "South America"
+                                              },
+                                              "url": "https://www.ncbi.nlm.nih.gov/nuccore/MF574562"
+                                            }
+                                          }
+                                        ],
+                                        "name": "NODE_0000002",
+                                        "node_attrs": {
+                                          "country": {
+                                            "confidence": {
+                                              "Colombia": 0.9960752999113262,
+                                              "Venezuela": 0.0023052061046888064
+                                            },
+                                            "entropy": 0.03120418212341291,
+                                            "value": "Colombia"
+                                          },
+                                          "div": 0.004096071127207911,
+                                          "num_date": {
+                                            "confidence": [
+                                              2015.691344667236,
+                                              2015.9264328758395
+                                            ],
+                                            "value": 2015.846726764422
+                                          },
+                                          "region": {
+                                            "confidence": {
+                                              "South America": 0.9997138506957859
+                                            },
+                                            "entropy": 0.002708431477456873,
+                                            "value": "South America"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "name": "NODE_0000001",
+                                    "node_attrs": {
+                                      "country": {
+                                        "confidence": {
+                                          "Brazil": 0.009432678212238426,
+                                          "Colombia": 0.8479025385904583,
+                                          "Panama": 0.033292301819877565,
+                                          "Venezuela": 0.09848992349374022
+                                        },
+                                        "entropy": 0.600722560014408,
+                                        "value": "Colombia"
+                                      },
+                                      "div": 0.0040030376623026815,
+                                      "num_date": {
+                                        "confidence": [
+                                          2015.5982076495675,
+                                          2015.9008712071586
+                                        ],
+                                        "value": 2015.7821850094722
+                                      },
+                                      "region": {
+                                        "confidence": {
+                                          "North America": 0.0024646266674957255,
+                                          "South America": 0.9974930367874038
+                                        },
+                                        "entropy": 0.01775702934966808,
+                                        "value": "South America"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "name": "NODE_0000000",
+                                "node_attrs": {
+                                  "country": {
+                                    "confidence": {
+                                      "Brazil": 0.030921012666098042,
+                                      "Colombia": 0.8061349873152789,
+                                      "Panama": 0.11531333797329076,
+                                      "Venezuela": 0.03355679144449739
+                                    },
+                                    "entropy": 0.7379030986186881,
+                                    "value": "Colombia"
+                                  },
+                                  "div": 0.0034446082682922626,
+                                  "num_date": {
+                                    "confidence": [
+                                      2015.1796824557944,
+                                      2015.6761601106332
+                                    ],
+                                    "value": 2015.518770422409
+                                  },
+                                  "region": {
+                                    "confidence": {
+                                      "North America": 0.04919941042036439,
+                                      "South America": 0.9504704760957173
+                                    },
+                                    "entropy": 0.19931876157134126,
+                                    "value": "South America"
+                                  }
+                                }
+                              }
+                            ],
+                            "name": "NODE_0000003",
+                            "node_attrs": {
+                              "country": {
+                                "confidence": {
+                                  "Brazil": 0.09355903484367616,
+                                  "Colombia": 0.8504887725998999,
+                                  "Panama": 0.03316391101913413,
+                                  "Venezuela": 0.010385235489391907
+                                },
+                                "entropy": 0.6038106736552633,
+                                "value": "Colombia"
+                              },
+                              "div": 0.003258550432411002,
+                              "num_date": {
+                                "confidence": [
+                                  2015.1110930341,
+                                  2015.645894257714
+                                ],
+                                "value": 2015.3560676744319
+                              },
+                              "region": {
+                                "confidence": {
+                                  "North America": 0.002403118520249043,
+                                  "South America": 0.9975553606370509
+                                },
+                                "entropy": 0.017378320700107096,
+                                "value": "South America"
+                              }
+                            }
+                          }
+                        ],
+                        "name": "NODE_0000006",
+                        "node_attrs": {
+                          "country": {
+                            "confidence": {
+                              "Brazil": 0.998435098513569,
+                              "Colombia": 0.0010211013235945574
+                            },
+                            "entropy": 0.01372725352071052,
+                            "value": "Brazil"
+                          },
+                          "div": 0.002234350569640211,
+                          "num_date": {
+                            "confidence": [
+                              2014.5159564985709,
+                              2015.1044817731597
+                            ],
+                            "value": 2014.8044330711755
+                          },
+                          "region": {
+                            "confidence": {
+                              "South America": 0.9998843644910913
+                            },
+                            "entropy": 0.001180098062838102,
+                            "value": "South America"
+                          }
+                        }
+                      },
+                      {
+                        "branch_attrs": {
+                          "labels": {
+                            "aa": "NS1: M349V"
+                          },
+                          "mutations": {
+                            "NS1": [
+                              "M349V"
+                            ],
+                            "nuc": [
+                              "A3517G",
+                              "G6966A"
+                            ]
+                          }
+                        },
+                        "children": [
+                          {
+                            "branch_attrs": {
+                              "mutations": {
+                                "nuc": [
+                                  "T1275C",
+                                  "T1858C",
+                                  "T2409C",
+                                  "A2754G",
+                                  "A3780G",
+                                  "G4971T",
+                                  "C5532T",
+                                  "G5751A",
+                                  "G6453C",
+                                  "A6873G",
+                                  "C8232A",
+                                  "T8553C",
+                                  "C8850T",
+                                  "A9420G",
+                                  "G9933T",
+                                  "C10098T",
+                                  "A10347G",
+                                  "T10372C"
+                                ]
+                              }
+                            },
+                            "name": "EcEs062_16",
+                            "node_attrs": {
+                              "accession": "KX879603",
+                              "author": {
+                                "author": "Marquez et al",
+                                "journal": "Genome Announc 5 (8), e01673-16 (2017)",
+                                "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28232448",
+                                "title": "First Complete Genome Sequences of Zika Virus Isolated from Febrile Patient Sera in Ecuador",
+                                "value": "Marquez et al"
+                              },
+                              "country": {
+                                "confidence": {
+                                  "Ecuador": 0.9999999999999999
+                                },
+                                "entropy": -9.99866855976916e-13,
+                                "value": "Ecuador"
+                              },
+                              "div": 0.003911298969753885,
+                              "num_date": {
+                                "confidence": [
+                                  2016.2518822724162,
+                                  2016.322826046126
+                                ],
+                                "value": 2016.2518822724162
+                              },
+                              "region": {
+                                "confidence": {
+                                  "South America": 1.0
+                                },
+                                "entropy": -1.000088900581841e-12,
+                                "value": "South America"
+                              },
+                              "url": "https://www.ncbi.nlm.nih.gov/nuccore/KX879603"
+                            }
+                          },
+                          {
+                            "branch_attrs": {
+                              "mutations": {
+                                "nuc": [
+                                  "T2358C",
+                                  "C2700T",
+                                  "T8028C",
+                                  "C9270T"
+                                ]
+                              }
+                            },
+                            "children": [
+                              {
+                                "branch_attrs": {
+                                  "labels": {
+                                    "aa": "2K: M7I"
+                                  },
+                                  "mutations": {
+                                    "2K": [
+                                      "M7I"
+                                    ],
+                                    "nuc": [
+                                      "G6849A",
+                                      "A8169G",
+                                      "G8520A"
+                                    ]
+                                  }
+                                },
+                                "name": "Brazil/2015/ZBRA105",
+                                "node_attrs": {
+                                  "accession": "KY558989",
+                                  "author": {
+                                    "author": "Faria et al",
+                                    "journal": "Nature 546 (7658), 406-410 (2017)",
+                                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538727",
+                                    "title": "Establishment and cryptic transmission of Zika virus in Brazil and the Americas",
+                                    "value": "Faria et al"
+                                  },
+                                  "country": {
+                                    "confidence": {
+                                      "Brazil": 0.9999999999999999
+                                    },
+                                    "entropy": -9.99866855976916e-13,
+                                    "value": "Brazil"
+                                  },
+                                  "div": 0.0028856651194405164,
+                                  "num_date": {
+                                    "confidence": [
+                                      2015.1478439425052,
+                                      2015.1478439425052
+                                    ],
+                                    "value": 2015.1478439425052
+                                  },
+                                  "region": {
+                                    "confidence": {
+                                      "South America": 1.0
+                                    },
+                                    "entropy": -1.000088900581841e-12,
+                                    "value": "South America"
+                                  },
+                                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY558989"
+                                }
+                              },
+                              {
+                                "branch_attrs": {
+                                  "labels": {
+                                    "aa": "NS5: I322V, D878E"
+                                  },
+                                  "mutations": {
+                                    "NS5": [
+                                      "I322V",
+                                      "D878E"
+                                    ],
+                                    "nuc": [
+                                      "T489C",
+                                      "T2043C",
+                                      "T2418C",
+                                      "C2844T",
+                                      "C5352T",
+                                      "T5823C",
+                                      "C6261T",
+                                      "T6891C",
+                                      "G8604A",
+                                      "A8614G",
+                                      "G9294A",
+                                      "T10284G"
+                                    ]
+                                  }
+                                },
+                                "children": [
+                                  {
+                                    "branch_attrs": {
+                                      "labels": {
+                                        "aa": "NS3: V126I"
+                                      },
+                                      "mutations": {
+                                        "NS3": [
+                                          "V126I"
+                                        ],
+                                        "nuc": [
+                                          "T510C",
+                                          "G630A",
+                                          "G3474A",
+                                          "G4972A",
+                                          "T5250C",
+                                          "C6934T",
+                                          "A7038C",
+                                          "T8025C",
+                                          "C8316A",
+                                          "C8370T",
+                                          "T10372C"
+                                        ]
+                                      }
+                                    },
+                                    "name": "DOM/2016/BB_0433",
+                                    "node_attrs": {
+                                      "accession": "KY785441",
+                                      "author": {
+                                        "author": "Metsky et al",
+                                        "journal": "Nature 546 (7658), 411-415 (2017)",
+                                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538734",
+                                        "title": "Zika virus evolution and spread in the Americas",
+                                        "value": "Metsky et al"
+                                      },
+                                      "country": {
+                                        "confidence": {
+                                          "Dominican Republic": 1.0
+                                        },
+                                        "entropy": -1.000088900581841e-12,
+                                        "value": "Dominican Republic"
+                                      },
+                                      "div": 0.004748064201492485,
+                                      "num_date": {
+                                        "confidence": [
+                                          2016.4517453798767,
+                                          2016.4517453798767
+                                        ],
+                                        "value": 2016.4517453798767
+                                      },
+                                      "region": {
+                                        "confidence": {
+                                          "North America": 1.0
+                                        },
+                                        "entropy": -1.000088900581841e-12,
+                                        "value": "North America"
+                                      },
+                                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY785441"
+                                    }
+                                  },
+                                  {
+                                    "branch_attrs": {
+                                      "mutations": {
+                                        "nuc": [
+                                          "C5232T"
+                                        ]
+                                      }
+                                    },
+                                    "children": [
+                                      {
+                                        "branch_attrs": {
+                                          "labels": {
+                                            "aa": "NS1: D208G; NS2A: L152M; NS5: Q650R"
+                                          },
+                                          "mutations": {
+                                            "NS1": [
+                                              "D208G"
+                                            ],
+                                            "NS2A": [
+                                              "L152M"
+                                            ],
+                                            "NS5": [
+                                              "Q650R"
+                                            ],
+                                            "nuc": [
+                                              "T2724C",
+                                              "T2823C",
+                                              "A3095G",
+                                              "T3982A",
+                                              "C6105T",
+                                              "A9599G",
+                                              "T10632C"
+                                            ]
+                                          }
+                                        },
+                                        "name": "DOM/2016/BB_0183",
+                                        "node_attrs": {
+                                          "accession": "KY785420",
+                                          "author": {
+                                            "author": "Metsky et al",
+                                            "journal": "Nature 546 (7658), 411-415 (2017)",
+                                            "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538734",
+                                            "title": "Zika virus evolution and spread in the Americas",
+                                            "value": "Metsky et al"
+                                          },
+                                          "country": {
+                                            "confidence": {
+                                              "Dominican Republic": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "Dominican Republic"
+                                          },
+                                          "div": 0.004468473521889809,
+                                          "num_date": {
+                                            "confidence": [
+                                              2016.2984257357973,
+                                              2016.2984257357973
+                                            ],
+                                            "value": 2016.2984257357973
+                                          },
+                                          "region": {
+                                            "confidence": {
+                                              "North America": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "North America"
+                                          },
+                                          "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY785420"
+                                        }
+                                      },
+                                      {
+                                        "branch_attrs": {
+                                          "mutations": {
+                                            "nuc": [
+                                              "C1137T",
+                                              "C1665T",
+                                              "A3987G",
+                                              "T8862C",
+                                              "A9387G",
+                                              "A10270C",
+                                              "A10616G"
+                                            ]
+                                          }
+                                        },
+                                        "name": "DOM/2016/MA_WGS16_011",
+                                        "node_attrs": {
+                                          "accession": "KY785484",
+                                          "author": {
+                                            "author": "Metsky et al",
+                                            "journal": "Nature 546 (7658), 411-415 (2017)",
+                                            "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538734",
+                                            "title": "Zika virus evolution and spread in the Americas",
+                                            "value": "Metsky et al"
+                                          },
+                                          "country": {
+                                            "confidence": {
+                                              "Dominican Republic": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "Dominican Republic"
+                                          },
+                                          "div": 0.004468419704818721,
+                                          "num_date": {
+                                            "confidence": [
+                                              2016.432580424367,
+                                              2016.432580424367
+                                            ],
+                                            "value": 2016.432580424367
+                                          },
+                                          "region": {
+                                            "confidence": {
+                                              "North America": 1.0
+                                            },
+                                            "entropy": -1.000088900581841e-12,
+                                            "value": "North America"
+                                          },
+                                          "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY785484"
+                                        }
+                                      },
+                                      {
+                                        "branch_attrs": {
+                                          "labels": {
+                                            "aa": "NS5: T808I"
+                                          },
+                                          "mutations": {
+                                            "NS5": [
+                                              "T808I"
+                                            ],
+                                            "nuc": [
+                                              "C10073T"
+                                            ]
+                                          }
+                                        },
+                                        "children": [
+                                          {
+                                            "branch_attrs": {
+                                              "mutations": {
+                                                "nuc": [
+                                                  "T1554C",
+                                                  "T2443C",
+                                                  "T2961C",
+                                                  "G4149A",
+                                                  "T5181C",
+                                                  "A7584G",
+                                                  "C7989T",
+                                                  "A8241G",
+                                                  "C8589T",
+                                                  "T8835C",
+                                                  "C9378T"
+                                                ]
+                                              }
+                                            },
+                                            "children": [
+                                              {
+                                                "branch_attrs": {
+                                                  "labels": {
+                                                    "aa": "NS1: P112S"
+                                                  },
+                                                  "mutations": {
+                                                    "NS1": [
+                                                      "P112S"
+                                                    ],
+                                                    "nuc": [
+                                                      "C2806T",
+                                                      "C7776T",
+                                                      "C8233T",
+                                                      "T10373C"
+                                                    ]
+                                                  }
+                                                },
+                                                "name": "USA/2016/FLUR022",
+                                                "node_attrs": {
+                                                  "accession": "KY325473",
+                                                  "author": {
+                                                    "author": "Grubaugh et al",
+                                                    "journal": "Nature (2017) In press",
+                                                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538723",
+                                                    "title": "Genomic epidemiology reveals multiple introductions of Zika virus into the United States",
+                                                    "value": "Grubaugh et al"
+                                                  },
+                                                  "country": {
+                                                    "confidence": {
+                                                      "USA": 1.0
+                                                    },
+                                                    "entropy": -1.000088900581841e-12,
+                                                    "value": "USA"
+                                                  },
+                                                  "div": 0.005306221885243012,
+                                                  "num_date": {
+                                                    "confidence": [
+                                                      2016.6680355920603,
+                                                      2016.6680355920603
+                                                    ],
+                                                    "value": 2016.6680355920603
+                                                  },
+                                                  "region": {
+                                                    "confidence": {
+                                                      "North America": 1.0
+                                                    },
+                                                    "entropy": -1.000088900581841e-12,
+                                                    "value": "North America"
+                                                  },
+                                                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY325473"
+                                                }
+                                              },
+                                              {
+                                                "branch_attrs": {
+                                                  "labels": {
+                                                    "aa": "ENV: A69V"
+                                                  },
+                                                  "mutations": {
+                                                    "ENV": [
+                                                      "A69V"
+                                                    ],
+                                                    "nuc": [
+                                                      "G459A",
+                                                      "C1166T",
+                                                      "T3982C"
+                                                    ]
+                                                  }
+                                                },
+                                                "name": "Aedes_aegypti/USA/2016/FL05",
+                                                "node_attrs": {
+                                                  "accession": "KY075937",
+                                                  "author": {
+                                                    "author": "Grubaugh et al",
+                                                    "journal": "Nature (2017) In press",
+                                                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538723",
+                                                    "title": "Genomic epidemiology reveals multiple introductions of Zika virus into the United States",
+                                                    "value": "Grubaugh et al"
+                                                  },
+                                                  "country": {
+                                                    "confidence": {
+                                                      "USA": 1.0
+                                                    },
+                                                    "entropy": -1.000088900581841e-12,
+                                                    "value": "USA"
+                                                  },
+                                                  "div": 0.005213149729489614,
+                                                  "num_date": {
+                                                    "confidence": [
+                                                      2016.6926762491444,
+                                                      2016.6926762491444
+                                                    ],
+                                                    "value": 2016.6926762491444
+                                                  },
+                                                  "region": {
+                                                    "confidence": {
+                                                      "North America": 1.0
+                                                    },
+                                                    "entropy": -1.000088900581841e-12,
+                                                    "value": "North America"
+                                                  },
+                                                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY075937"
+                                                }
+                                              }
+                                            ],
+                                            "name": "NODE_0000029",
+                                            "node_attrs": {
+                                              "country": {
+                                                "confidence": {
+                                                  "Dominican Republic": 0.015893407808824086,
+                                                  "USA": 0.9830617373833994
+                                                },
+                                                "entropy": 0.09246692367128584,
+                                                "value": "USA"
+                                              },
+                                              "div": 0.0049340051487095065,
+                                              "num_date": {
+                                                "confidence": [
+                                                  2016.2229693632282,
+                                                  2016.5714678088882
+                                                ],
+                                                "value": 2016.490389106341
+                                              },
+                                              "region": {
+                                                "confidence": {
+                                                  "North America": 0.9997277362015242
+                                                },
+                                                "entropy": 0.002606344220211139,
+                                                "value": "North America"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "branch_attrs": {
+                                              "mutations": {
+                                                "nuc": [
+                                                  "T531C",
+                                                  "T1524G",
+                                                  "C2238T"
+                                                ]
+                                              }
+                                            },
+                                            "children": [
+                                              {
+                                                "branch_attrs": {
+                                                  "labels": {
+                                                    "aa": "NS3: Y498C"
+                                                  },
+                                                  "mutations": {
+                                                    "NS3": [
+                                                      "Y498C"
+                                                    ],
+                                                    "nuc": [
+                                                      "C4020T",
+                                                      "C4749T",
+                                                      "A6089G"
+                                                    ]
+                                                  }
+                                                },
+                                                "name": "DOM/2016/BB_0059",
+                                                "node_attrs": {
+                                                  "accession": "KY785425",
+                                                  "author": {
+                                                    "author": "Metsky et al",
+                                                    "journal": "Nature 546 (7658), 411-415 (2017)",
+                                                    "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538734",
+                                                    "title": "Zika virus evolution and spread in the Americas",
+                                                    "value": "Metsky et al"
+                                                  },
+                                                  "country": {
+                                                    "confidence": {
+                                                      "Dominican Republic": 1.0
+                                                    },
+                                                    "entropy": -1.000088900581841e-12,
+                                                    "value": "Dominican Republic"
+                                                  },
+                                                  "div": 0.0044682308973576605,
+                                                  "num_date": {
+                                                    "confidence": [
+                                                      2016.2600958247776,
+                                                      2016.2600958247776
+                                                    ],
+                                                    "value": 2016.2600958247776
+                                                  },
+                                                  "region": {
+                                                    "confidence": {
+                                                      "North America": 1.0
+                                                    },
+                                                    "entropy": -1.000088900581841e-12,
+                                                    "value": "North America"
+                                                  },
+                                                  "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY785425"
+                                                }
+                                              },
+                                              {
+                                                "branch_attrs": {
+                                                  "mutations": {
+                                                    "nuc": [
+                                                      "C918T",
+                                                      "T1047C",
+                                                      "G6882A",
+                                                      "T10320C"
+                                                    ]
+                                                  }
+                                                },
+                                                "children": [
+                                                  {
+                                                    "branch_attrs": {
+                                                      "labels": {
+                                                        "aa": "NS3: S506P; PRO: R89Q"
+                                                      },
+                                                      "mutations": {
+                                                        "NS3": [
+                                                          "S506P"
+                                                        ],
+                                                        "PRO": [
+                                                          "R89Q"
+                                                        ],
+                                                        "nuc": [
+                                                          "G722A",
+                                                          "T1224C",
+                                                          "A3639G",
+                                                          "T4734C",
+                                                          "T6112C",
+                                                          "G8082A",
+                                                          "C8544T"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "name": "USA/2016/FL022",
+                                                    "node_attrs": {
+                                                      "accession": "KY075935",
+                                                      "author": {
+                                                        "author": "Grubaugh et al",
+                                                        "journal": "Nature (2017) In press",
+                                                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538723",
+                                                        "title": "Genomic epidemiology reveals multiple introductions of Zika virus into the United States",
+                                                        "value": "Grubaugh et al"
+                                                      },
+                                                      "country": {
+                                                        "confidence": {
+                                                          "USA": 1.0
+                                                        },
+                                                        "entropy": -1.000088900581841e-12,
+                                                        "value": "USA"
+                                                      },
+                                                      "div": 0.005212860212006738,
+                                                      "num_date": {
+                                                        "confidence": [
+                                                          2016.558521560575,
+                                                          2016.558521560575
+                                                        ],
+                                                        "value": 2016.558521560575
+                                                      },
+                                                      "region": {
+                                                        "confidence": {
+                                                          "North America": 0.9999999999999999
+                                                        },
+                                                        "entropy": -9.99866855976916e-13,
+                                                        "value": "North America"
+                                                      },
+                                                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY075935"
+                                                    }
+                                                  },
+                                                  {
+                                                    "branch_attrs": {
+                                                      "mutations": {
+                                                        "nuc": [
+                                                          "G2481A",
+                                                          "T10373C"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "name": "USA/2016/FLWB042",
+                                                    "node_attrs": {
+                                                      "accession": "KY325478",
+                                                      "author": {
+                                                        "author": "Grubaugh et al",
+                                                        "journal": "Nature (2017) In press",
+                                                        "paper_url": "https://www.ncbi.nlm.nih.gov/pubmed/28538723",
+                                                        "title": "Genomic epidemiology reveals multiple introductions of Zika virus into the United States",
+                                                        "value": "Grubaugh et al"
+                                                      },
+                                                      "country": {
+                                                        "confidence": {
+                                                          "USA": 1.0
+                                                        },
+                                                        "entropy": -1.000088900581841e-12,
+                                                        "value": "USA"
+                                                      },
+                                                      "div": 0.004747401655644155,
+                                                      "num_date": {
+                                                        "confidence": [
+                                                          2016.7392197125257,
+                                                          2016.7392197125257
+                                                        ],
+                                                        "value": 2016.7392197125257
+                                                      },
+                                                      "region": {
+                                                        "confidence": {
+                                                          "North America": 0.9999999999999999
+                                                        },
+                                                        "entropy": -9.99866855976916e-13,
+                                                        "value": "North America"
+                                                      },
+                                                      "url": "https://www.ncbi.nlm.nih.gov/nuccore/KY325478"
+                                                    }
+                                                  }
+                                                ],
+                                                "name": "NODE_0000031",
+                                                "node_attrs": {
+                                                  "country": {
+                                                    "confidence": {
+                                                      "Dominican Republic": 0.015894550259803204,
+                                                      "USA": 0.983060626175143
+                                                    },
+                                                    "entropy": 0.09247136648462362,
+                                                    "value": "USA"
+                                                  },
+                                                  "div": 0.004561310184936269,
+                                                  "num_date": {
+                                                    "confidence": [
+                                                      2016.135802881703,
+                                                      2016.4147189700354
+                                                    ],
+                                                    "value": 2016.2291665461812
+                                                  },
+                                                  "region": {
+                                                    "confidence": {
+                                                      "North America": 0.9997293232316543
+                                                    },
+                                                    "entropy": 0.0025931250938307,
+                                                    "value": "North America"
+                                                  }
+                                                }
+                                              }
+                                            ],
+                                            "name": "NODE_0000030",
+                                            "node_attrs": {
+                                              "country": {
+                                                "confidence": {
+                                                  "Dominican Republic": 0.524031042886865,
+                                                  "USA": 0.4735108132936197
+                                                },
+                                                "entropy": 0.7136473243811504,
+                                                "value": "Dominican Republic"
+                                              },
+                                              "div": 0.004189076005800676,
+                                              "num_date": {
+                                                "confidence": [
+                                                  2015.8563653071176,
+                                                  2016.1455196991683
+                                                ],
+                                                "value": 2016.044180283364
+                                              },
+                                              "region": {
+                                                "confidence": {
+                                                  "North America": 0.9997097781989117
+                                                },
+                                                "entropy": 0.002757054784361329,
+                                                "value": "North America"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "name": "NODE_0000028",
+                                        "node_attrs": {
+                                          "country": {
+                                            "confidence": {
+                                              "Dominican Republic": 0.5239930946497486,
+                                              "USA": 0.4735437198235657
+                                            },
+                                            "entropy": 0.7136880773701251,
+                                            "value": "Dominican Republic"
+                                          },
+                                          "div": 0.003909912000169897,
+                                          "num_date": {
+                                            "confidence": [
+                                              2015.5756312328008,
+                                              2016.004014416941
+                                            ],
+                                            "value": 2015.89637433467
+                                          },
+                                          "region": {
+                                            "confidence": {
+                                              "North America": 0.9996853906522067
+                                            },
+                                            "entropy": 0.002957295666772064,
+                                            "value": "North America"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "name": "NODE_0000026",
+                                    "node_attrs": {
+                                      "country": {
+                                        "confidence": {
+                                          "Dominican Republic": 0.9988901235732948
+                                        },
+                                        "entropy": 0.009327545334862455,
+                                        "value": "Dominican Republic"
+                                      },
+                                      "div": 0.0038168782782896926,
+                                      "num_date": {
+                                        "confidence": [
+                                          2015.5096563623997,
+                                          2015.9614037627707
+                                        ],
+                                        "value": 2015.8313974110965
+                                      },
+                                      "region": {
+                                        "confidence": {
+                                          "North America": 0.999646627605579
+                                        },
+                                        "entropy": 0.0031725826949494554,
+                                        "value": "North America"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "name": "NODE_0000025",
+                                "node_attrs": {
+                                  "country": {
+                                    "confidence": {
+                                      "Brazil": 0.02038233623446182,
+                                      "Dominican Republic": 0.9760054464770502
+                                    },
+                                    "entropy": 0.13197703260832766,
+                                    "value": "Dominican Republic"
+                                  },
+                                  "div": 0.003723843763891156,
+                                  "num_date": {
+                                    "confidence": [
+                                      2015.440895772629,
+                                      2015.9172562132467
+                                    ],
+                                    "value": 2015.705227062378
+                                  },
+                                  "region": {
+                                    "confidence": {
+                                      "North America": 0.9379350373308736,
+                                      "South America": 0.0617006747409255
+                                    },
+                                    "entropy": 0.23509350106976631,
+                                    "value": "North America"
+                                  }
+                                }
+                              }
+                            ],
+                            "name": "NODE_0000024",
+                            "node_attrs": {
+                              "country": {
+                                "confidence": {
+                                  "Brazil": 0.9236010038677318,
+                                  "Dominican Republic": 0.05553020418142342,
+                                  "Ecuador": 0.010832965586772861,
+                                  "French Polynesia": 0.00225696004561854
+                                },
+                                "entropy": 0.35263030755276903,
+                                "value": "Brazil"
+                              },
+                              "div": 0.002606541846981179,
+                              "num_date": {
+                                "confidence": [
+                                  2014.8522678009053,
+                                  2015.095642820057
+                                ],
+                                "value": 2015.003133509632
+                              },
+                              "region": {
+                                "confidence": {
+                                  "North America": 0.05808633373289472,
+                                  "South America": 0.9415322251208496
+                                },
+                                "entropy": 0.22525651204998084,
+                                "value": "South America"
+                              }
+                            }
+                          }
+                        ],
+                        "name": "NODE_0000023",
+                        "node_attrs": {
+                          "country": {
+                            "confidence": {
+                              "Brazil": 0.9271575615179198,
+                              "Dominican Republic": 0.019574947656682887,
+                              "Ecuador": 0.036596717161630085,
+                              "French Polynesia": 0.005999263137872718
+                            },
+                            "entropy": 0.37176788759059076,
+                            "value": "Brazil"
+                          },
+                          "div": 0.0022343509720201223,
+                          "num_date": {
+                            "confidence": [
+                              2014.5827884564044,
+                              2014.9494099947376
+                            ],
+                            "value": 2014.7409978365113
+                          },
+                          "region": {
+                            "confidence": {
+                              "North America": 0.0178544850316881,
+                              "South America": 0.9817184882411383
+                            },
+                            "entropy": 0.09341774169022339,
+                            "value": "South America"
+                          }
+                        }
+                      }
+                    ],
+                    "name": "NODE_0000007",
+                    "node_attrs": {
+                      "country": {
+                        "confidence": {
+                          "Brazil": 0.9770173888261177,
+                          "Ecuador": 0.0027857083103623352,
+                          "French Polynesia": 0.012771348482517354,
+                          "Puerto Rico": 0.0033480555677957557
+                        },
+                        "entropy": 0.1440779772301267,
+                        "value": "Brazil"
+                      },
+                      "div": 0.002048281036926199,
+                      "num_date": {
+                        "confidence": [
+                          2014.4277614230136,
+                          2014.854885096099
+                        ],
+                        "value": 2014.560476171914
+                      },
+                      "region": {
+                        "confidence": {
+                          "North America": 0.025659566373315294,
+                          "Oceania": 0.004332544332980809,
+                          "South America": 0.9699550053285484
+                        },
+                        "entropy": 0.1476726548355483,
+                        "value": "South America"
+                      }
+                    }
+                  }
+                ],
+                "name": "NODE_0000009",
+                "node_attrs": {
+                  "country": {
+                    "confidence": {
+                      "French Polynesia": 0.9988192302553927
+                    },
+                    "entropy": 0.010086350675222535,
+                    "value": "French Polynesia"
+                  },
+                  "div": 0.0013968125635655043,
+                  "num_date": {
+                    "confidence": [
+                      2013.7812783867917,
+                      2013.8992218313642
+                    ],
+                    "value": 2013.8298735594567
+                  },
+                  "region": {
+                    "confidence": {
+                      "Oceania": 0.999274466162976
+                    },
+                    "entropy": 0.006172483053531114,
+                    "value": "Oceania"
+                  }
+                }
+              }
+            ],
+            "name": "NODE_0000011",
+            "node_attrs": {
+              "country": {
+                "confidence": {
+                  "American Samoa": 0.004392160522330537,
+                  "French Polynesia": 0.9910888655325212,
+                  "Singapore": 0.0014582922832702778
+                },
+                "entropy": 0.06707504321025663,
+                "value": "French Polynesia"
+              },
+              "div": 0.0013037847135130244,
+              "num_date": {
+                "confidence": [
+                  2013.667121851472,
+                  2013.8653785075612
+                ],
+                "value": 2013.8132739972966
+              },
+              "region": {
+                "confidence": {
+                  "Oceania": 0.9994008678711306
+                },
+                "entropy": 0.005447032731003333,
+                "value": "Oceania"
+              }
+            }
+          }
+        ],
+        "name": "NODE_0000012",
+        "node_attrs": {
+          "country": {
+            "confidence": {
+              "American Samoa": 0.18350701247808252,
+              "French Polynesia": 0.6551587674694227,
+              "Singapore": 0.05648501518776817,
+              "Thailand": 0.026880748407201036
+            },
+            "entropy": 1.232926057895513,
+            "value": "French Polynesia"
+          },
+          "div": 0.0012107561869862374,
+          "num_date": {
+            "confidence": [
+              2013.6381304716897,
+              2013.8871164331742
+            ],
+            "value": 2013.7444949350936
+          },
+          "region": {
+            "confidence": {
+              "Oceania": 0.9810870253804866,
+              "South America": 0.0012376497404330412,
+              "Southeast Asia": 0.016690453145411243
+            },
+            "entropy": 0.10214941181369344,
+            "value": "Oceania"
+          }
+        }
+      }
+    ],
+    "name": "NODE_0000034",
+    "node_attrs": {
+      "country": {
+        "confidence": {
+          "American Samoa": 0.12867669342692836,
+          "French Polynesia": 0.4276055892363558,
+          "Singapore": 0.17786710020330784,
+          "Thailand": 0.08898400844062339
+        },
+        "entropy": 1.879206781163566,
+        "value": "French Polynesia"
+      },
+      "div": 0,
+      "num_date": {
+        "confidence": [
+          2011.5618180748477,
+          2013.3913714064352
+        ],
+        "value": 2012.6387463799927
+      },
+      "region": {
+        "confidence": {
+          "North America": 0.016718115459202657,
+          "Oceania": 0.6762182474947085,
+          "South America": 0.014781264457128046,
+          "Southeast Asia": 0.29228237258896067
+        },
+        "entropy": 0.754773028420379,
+        "value": "Oceania"
+      }
+    }
+  },
+  "version": "v2"
+}


### PR DESCRIPTION
Updates the json_to_tree utility to support v2 auspice JSONs which previously
caused the tool to break. This commit minimally modifies the original function
to pull out the tree information from v2 JSONs. The function does not attempt to
maintain the same attribute interface between v1 and v2 JSONs. For example, the
`attr` attribute from v1 JSONs is split into the `node_attrs` and `branch_attrs`
attributes in v2 JSONs and the json_to_tree function does not try to force all
outputs to have a unified `attr` attribute.

This commit also adds a v2 tree and metadata JSON from the Zika tutorial build
to the test data and doctests for the new json_to_tree support for these v2
JSONs.

Closes #428.