### PR TITLE
Use str.replace in make_gaps_ambiguous

### DIFF
--- a/augur/align.py
+++ b/augur/align.py
@@ -267,10 +267,10 @@ def make_gaps_ambiguous(aln):
         Biopython Alignment
     '''
     for seq in aln:
-        seq_array = np.array(seq)
-        gaps = seq_array=='-'
-        seq_array[gaps]='N'
-        seq.seq = Seq.Seq("".join(seq_array))
+        _seq = str(seq.seq)
+        _seq = _seq.replace('-', 'N')
+        seq.seq = Seq.Seq(_seq, alphabet=seq.seq.alphabet)
+        
 
 def check_duplicates(*values):
     names = set()


### PR DESCRIPTION
### Description of proposed changes    
This PR switches out the numpy based implementation for one that uses str.replace.  Not only is it *significantly* faster, but it is also more memory efficient.

```python
In [221]: %timeit make_gaps_ambiguous(a)
1.24 ms ± 27.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [222]: %timeit str_replace(a)
7.78 µs ± 283 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

### Testing
Ran the two implementations on the same input (a case with no '-' characters and a case with '-' characters) and observed the same output.

