### PR TITLE
#72: Mask nonsense sites

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -381,6 +381,12 @@ def register_arguments(parser):
 
 
 def run(args):
+    # Load zero-based excluded sites.
+    if args.exclude_file is not None:
+        exclude_sites = load_excluded_sites(args.exclude_file).tolist()
+    else:
+        exclude_sites = []
+
     # check alignment type, convert to FASTA if it is a VCF
     if any(args.alignment.lower().endswith(x) for x in ('.vcf', '.vcf.gz')):
         # Prepare a multiple sequence alignment from the given variants VCF and
@@ -389,11 +395,13 @@ def run(args):
             print("ERROR: a reference Fasta is required with VCF-format alignments")
             return 1
         compress_seq = read_vcf(args.alignment, args.vcf_reference)
-        aln_file = write_out_informative_fasta(compress_seq, args.alignment)
+        # Because we only write the sequence vairants, we need to strip exclude sites now.
+        aln_file = write_out_informative_fasta(compress_seq, args.alignment, exclude_sites)
+        exclude_sites = []
     else:
         aln_file = args.alignment
 
-    aln_file = mask_and_cleanup_multiple_sequence_alignment(aln_file, args.exclude_sites)
+    aln_file = mask_and_cleanup_multiple_sequence_alignment(aln_file, exclude_sites)
 
     start = time.time()
 

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -339,14 +339,19 @@ def mask_and_cleanup_multiple_sequence_alignment(alignment_file, excluded_sites_
     alignment_file_path = Path(alignment_file)
     masked_alignment_file = str(alignment_file_path.parent / ("masked_%s" % alignment_file_path.name))
     # Valid sites from: http://reverse-complement.com/ambiguity.html
+    # Including both upper & lower because set.includes is faster than str.upper
     valid_sites = {"A", "G", "C", "T", "U", "R", "Y", "S", "W",
-                   "K", "M", "B", "V", "D", "H", "N", "-"}
+                   "a", "g", "c", "t", "u", "r", "y", "s", "w",
+                   "K", "M", "B", "V", "D", "H", "N", "-",
+                   "k", "m", "b", "v", "d", "h", "n"}
     with open(masked_alignment_file, "w") as oh:
         for record in alignment:
             # Replace invalid sites and convert to a mutable sequence
             # to enable masking with Ns.
             sequence = Bio.Seq.MutableSeq([
-                site if site in valid_sites else "N" for site in record.seq
+                # For some reason, converting the Seq object to a string
+                # makes this ~5x faster.
+                site if site in valid_sites else "N" for site in str(record.seq)
             ])
             # Replace all excluded sites with Ns.
             for site in excluded_sites:

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -309,7 +309,7 @@ def write_out_informative_fasta(compress_seq, alignment, exclude_sites):
 
     return fasta_file
 
-def mask_and_cleanup_multiple_sequence_alignment(alignment_file, excluded_sites_file):
+def mask_and_cleanup_multiple_sequence_alignment(alignment_file, exclude_sites):
     """Creates a new multiple sequence alignment FASTA file from which the given
     excluded sites have been removed and any invalid characters have been masked
     and returns the filename of the new
@@ -328,12 +328,6 @@ def mask_and_cleanup_multiple_sequence_alignment(alignment_file, excluded_sites_
     str
         path to the new FASTA file from which sites have been excluded
     """
-    # Load zero-based excluded sites.
-    if excluded_sites_file is not None:
-        excluded_sites = load_excluded_sites(excluded_sites_file).tolist()
-    else:
-        excluded_sites = []
-
     # Load alignment as FASTA generator to prevent loading the whole alignment
     # into memory.
     alignment = Bio.SeqIO.parse(alignment_file, "fasta")
@@ -357,9 +351,8 @@ def mask_and_cleanup_multiple_sequence_alignment(alignment_file, excluded_sites_
                 site if site in valid_sites else "N" for site in str(record.seq)
             ])
             # Replace all excluded sites with Ns.
-            for site in excluded_sites:
+            for site in exclude_sites:
                 sequence[site] = "N"
-
             record.seq = sequence
             Bio.SeqIO.write(record, oh, "fasta")
 

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -375,8 +375,8 @@ def register_arguments(parser):
 
 def run(args):
     # Load zero-based excluded sites.
