### PR TITLE
Add brew tap command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Augur uses some common external bioinformatics programs which you'll need to ins
 
 On macOS, you can install these external programs using Homebrew with:
 ```bash
+brew tap brewsci/bio
 brew install mafft iqtree raxml fasttree vcftools
 ```
 


### PR DESCRIPTION
### Description of proposed changes    
This PR adds `brew tap brewsci/bio` to the Mac installation commands for optional packages. Without this command, the `brew install mafft iqtree ...` will fail. This will be helpful for future contributors

### Related issue(s)  

### Testing

### Thank you for contributing to Nextstrain!
