### PR TITLE
Add conda-forge as the third channel for package selection

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: augur
 channels:
 - bioconda
 - defaults
+- conda-forge
 dependencies:
 - python=3.6
 - mafft


### PR DESCRIPTION
### Description of proposed changes    
This PR adds conda-forge as the third channel for package selection when using conda's `environment.yml`:
```
channels:
-  bioconda
-  defaults
-  conda-forge
```
This results in faster dependency resolution.

I'm assuming based on #421 that the team will move to using `nextstrain/conda` `nextstrain.yml` in the future.

### Related issue(s)  
Fixes #  
Related to #413 #421 

### Testing

None

### Thank you for contributing to Nextstrain!