-    if args.exclude_file is not None:
-        exclude_sites = load_excluded_sites(args.exclude_file).tolist()
+    if args.exclude_sites is not None:
+        exclude_sites = load_excluded_sites(args.exclude_sites).tolist()
     else:
         exclude_sites = []
 

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -319,12 +319,27 @@ def mask_and_cleanup_multiple_sequence_alignment(alignment_file, exclude_sites):
         path to the original multiple sequence alignment file
 
     exclude_sites : list
-        list of sites to exclude from the output
+        zero-indexed list of sites to exclude from the output
 
     Returns
     -------
     str
         path to the new FASTA file from which sites have been excluded
+
+    Tests
+    -----
+    >>> mask_and_cleanup_multiple_sequence_alignment("./tests/data/tree/mask_and_cleanup.fasta", [])
+    'tests/data/tree/masked_mask_and_cleanup.fasta'
+    >>> str(Bio.SeqIO.to_dict(Bio.SeqIO.parse("tests/data/tree/masked_mask_and_cleanup.fasta", "fasta"))["filter_chars"].seq)
+    'ABCDNNGHNNKNMNNNNRSTUVWNYNabcdNNghNNkNmnNNNrstuvwNyNNNN-NNN'
+    >>> mask_and_cleanup_multiple_sequence_alignment("./tests/data/tree/mask_and_cleanup.fasta", [4,9])
+    'tests/data/tree/masked_mask_and_cleanup.fasta'
+    >>> str(Bio.SeqIO.to_dict(Bio.SeqIO.parse("tests/data/tree/masked_mask_and_cleanup.fasta", "fasta"))["exclude_sites"].seq)
+    'atatNatatNatat'
+    >>> mask_and_cleanup_multiple_sequence_alignment("./tests/data/tree/mask_and_cleanup.fasta", [4,])
+    'tests/data/tree/masked_mask_and_cleanup.fasta'
+    >>> str(Bio.SeqIO.to_dict(Bio.SeqIO.parse("tests/data/tree/masked_mask_and_cleanup.fasta", "fasta"))["filter_and_exclude"].seq)
+    'NtatNatatGatat'
     """
     # Load alignment as FASTA generator to prevent loading the whole alignment
     # into memory.

--- a/tests/data/tree/.gitignore
+++ b/tests/data/tree/.gitignore
@@ -1,0 +1,1 @@
+masked_mask_and_cleanup.fasta

--- a/tests/data/tree/mask_and_cleanup.fasta
+++ b/tests/data/tree/mask_and_cleanup.fasta
@@ -1,0 +1,6 @@
+>filter_chars
+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123-#$!
+>exclude_sites
+atatGatatGatat
+>filter_and_exclude
+EtatGatatGatat


### PR DESCRIPTION
Fix for #72: Update augur tree to clean up nonsense sites in submitted sequences.

This also cleans up and reworks the logic in run() - there were a bunch of unused variables and some convoluted logic. Github's diff view is a bit rough for this, happy to walk through any of it, and you may want to view the file directly. 

Ran through the full test suite (which mercifully caught a few things).

Changes:
**`- run():`**
Change the flow to:
- Load excluded sites 
- If file is a VCF, parse it, emptying the excluded sites and producing an aligned fasta
- Take aligned fasta, rework for invalid sites, and exclude sites if we haven't already done so
- Pass new filename to commands.

**`- write_informative_fasta(): `**
Take in exclude_sites as a list/array, not a filename

**`- mask_sites_in_multiple_sequence_alignment() -> mask_and_cleanup_multiple_sequence_alignment(): `**
Take in exclude_sites as a list/array, not a filename,
Parse each sequence to mask any invalid sites

This is almost certainly going to be slower, since we're checking each character in each sequence, but absent shelling out to sed or something, I think I've made this as fast as it can be. I also made the call to avoid assuming the sequence was uppercase, since this is designed to potentially take input from anywhere, not just augur align. It doesn't add much complexity.

Last potential note here: The example given in the bug had "IRLH" at the front, which caused the error. I and L are invalid characters, R and H are not - so, the change is to "NRNH", not "NNNN".