### PR TITLE
Filter command: Add '--where' option for complex queries

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -358,7 +358,7 @@ def run(args):
 
     print("\n%i sequences were dropped during filtering" % (len(all_seq) - len(seq_keep),))
     if num_excluded_lacking_metadata:
-        print("\t%i of these were dropped because they did not have metadata")
+        print("\t%i of these were dropped because they did not have metadata" % num_excluded_lacking_metadata)
     if args.exclude:
         print("\t%i of these were dropped because they were in %s" % (num_excluded_by_name, args.exclude))
     if args.exclude_where:

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -76,7 +76,7 @@ def register_arguments(parser):
                                 help="Exclude samples matching these conditions. Ex: \"host=rat\" or \"host!=rat\". Multiple values are processed as OR (matching any of those specified will be excluded), not AND")
     parser.add_argument('--include-where', nargs='+',
                                 help="Include samples with these values. ex: host=rat. Multiple values are processed as OR (having any of those specified will be included), not AND. This rule is applied last and ensures any sequences matching these rules will be included.")
-    parser.add_argument('--where', type=str, metavar="QUERY",
+    parser.add_argument('--prefilter-metadata', type=str, metavar="QUERY",
                                 help="Filter samples by attribute. Uses Pandas Dataframe querying, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query for syntax. Note this behavior overrides '--include' and '--include-where'.")
     parser.add_argument('--output', '-o', help="output file", required=True)
 
@@ -120,7 +120,7 @@ def run(args):
         all_seq = seq_keep.copy()
 
     try:
-        meta_dict, meta_columns, meta_filtered = read_metadata_with_query(args.metadata, query=args.where)
+        meta_dict, meta_columns, meta_filtered = read_metadata_with_query(args.metadata, query=args.prefilter_metadata)
     except ValueError as error:
         print("ERROR: Problem reading in {}:".format(args.metadata))
         print(error)
@@ -379,8 +379,8 @@ def run(args):
     if args.include_where:
         print("\t%i sequences were added back because of '%s'" % (num_included_by_metadata, args.include_where))
 
-    if args.where:
+    if args.prefilter_metadata:
         print("\n\t%i were dropped due to the metadata query:\n\t\t%s"
-              % (num_excluded_filtered_metadata, args.where))
+              % (num_excluded_filtered_metadata, args.prefilter_metadata))
 
     print("%i sequences have been written out to %s" % (len(seq_keep), args.output))

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -71,7 +71,7 @@ def ambiguous_date_to_date_range(mydate, fmt, min_max_year=None):
     upper_bound = datetime(year=max_date['year'], month=max_date['month'], day=max_date['day']).date()
     return (lower_bound, upper_bound if upper_bound<today else today)
 
-def read_metadata(fname):
+def read_metadata(fname, query=None):
     if not fname:
         print("ERROR: read_metadata called without a filename")
         return {}, []
@@ -83,6 +83,15 @@ def read_metadata(fname):
             print("Error reading metadata file {}".format(fname))
             print(e)
             sys.exit(2)
+        if query:
+            try:
+                metadata.query(query, inplace=True)
+            except Exception as e:
+                # Would like to make this more specific, but Pandas throws multiple different
+                # errors from panda specific to python generic errors.
+                print("ERROR: Invalid query string: '{}'".format(query))
+                print(e)
+                sys.exit(2)
         meta_dict = {}
         for ii, val in metadata.iterrows():
             if hasattr(val, "strain"):

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -97,7 +97,7 @@ def read_metadata(fname):
     query : str
         Pandas Dataframe query string. For syntax, see:
         https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html
-    
+
     Returns
     -------
     Tuple of dictionary mapping strain name to its metadata and 
