### PR TITLE
align: Run mafft with --nomemsave option

### DIFF
--- a/augur/align.py
+++ b/augur/align.py
@@ -176,9 +176,9 @@ def read_reference(ref_fname):
 def generate_alignment_cmd(method, nthreads, existing_aln_fname, seqs_to_align_fname, aln_fname, log_fname):
     if method=='mafft':
         if existing_aln_fname:
-            cmd = "mafft --add %s --keeplength --reorder --anysymbol --thread %d %s 1> %s 2> %s"%(shquote(seqs_to_align_fname), nthreads, shquote(existing_aln_fname), shquote(aln_fname), shquote(log_fname))
+            cmd = "mafft --add %s --keeplength --reorder --anysymbol --nomemsave --thread %d %s 1> %s 2> %s"%(shquote(seqs_to_align_fname), nthreads, shquote(existing_aln_fname), shquote(aln_fname), shquote(log_fname))
         else:
-            cmd = "mafft --reorder --anysymbol --thread %d %s 1> %s 2> %s"%(nthreads, shquote(seqs_to_align_fname), shquote(aln_fname), shquote(log_fname))
+            cmd = "mafft --reorder --anysymbol --nomemsave --thread %d %s 1> %s 2> %s"%(nthreads, shquote(seqs_to_align_fname), shquote(aln_fname), shquote(log_fname))
         print("\nusing mafft to align via:\n\t" + cmd +
               " \n\n\tKatoh et al, Nucleic Acid Research, vol 30, issue 14"
               "\n\thttps://doi.org/10.1093%2Fnar%2Fgkf436\n")


### PR DESCRIPTION
MAFFT will automatically switch to memory saving mode when dealing with alignments longer than 10kb:
>Use[s] the Myers-Miller (1988) algorithm.  Default: automatically turned on when the alignment length exceeds 10,000 (aa/nt).

This can be turned off by running mafft with `--nomemsave`. Doing so for `/ncov` on my computer drops runtime for alignment from >30min to 3.5min.

It's possible that we'll start running into memory overhead here, but if so, we could set our own logic for when to run with memsave on.

I'd like to flag this for rapid merge and release as it impacts our ability to keep https://nextstrain.org/ncov current.