### PR TITLE
export traits which are filters but not colorings

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -555,11 +555,15 @@ def set_node_attrs_on_tree(data_json, node_attrs):
             if is_valid(raw_data.get(prop, None)):
                 node["node_attrs"][prop] = str(raw_data[prop])
 
-    def _transfer_colorings(node, raw_data):
-        # exclude special cases already taken care of
-        colorings = [c for c in data_json["meta"]["colorings"] if c["key"] not in ["gt", "num_date", "author"]]
-        for coloring in colorings:
-            key = coloring["key"]
+    def _transfer_colorings_filters(node, raw_data):
+        trait_keys = set() # order we add to the node_attrs is not important for auspice
+        if "colorings" in data_json["meta"]:
+            trait_keys = trait_keys.union([t["key"] for t in data_json["meta"]["colorings"]])
+        if "filters" in data_json["meta"]:
+            trait_keys = trait_keys.union(data_json["meta"]["filters"])
+        exclude_list = ["gt", "num_date", "author"] # exclude special cases already taken care of
+        trait_keys = trait_keys.difference(exclude_list)
+        for key in trait_keys:
             if is_valid(raw_data.get(key, None)):
                 node["node_attrs"][key] = {"value": raw_data[key]}
                 if is_valid(raw_data.get(key+"_confidence", None)):
@@ -582,8 +586,8 @@ def set_node_attrs_on_tree(data_json, node_attrs):
         _transfer_num_date(node, raw_data)
         _transfer_url_accession(node, raw_data)
         _transfer_author_data(node)
-        # transfer colorings, including entropy & confidence if available
-        _transfer_colorings(node, raw_data)
+        # transfer colorings & filters, including entropy & confidence if available
+        _transfer_colorings_filters(node, raw_data)
 
         for child in node.get("children", []):
             _recursively_set_data(child)

--- a/tests/builds/various_export_settings/Snakefile
+++ b/tests/builds/various_export_settings/Snakefile
@@ -7,7 +7,8 @@ rule all:
         div_only = "auspice/v2_div-only-tree.json",
         bool_metadata = "auspice/v2_boolean-metadata.json",
         default_layout = "auspice/v2_default-layout.json",
-        footer = "auspice/v2_custom-footer.json"
+        footer = "auspice/v2_custom-footer.json",
+        filter_not_color = "auspice/v2_filters-not-colors.json"
 rule files:
     params:
         hidden_nodes = "data/hidden_nodes.json",
@@ -203,6 +204,25 @@ rule export_with_custom_footer_description:
             --metadata {input.metadata} \
             --description {input.footer} \
             --title "Custom footer" \
+            --output {output.auspice}
+        """
+
+rule export_filter_which_isnt_a_coloring:
+    message: "Exporting (v2) with a filter which is not a coloring"
+    input:
+        tree = {rules.refine_with_temporal_information.output.tree},
+        branch_lengths = {rules.refine_with_temporal_information.output.node_data},
+        metadata = {rules.parse.output.metadata},
+        config = "config/filters.json"
+    output:
+        auspice = rules.all.input.filter_not_color,
+    shell:
+        """
+        augur export v2 \
+            --tree {input.tree} \
+            --node-data {input.branch_lengths} \
+            --metadata {input.metadata} \
+            --auspice-config {input.config} \
             --output {output.auspice}
         """
 

--- a/tests/builds/various_export_settings/config/filters.json
+++ b/tests/builds/various_export_settings/config/filters.json
@@ -1,0 +1,16 @@
+{
+  "title": "Country is a filter but not a coloring",
+  "colorings": [
+    {
+      "key": "num_date",
+      "title": "Sampling date",
+      "type": "continuous"
+    }
+  ],
+  "panels": [
+    "tree"
+  ],
+  "filters": [
+    "country"
+  ]
+}


### PR DESCRIPTION
Previous behavior of `augur export v2` was to ignore traits which were defined as filters (via auspice config JSON) if they weren't exported as colorings. Here we allow the export of such traits, and add a test build. Auspice requires no changes to display these. All test builds pass.