@@ -118,7 +118,7 @@ def read_metadata(fname):
 
 def read_metadata_with_query(fname, query=None):
     """Read metadata from a .TSV or .CSV file, optionally filtering by a query string.
-    
+
     This function is extremely similar to read_metadata. It was separated to preserve existing
     uses of read_metadata while providing the option to filter metadata and see the filtered strains.
 
@@ -133,7 +133,7 @@ def read_metadata_with_query(fname, query=None):
     query : str
         Pandas Dataframe query string. For syntax, see:
         https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html
-    
+
     Returns
     -------
     Tuple of metadata dictionary, list of columns in metadata,
@@ -172,7 +172,7 @@ def load_metadata_file(fname):
     ----------
     fname : str
         Path to the TSV or CSV file to read
-    
+
     Returns
     -------
     Pandas.DataFrame read from the file
@@ -200,7 +200,7 @@ def format_metadata(metadata):
     metadata : Pandas.DataFrame
         Pandas DataFrame containing strain metadata. Must have at least
         a 'name' or 'strain' column, cannot have duplicates.
-    
+
     Returns
     -------
     Dictionary mapping strain name to its metadata as a dictionary.


### PR DESCRIPTION
Per discussion in #244 , adds a `--where` option to `augur filter` to perform complex queries by leveraging Pandas DataFrame.query() method

I'm new and mostly trying to work off some nervous energy while stuck indoors, so I defer to the users and maintainers on whether this is the right implementation. There's some issues with the approach:

Because of where the metadata filtering takes place, this winds up being a bit messy for a few reasons:
1. there's no way to tell later during filtering whether an entry is missing metadata because of the filter or because it's just missing metadata.
2. Because we're dropping the metadata before any of the rest of the filtering happens, `--include` and `--include-with` can't override the query.
3. Because we're just passing a string directly to DataFrame.query(), we can't compare dates or do substring filtering. We can only compare integers and exact strings. Finally, Pandas' error handling for query failures is nonspecific
4. I got a handful of different errors when trying to break this, some Pandas specific and some not, so the error message is effectively "You did a bad filter, here's what pandas said."

It's possible to improve 1 and 2 by reworking what `utils.read_metadata` returns, but that'd require updating everything else that uses read_metadata and I didn't want to step in that for my first patch - this is intentionally a minimal change.

All that said, this gets the job done as discussed in #244 and is probably worth it for the added functionality, but I'm not going to feel put out if y'all pass on this one.

Oh, and - example output, using the nextstrain/zika-tutorial files:
Good:
```
% augur filter \
  --sequences data/sequences.fasta \
  --metadata data/metadata.tsv \
  --min-date 2012 \
  --group-by country year month \
  --sequences-per-group 1 \
  --output filtered.fasta \
  --where="(journal == 'Nature (2017) In press') | (region == 'North America')"
No meta data for COL/FLR_00024/2015, excluding from all further analysis.
No meta data for COL/FLR_00008/2015, excluding from all further analysis.
<...snip...>
No meta data for SMGC_1, excluding from all further analysis.

24 sequences were dropped during filtering
	0 of these were dropped because of their date (or lack of date)
	3 of these were dropped because of subsampling criteria

	21 sequences were dropped because they did not have metadata. This may be due to the metadata query:
		(journal == 'Nature (2017) In press') | (region == 'North America')
10 sequences have been written out to filtered.fasta
```
Bad query:
```
% augur filter \
  --sequences data/sequences.fasta \
  --metadata data/metadata.tsv \
  --min-date 2012 \
  --group-by country year month \
  --sequences-per-group 1 \
  --output filtered.fasta \
  --where="(foo == bar)"
ERROR: Invalid query string: '(foo == bar)'
name 'foo' is not defined
```
Numeric:
```
(augur) [17:45] eric@tceskia:nextstrain/zika-tutorial ‹master*›
% augur filter \
  --sequences data/sequences.fasta \
  --metadata data/metadatawithnumbers.tsv \
  --min-date 2012 \
  --group-by country year month \
  --output filtered.fasta \
  --where="(length >= 1000)"
No meta data for BRA/2016/FC_6706, excluding from all further analysis.
No meta data for Aedes_aegypti/USA/2016/FL05, excluding from all further analysis.
<...snip...>
No meta data for Brazil/2015/ZBRC303, excluding from all further analysis.

9 sequences were dropped during filtering
	0 of these were dropped because of their date (or lack of date)

	9 sequences were dropped because they did not have metadata. This may be due to the metadata query:
		(length >= 1000)
25 sequences have been written out to filtered.fasta
```
