### PR TITLE
Add FASTA handling to Augur Mask

### DIFF
--- a/augur/mask.py
+++ b/augur/mask.py
@@ -25,7 +25,7 @@ def read_bed_file(mask_file):
     bed = pd.read_csv(mask_file, sep='\t')
     for _, row in bed.iterrows():
         sitesToMask.extend(list(range(row[1], row[2]+1)))
-    sitesToMask = np.unique(sitesToMask)
+    sitesToMask = np.unique(sitesToMask).tolist()
     print("Found %d sites to mask" % len(sitesToMask))
     return sitesToMask
 

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -79,13 +79,12 @@ def mask_fasta(mask_sites, in_file, out_file):
             record.seq = sequence
             SeqIO.write(record, oh, "fasta")
 
-
 def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF format")
     parser.add_argument('--mask', required=True, help="locations to be masked in BED file format")
     parser.add_argument('--output', '-o', help="output file")
     parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",
-                        help="leave intermediate files around. May be useful for debugging")
+                        help="Leave intermediate files around. May be useful for debugging")
 
 def run(args):
     '''
@@ -115,7 +114,7 @@ def run(args):
 
     mask_sites = read_bed_file(args.mask)
 
-    # For both FASTA and VCF parsing, we need a proper separate output file
+    # For both FASTA and VCF masking, we need a proper separate output file
     out_file = args.output if args.output is not None else "masked_" + args.sequences
 
     if is_vcf(args.sequences):
@@ -126,4 +125,4 @@ def run(args):
     if args.output is None:
         copyfile(out_file, args.sequences)
         if args.cleanup:
-           os.remove(out_file)
+            os.remove(out_file)

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from Bio import SeqIO
 
-from .utils import run_shell_command, shquote
+from .utils import run_shell_command, shquote, open_file
 
 def get_mask_sites(vcf_file, mask_file):
     '''
@@ -20,8 +20,7 @@ def get_mask_sites(vcf_file, mask_file):
 
     #Need CHROM name from VCF file:
     chromName = None
-    opn = gzip.open if vcf_file.lower().endswith('.gz') else open
-    with opn(vcf_file, mode='rt') as f: #'rt' necessary for gzip
+    with open_file(vcf_file, mode='r') as f:
         for line in f:
             if line[0] != "#":
                 header = line.strip().split('\t')

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -33,14 +33,7 @@ def get_mask_sites(vcf_file, mask_file):
               "Please check the file is valid VCF format.")
         return None
 
-    #Read in BED file - 2nd column always chromStart, 3rd always chromEnd
-    #I timed this against sets/update/sorted; this is faster
-    sitesToMask = []
-    bed = pd.read_csv(mask_file, sep='\t')
-    for _, row in bed.iterrows():
-        sitesToMask.extend(list(range(row[1], row[2]+1)))
-    sitesToMask = np.unique(sitesToMask)
-
+    sitesToMask = read_bed_file(mask_file)
     exclude = []
     for pos in sitesToMask:
         exclude.append(chromName+"\t"+str(pos))
@@ -51,6 +44,15 @@ def get_mask_sites(vcf_file, mask_file):
 
     return tempMaskFile
 
+def read_bed_file(mask_file):
+    #Read in BED file - 2nd column always chromStart, 3rd always chromEnd
+    #I timed this against sets/update/sorted; this is faster
+    sitesToMask = []
+    bed = pd.read_csv(mask_file, sep='\t')
+    for _, row in bed.iterrows():
+        sitesToMask.extend(list(range(row[1], row[2]+1)))
+    sitesToMask = np.unique(sitesToMask)
+    return sitesToMask
 
 def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF format")

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -29,9 +29,13 @@ def read_bed_file(mask_file):
     Second column is chromStart, 3rd is chromEnd. Generate a range from these two columns.
     """
     sites_to_mask = []
-    bed = pd.read_csv(mask_file, sep='\t', header=None)
-    for _, row in bed.iterrows():
-        sites_to_mask.extend(list(range(row[1], row[2]+1)))
+    bed = pd.read_csv(mask_file, sep='\t', header=None, usecols=[1,2])
+    for idx, row in bed.iterrows():
+        try:
+            sites_to_mask.extend(list(range(int(row[1]), int(row[2])+1)))
+        except ValueError as err:
+            # Skip unparseable lines, including header lines.
+            print("Could not read line %d of BED file %s: %s. Continuing." % (idx, mask_file, err))
     sites_to_mask = np.unique(sites_to_mask).tolist()
     print("Found %d sites to mask" % len(sites_to_mask))
     return sites_to_mask

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -29,7 +29,7 @@ def read_bed_file(mask_file):
     Second column is chromStart, 3rd is chromEnd. Generate a range from these two columns.
     """
     sites_to_mask = []
