### PR TITLE
New style exceptions for both Python 2 and Python 3

### DIFF
--- a/scripts/s3.py
+++ b/scripts/s3.py
@@ -291,7 +291,7 @@ if __name__ == "__main__":
             args.func(args.bucket, args.prefixes, args.local_dir, args.dryrun)
         elif args.command_name == "sync":
             args.func(args.source_bucket, args.destination_bucket, args.prefixes, args.dryrun)
-    except botocore.exceptions.NoCredentialsError, e:
+    except botocore.exceptions.NoCredentialsError as e:
         parser.error("Unable to locate AWS credentials. Set environment variables for AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID.")
-    except Exception, e:
+    except Exception as e:
         parser.error(e.message)

--- a/scripts/swap_colors.py
+++ b/scripts/swap_colors.py
@@ -14,7 +14,7 @@ if args['jsons'] == None:
         jsons = glob('./*meta.json')
         assert len(jsons) > 0
     except:
-        raise IOError, 'ERROR: either provide path(s) to meta.json file(s) or run this script from directory with meta.json files.'
+        raise IOError('ERROR: either provide path(s) to meta.json file(s) or run this script from directory with meta.json files.')
 else:
     jsons = args['jsons']
 


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 while new style exceptions work as expected on both Python 2 and Python 3.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
