### PR TITLE
Add unit test coverage to `filter.read_vcf` and refactor

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -12,17 +12,21 @@ from .utils import read_metadata, get_numerical_dates, run_shell_command, shquot
 
 comment_char = '#'
 
-def read_vcf(compressed, input_file):
-    import gzip
-    opn = gzip.open if compressed else open
 
-    with opn(input_file, mode='rt') as f: #'rt' necessary for gzip
-        for line in f:
-            if line[0:2] == "#C":
-                header = line.strip().split('\t')
-                seq_keep = header[header.index("FORMAT")+1:]
-                all_seq = seq_keep.copy() #because we need 'seqs to remove' for VCF
-                return seq_keep, all_seq
+def read_vcf(filename):
+    if filename.lower().endswith(".gz"):
+        import gzip
+        file = gzip.open(filename, mode="rt")
+    else:
+        file = open(filename)
+
+    chrom_line = next(line for line in file if line.startswith("#C"))
+    file.close()
+    headers = chrom_line.strip().split("\t")
+    sequences = headers[headers.index("FORMAT") + 1:]
+
+    # because we need 'seqs to remove' for VCF
+    return sequences, sequences.copy()
 
 
 def write_vcf(compressed, input_file, output_file, dropped_samps):
@@ -104,7 +108,7 @@ def run(args):
 
     #If VCF, open and get sequence names
     if is_vcf:
-        seq_keep, all_seq = read_vcf(is_compressed, args.sequences)
+        seq_keep, all_seq = read_vcf(args.sequences)
 
     #if Fasta, read in file to get sequence names and sequences
     else:

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,19 @@
+import augur.filter
+
+
+class TestFilter:
+    def test_read_vcf_compressed(self):
+        seq_keep, all_seq = augur.filter.read_vcf(
+            "tests/builds/tb/data/lee_2015.vcf.gz"
+        )
+
+        assert len(seq_keep) == 150
+        assert seq_keep[149] == "G22733"
+        assert seq_keep == all_seq
+
+    def test_read_vcf_uncompressed(self):
+        seq_keep, all_seq = augur.filter.read_vcf("tests/builds/tb/data/lee_2015.vcf")
+
+        assert len(seq_keep) == 150
+        assert seq_keep[149] == "G22733"
+        assert seq_keep == all_seq


### PR DESCRIPTION
Add test coverage to `filter.read_vcf` and do some nonfunctional refactoring.

There are further potential improvements here, but I wanted to do only nonfunctional changes until the module has more test coverage.

As a point of order:
If the team prefers to see larger PRs at lower frequency, I'm happy to accommodate that. I would guess that smaller, faster PRs ease collaboration in a project that may have a large number of new contributors.