-    bed = pd.read_csv(mask_file, sep='\t')
+    bed = pd.read_csv(mask_file, sep='\t', header=None)
     for _, row in bed.iterrows():
         sites_to_mask.extend(list(range(row[1], row[2]+1)))
     sites_to_mask = np.unique(sites_to_mask).tolist()

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -108,9 +108,11 @@ def mask_fasta(mask_sites, in_file, out_file):
         for record in alignment:
             # Convert to a mutable sequence to enable masking with Ns.
             sequence = record.seq.tomutable()
+            sequence_length = len(sequence)
             # Replace all excluded sites with Ns.
             for site in mask_sites:
-                sequence[site] = "N"
+                if site < sequence_length:
+                    sequence[site] = "N"
             record.seq = sequence
             SeqIO.write(record, oh, "fasta")
 

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -32,13 +32,6 @@ def read_bed_file(mask_file):
     sitesToMask = np.unique(sitesToMask)
     return sitesToMask
 
-def register_arguments(parser):
-    parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF format")
-    parser.add_argument('--mask', required=True, help="locations to be masked in BED file format")
-    parser.add_argument('--output', '-o', help="output file")
-    parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",
-                        help="leave intermediate files around. May be useful for debugging")
-
 def mask_vcf(mask_sites, in_file, out_file, cleanup=True):
     cleanup_files = ['out.log']
 
@@ -77,6 +70,12 @@ def mask_vcf(mask_sites, in_file, out_file, cleanup=True):
             except OSError:
                 pass
 
+def register_arguments(parser):
+    parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF format")
+    parser.add_argument('--mask', required=True, help="locations to be masked in BED file format")
+    parser.add_argument('--output', '-o', help="output file")
+    parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",
+                        help="leave intermediate files around. May be useful for debugging")
 
 def run(args):
     '''

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -39,7 +39,7 @@ def register_arguments(parser):
     parser.add_argument('--mask', required=True, help="locations to be masked in BED file format")
     parser.add_argument('--output', '-o', help="output file")
 
-def mask_vcf(mask_file, in_file, out_file):
+def mask_vcf(mask_sites, in_file, out_file, cleanup=True):
     cleanup_files = ['out.log']
 
     # Create the temporary masking file to be passed to VCFTools
@@ -70,11 +70,12 @@ def mask_vcf(mask_file, in_file, out_file):
     print(" ".join(call))
     run_shell_command(" ".join(call), raise_errors = True)
     # remove vcftools log file
-    for file in cleanup_files:
-        try:
-            os.remove(file)
-        except OSError:
-            pass
+    if cleanup:
+        for file in cleanup_files:
+            try:
+                os.remove(file)
+            except OSError:
+                pass
 
 
 def run(args):

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -1,5 +1,5 @@
 """
-Mask specified sites from a VCF file.
+Mask specified sites from a VCF or FASTA file.
 """
 import os
 import sys
@@ -117,7 +117,7 @@ def mask_fasta(mask_sites, in_file, out_file):
             SeqIO.write(record, oh, "fasta")
 
 def register_arguments(parser):
-    parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF format")
+    parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF or FASTA format")
     parser.add_argument('--mask', required=True, help="locations to be masked in BED file format")
     parser.add_argument('--output', '-o', help="output file")
     parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -30,6 +30,7 @@ def read_bed_file(mask_file):
     for _, row in bed.iterrows():
         sitesToMask.extend(list(range(row[1], row[2]+1)))
     sitesToMask = np.unique(sitesToMask)
+    print("Found %d sites to mask" % len(sitesToMask))
     return sitesToMask
 
 def mask_vcf(mask_sites, in_file, out_file, cleanup=True):

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -1,8 +1,6 @@
 """
 Mask specified sites from a VCF file.
 """
-
-import gzip
 import os
 from shutil import copyfile
 

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -2,6 +2,7 @@
 Mask specified sites from a VCF file.
 """
 import os
+import sys
 from shutil import copyfile
 
 import numpy as np
@@ -16,11 +17,6 @@ def get_chrom_name(vcf_file):
             if line[0] != "#":
                 header = line.strip().partition('\t')
                 return header[0]
-
-    print("ERROR: Something went wrong reading your VCF file: a CHROM column could not be found. "
-          "Please check the file is valid VCF format.")
-    return None
-
 
 def read_bed_file(mask_file):
     #Read in BED file - 2nd column always chromStart, 3rd always chromEnd
@@ -40,7 +36,10 @@ def mask_vcf(mask_sites, in_file, out_file, cleanup=True):
     # Need CHROM name from VCF file:
     chrom_name = get_chrom_name(in_file)
     if chrom_name is None:
-        return 1
+        print("ERROR: Something went wrong reading your VCF file: a CHROM column could not be found. "
+              "Please check the file is valid VCF format.")
+        sys.exit(1)
+
     exclude = [chrom_name + "\t" + str(pos) for pos in mask_sites]
     temp_mask_file = in_file + "_maskTemp"
     with open_file(temp_mask_file, 'w') as fh:

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -36,6 +36,8 @@ def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF format")
     parser.add_argument('--mask', required=True, help="locations to be masked in BED file format")
     parser.add_argument('--output', '-o', help="output file")
+    parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",
+                        help="leave intermediate files around. May be useful for debugging")
 
 def mask_vcf(mask_sites, in_file, out_file, cleanup=True):
     cleanup_files = ['out.log']
@@ -102,4 +104,4 @@ def run(args):
     mask_sites = read_bed_file(args.mask)
 
     if is_vcf(args.sequences):
-        mask_vcf(mask_sites, args.sequences, args.output)
+        mask_vcf(mask_sites, args.sequences, args.output, args.cleanup)

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -21,13 +21,13 @@ def get_chrom_name(vcf_file):
 def read_bed_file(mask_file):
     #Read in BED file - 2nd column always chromStart, 3rd always chromEnd
     #I timed this against sets/update/sorted; this is faster
-    sitesToMask = []
+    sites_to_mask = []
     bed = pd.read_csv(mask_file, sep='\t')
     for _, row in bed.iterrows():
-        sitesToMask.extend(list(range(row[1], row[2]+1)))
-    sitesToMask = np.unique(sitesToMask).tolist()
-    print("Found %d sites to mask" % len(sitesToMask))
-    return sitesToMask
+        sites_to_mask.extend(list(range(row[1], row[2]+1)))
+    sites_to_mask = np.unique(sites_to_mask).tolist()
+    print("Found %d sites to mask" % len(sites_to_mask))
+    return sites_to_mask
 
 def mask_vcf(mask_sites, in_file, out_file, cleanup=True):
     cleanup_files = ['out.log']

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -152,7 +152,11 @@ def run(args):
     mask_sites = read_bed_file(args.mask)
 
     # For both FASTA and VCF masking, we need a proper separate output file
-    out_file = args.output if args.output is not None else "masked_" + args.sequences
+    if args.output is not None:
+        out_file = args.output
+    else:
+        out_file = os.path.join(os.path.dirname(args.sequences),
+                                "masked_" + os.path.basename(args.sequences))
 
     if is_vcf(args.sequences):
         mask_vcf(mask_sites, args.sequences, out_file, args.cleanup)

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -33,8 +33,16 @@ def open_file(fname, mode):
             yield fh
 
 def is_vcf(fname):
-    """Convenience method to check if a file is a vcf file."""
-    return fname.endswith(".vcf") or fname.endswith(".vcf.gz")
+    """Convenience method to check if a file is a vcf file.
+
+    >>> is_vcf("./foo")
+    False
+    >>> is_vcf("./foo.vcf")
+    True
+    >>> is_vcf("./foo.vcf.GZ")
+    True
+    """
+    return fname.lower().endswith(".vcf") or fname.lower().endswith(".vcf.gz")
 
 def myopen(fname, mode):
     if fname.endswith('.gz'):

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -32,6 +32,10 @@ def open_file(fname, mode):
         with open(fname, mode) as fh:
             yield fh
 
+def is_vcf(fname):
+    """Convenience method to check if a file is a vcf file."""
+    return fname.endswith(".vcf") or fname.endswith(".vcf.gz")
+
 def myopen(fname, mode):
     if fname.endswith('.gz'):
         import gzip

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -1,10 +1,12 @@
 import argparse
 import Bio
 import Bio.Phylo
+import gzip
 import os, json, sys
 import pandas as pd
 import subprocess
 import shlex
+from contextlib import contextmanager
 from treetime.utils import numeric_date
 from collections import defaultdict
 from pkg_resources import resource_stream
@@ -16,6 +18,19 @@ from .validate import validate, ValidateError, load_json_schema
 
 class AugurException(Exception):
     pass
+
+@contextmanager
+def open_file(fname, mode):
+    """Open a file using either gzip.open() or open() depending on file name. Semantics identical to open()"""
+    if fname.endswith('.gz'):
+        if "t" not in mode:
+            # For interoperability, gzip needs to open files in "text" mode
+            mode = mode + "t"
+        with gzip.open(fname, mode) as fh:
+            yield fh
+    else:
+        with open(fname, mode) as fh:
+            yield fh
 
 def myopen(fname, mode):
     if fname.endswith('.gz'):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -90,6 +90,13 @@ class TestMask:
             fh.write("#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO\n")
         assert mask.get_chrom_name(vcf_file) is None
     
+    def test_read_bed_file_with_header(self, bed_file):
+        """read_bed_file should ignore header rows if they exist"""
+        with open(bed_file, "w") as fh:
+            fh.write("CHROM\tSTART\tEND\n")
+            fh.write("SEQ\t5\t6")
+        assert mask.read_bed_file(bed_file) == [5,6]
+
     def test_read_bed_file(self, bed_file):
         """read_bed_file should read and deduplicate the list of sites in a bed file"""
         # Not a whole lot of testing to do with bed files. We're basically testing if pandas

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,0 +1,160 @@
+import os
+import pytest
+
+from Bio import SeqIO
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+
+from augur import mask
+
+# Test inputs for the commands. Writing these here so tests are self-contained.
+@pytest.fixture
+def sequences():
+    return {
+        "SEQ1": SeqRecord(Seq("ATGC-ATGC-ATGC"), id="SEQ1"),
+        "SEQ2": SeqRecord(Seq("ATATATATATATATAT"), id="SEQ2")
+    }
+
+@pytest.fixture
+def fasta_file(tmpdir, sequences):
+    fasta_file = str(tmpdir / "test.fasta")
+    with open(fasta_file, "w") as fh:
+        SeqIO.write(sequences.values(), fh, "fasta")
+    return fasta_file
+
+TEST_VCF="""\
+##fileformat=VCFv4.2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+SEQ	1	.	G	A	.		.
+SEQ	2	.	G	A	.		.
+SEQ	3	.	C	T	.		.
+SEQ	5	.	C	T	.		.
+SEQ	8	.	A	C	.		.
+"""
+
+@pytest.fixture
+def vcf_file(tmpdir):
+    vcf_file = str(tmpdir / "test.vcf")
+    with open(vcf_file, "w") as fh:
+        fh.write(TEST_VCF)
+    return vcf_file
+
+TEST_BED="""\
+Chrom	ChromStart	ChromEnd	locus tag	Comment	
+SEQ1	1	2	IG18_Rv0018c-Rv0019c	
+SEQ1	4	4	IG18_Rv0018c-Rv0019c	
+SEQ1	6	8	IG18_Rv0018c-Rv0019c	
+SEQ1	7	10	IG18_Rv0018c-Rv0019c	
+"""
+
+@pytest.fixture
+def bed_file(tmpdir):
+    bed_file = str(tmpdir / "exclude.bed")
+    with open(bed_file, "w") as fh:
+        fh.write(TEST_BED)
+    return bed_file
+
+@pytest.fixture
+def mp_context(monkeypatch):
+    #Have found explicit monkeypatch context-ing prevents stupid bugs
+    with monkeypatch.context() as mp:
+        yield mp
+
+class TestMask:
+    def test_get_chrom_name_valid(self, vcf_file):
+        """get_chrom_name should return the first CHROM field in a vcf file"""
+        assert mask.get_chrom_name(vcf_file) == "SEQ"
+
+    def test_get_chrom_name_invalid(self, tmpdir):
+        """get_chrom_name should return nothing if no CHROM field is found in the VCF"""
+        vcf_file = str(tmpdir / "incomplete.vcf")
+        with open(vcf_file, "w") as fh:
+            fh.write("##fileformat=VCFv4.2\n")
+            fh.write("#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO\n")
+        assert mask.get_chrom_name(vcf_file) is None
+    
+    def test_read_bed_file(self, bed_file):
+        """read_bed_file should read and deduplicate the list of sites in a bed file"""
+        # Not a whole lot of testing to do with bed files. We're basically testing if pandas
+        # can read a CSV and numpy can dedupe it.
+        assert mask.read_bed_file(bed_file) == [1,2,4,6,7,8,9,10]
+
+    def test_mask_vcf_bails_on_no_chrom(self, tmpdir, mp_context):
+        """mask_vcf should pull a sys.exit() if get_chrom_name returns None"""
+        bad_vcf = str(tmpdir / "bad.vcf")
+        with open(bad_vcf, "w") as fh:
+            fh.write("#")
+        with pytest.raises(SystemExit) as err:
+            mask.mask_vcf([], bad_vcf, "")
+    
+    def test_mask_vcf_creates_maskfile(self, vcf_file, mp_context):
+        """mask_vcf should create and use a mask file from the given list of sites"""
+        mask_file = vcf_file + "_maskTemp"
+        def shell_has_maskfile(call, **kwargs):
+            assert mask_file in call
+        mp_context.setattr(mask, "get_chrom_name", lambda f: "SEQ")
+        mp_context.setattr(mask, "run_shell_command", shell_has_maskfile)
+        mask.mask_vcf([1,5], vcf_file, vcf_file, cleanup=False)
+        assert os.path.isfile(mask_file), "Mask file was not written!"
+        with open(mask_file) as fh:
+            assert fh.read() == "SEQ	1\nSEQ	5", "Incorrect mask file written!"
+    
+    def test_mask_vcf_handles_gz(self, vcf_file, mp_context):
+        """mask_vcf should recognize when the in or out files are .gz and call out accordingly"""
+        def test_shell(call, raise_errors=True):
+            assert "--gzvcf" in call
+            assert "| gzip -c" in call
+        mp_context.setattr(mask, "run_shell_command", test_shell)
+        mp_context.setattr(mask, "get_chrom_name", lambda f: "SEQ")
+        # Still worth using the fixture here because writing the mask file uses this path
+        # Using it for both entries in case god forbid someone starts assuming that path
+        # valid earlier than it currently is.
+        in_file = vcf_file + ".gz"
+        mask.mask_vcf([1,5], in_file, in_file)
+
+    def test_mask_vcf_removes_matching_sites(self, tmpdir, vcf_file):
+        """mask_vcf should remove the given sites from the VCF file"""
+        out_file = str(tmpdir / "output.vcf")
+        mask.mask_vcf([5,6], vcf_file, out_file)
+        with open(out_file) as after, open(vcf_file) as before:
+            assert len(after.readlines()) == len(before.readlines()) - 1, "Too many lines removed!"
+            assert "SEQ\t5" not in after.read(), "Correct sites not removed!"
+
+    def test_mask_vcf_cleanup_flag(self, vcf_file, mp_context):
+        """mask_vcf should respect the cleanup flag"""
+        tmp_mask_file = vcf_file + "_maskTemp"
+        mp_context.setattr(mask, "run_shell_command", lambda *a, **k: None)
+        mp_context.setattr(mask, "get_chrom_name", lambda f: "SEQ")
+
+        mask.mask_vcf([], vcf_file, "", cleanup=True)
+        assert not os.path.isfile(tmp_mask_file), "Temporary mask not cleaned up"
+
+        mask.mask_vcf([], vcf_file, "", cleanup=False)
+        assert os.path.isfile(tmp_mask_file), "Temporary mask cleaned up as expected"
+    
+    def test_mask_fasta_normal_case(self, tmpdir, fasta_file, sequences):
+        """mask_fasta normal case - all sites in sequences"""
+        out_file = str(tmpdir / "output.fasta")
+        mask_sites = [5,10]
+        mask.mask_fasta([5,10], fasta_file, out_file)
+        output = SeqIO.parse(out_file, "fasta")
+        for seq in output:
+            original = sequences[seq.id]
+            for idx, site in enumerate(seq):
+                if idx not in mask_sites:
+                    assert site == original[idx], "Incorrect sites modified!"
+                else:
+                    assert site == "N", "Not all sites modified correctly!"
+    
+    def test_mask_fasta_out_of_index(self, tmpdir, fasta_file, sequences):
+        """mask_fasta provided a list of indexes past the length of the sequences"""
+        out_file = str(tmpdir / "output.fasta")
+        max_length = max(len(record.seq) for record in sequences.values())
+        mask.mask_fasta([5, max_length, max_length+5], fasta_file, out_file)
+        output = SeqIO.parse(out_file, "fasta")
+        for seq in output:
+            assert seq[5] == "N", "Not all sites masked correctly!"
+            original = sequences[seq.id]
+            for idx, site in enumerate(seq):
+                if idx != 5:
+                    assert site == original[idx], "Incorrect sites modified!"

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -48,7 +48,6 @@ def vcf_file(tmpdir):
 TEST_BED_SEQUENCE = [1,2,4,6,7,8,9,10]
 # IF YOU UPDATE ONE OF THESE, UPDATE THE OTHER.
 TEST_BED="""\
-Chrom	ChromStart	ChromEnd	locus tag	Comment	
 SEQ1	1	2	IG18_Rv0018c-Rv0019c	
 SEQ1	4	4	IG18_Rv0018c-Rv0019c	
 SEQ1	6	8	IG18_Rv0018c-Rv0019c	


### PR DESCRIPTION
### Description of proposed changes    
Add FASTA handling to `augur mask` and two additional functions to `augur.utils` to deduplicate some code.

Note this is Just the FASTA handling for `augur mask` - I'll add the nonsense site handling and the rest of the capabilities from ncov's `mask-alignment.py` next.

### Related issue(s)  
Fixes #148

### Testing
Ran the full test suite as well as wrote a lot of additional tests for augur.mask

However, as usual, please a) sanity check and b) actually test this with live files. I've got the files in the tests/build directory to work with, but that's about it.

### Notes
This is a pretty big overhaul because `augur.mask` was written solely to handle .vcf files before, so I had to refactor most of the file before I could even start. There's no other new functionality except a debug flag - this is _just_ adding masking to FASTA files.

The VCF-specific parts have been moved to their own functions, and I've ported the FASTA masking from `augur.tree` in. I added tests for this file, as well as a couple utility functions that *I've* already had to rewrite half a dozen times in various files.

After this is accepted, I'd like to add the nonsense site masking from #72 as well as the `--mask-from-beginning` and `--mask-from-end` functionality from the [ncov `mask-alignment` script](https://github.com/nextstrain/ncov/blob/master/scripts/mask-alignment.py), but I wanted to get the basic rework done first.

There's also a bunch of parts of this around error handling and validating inputs I'd like to change as well, but again, I wanted to get the basic refactor in first. This doesn't introduce any regressions and is already a large enough PR.

### Thank you for contributing to Nextstrain!
