### PR TITLE
WIP and RFC: Rewrite `filter.py` with several classes

### DIFF
--- a/augur/exceptions.py
+++ b/augur/exceptions.py
@@ -1,0 +1,8 @@
+class AugurException(Exception):
+    pass
+
+
+class MissingDependencyException(AugurException):
+    """Raised when a required external dependency is not present."""
+    #TODO raise "ERROR: `vcftools` is not installed! This is required for VCF data. Please see the augur install instructions to install it."
+    pass

--- a/augur/filtering/matchers/__init__.py
+++ b/augur/filtering/matchers/__init__.py
@@ -1,0 +1,14 @@
+from augur.filtering.matchers.date import Date
+from augur.filtering.matchers.length import Length
+from augur.filtering.matchers.metadata import Metadata
+from augur.filtering.matchers.name import Name
+from augur.filtering.matchers.nonnucleotide import Nonnucleotide
+
+
+MATCHER_CLASSES = {
+    "date": Date,
+    "length": Length,
+    "metadata": Metadata,
+    "name": Name,
+    "non-nucleotide": Nonnucleotide,
+}

--- a/augur/filtering/matchers/base_matcher.py
+++ b/augur/filtering/matchers/base_matcher.py
@@ -1,0 +1,28 @@
+import abc
+
+
+class BaseMatcher(abc.ABC):
+    """
+    def filter(self, sequences, all_sequences):
+        if self.filter_operation() == "include":
+            self.affected_sequences_set = set(self.affected_sequences(all_sequences))
+
+            return set(sequences).union(self.affected_sequences_set)
+        elif self.filter_operation() == "exclude":
+            self.affected_sequences_set = set(self.affected_sequences(sequences))
+
+            return set(sequences).difference(self.affected_sequences_set)
+        else:
+            raise Exception(f"Unknown filter operation {self.filter_operation()}")
+    """
+
+    @abc.abstractmethod
+    def is_affected(self, sequence):
+        pass
+
+    """
+    @staticmethod
+    @abc.abstractmethod
+    def is_enabled(args):
+        pass
+    """

--- a/augur/filtering/matchers/date.py
+++ b/augur/filtering/matchers/date.py
@@ -1,0 +1,66 @@
+import datetime
+import re
+
+from augur.utils import ambiguous_date_to_date_range
+from augur.filtering.matchers.base_matcher import BaseMatcher
+
+
+class Date(BaseMatcher):
+    FILTER_OPERATION = "exclude"
+
+    def __init__(self, *, min_date=None, max_date=None):
+        self.min_date = min_date
+        self.max_date = max_date
+
+    def is_affected(self, sequence):
+        # TODO need the ambiguous sample date be ENTIRELY within the constraint range? or is partial overlap enough to inclued the sample?
+        if sequence.date is None:
+            return False
+
+        sample_date_min, sample_date_max = ambiguous_date_to_date_range(
+            sequence.date, "%Y-%m-%d"
+        )
+
+        if self.min_date and sample_date_max < self.min_date:
+            return True
+
+        if self.max_date and sample_date_min > self.max_date:
+            return True
+
+        return False
+
+    @classmethod
+    def build(cls, matcher_args):
+        # TODO naive and clumsy
+        arg_matches = re.search(r"min=([^,]*)", matcher_args)
+        min_date_arg = arg_matches.groups()[0] if arg_matches else None
+
+        arg_matches = re.search(r"max=([^,]*)", matcher_args)
+        max_date_arg = arg_matches.groups()[0] if arg_matches else None
+
+        # TODO fromisoformat is a behavior change! might as well introduce some predictability to the input. backwards compatibility?
+        if min_date_arg:
+            try:
+                min_date = datetime.date.fromisoformat(min_date_arg)
+            except ValueError:
+                # TODO is this the legacy behavior? seems weird.
+                min_date = datetime.date(year=int(min_date_arg), month=1, day=1)
+        else:
+            min_date = None
+        if max_date_arg:
+            try:
+                max_date = datetime.date.fromisoformat(max_date_arg)
+            except ValueError:
+                max_date = datetime.date(year=int(max_date_arg), month=1, day=1)
+        else:
+            max_date = None
+        return Date(min_date=min_date, max_date=max_date)
+
+    @staticmethod
+    def add_arguments(parser):
+        parser.add_argument(
+            "--min-date", type=str, help="minimal cutoff for numerical date"
+        )
+        parser.add_argument(
+            "--max-date", type=str, help="maximal cutoff for numerical date"
+        )

--- a/augur/filtering/matchers/date.py
+++ b/augur/filtering/matchers/date.py
@@ -9,8 +9,21 @@ class Date(BaseMatcher):
     FILTER_OPERATION = "exclude"
 
     def __init__(self, *, min_date=None, max_date=None):
-        self.min_date = min_date
-        self.max_date = max_date
+        if min_date:
+            try:
+                self.min_date = datetime.date.fromisoformat(min_date)
+            except ValueError:
+                # TODO is this the legacy behavior? seems weird.
+                self.min_date = datetime.date(year=int(min_date), month=1, day=1)
+        else:
+            self.min_date = None
+        if max_date:
+            try:
+                self.max_date = datetime.date.fromisoformat(max_date)
+            except ValueError:
+                self.max_date = datetime.date(year=int(max_date), month=1, day=1)
+        else:
+            self.max_date = None
 
     def is_affected(self, sequence):
         # TODO need the ambiguous sample date be ENTIRELY within the constraint range? or is partial overlap enough to inclued the sample?
@@ -28,33 +41,6 @@ class Date(BaseMatcher):
             return True
 
         return False
-
-    @classmethod
-    def build(cls, matcher_args):
-        # TODO naive and clumsy
-        arg_matches = re.search(r"min=([^,]*)", matcher_args)
-        min_date_arg = arg_matches.groups()[0] if arg_matches else None
-
-        arg_matches = re.search(r"max=([^,]*)", matcher_args)
-        max_date_arg = arg_matches.groups()[0] if arg_matches else None
-
-        # TODO fromisoformat is a behavior change! might as well introduce some predictability to the input. backwards compatibility?
-        if min_date_arg:
-            try:
-                min_date = datetime.date.fromisoformat(min_date_arg)
-            except ValueError:
-                # TODO is this the legacy behavior? seems weird.
-                min_date = datetime.date(year=int(min_date_arg), month=1, day=1)
-        else:
-            min_date = None
-        if max_date_arg:
-            try:
-                max_date = datetime.date.fromisoformat(max_date_arg)
-            except ValueError:
-                max_date = datetime.date(year=int(max_date_arg), month=1, day=1)
-        else:
-            max_date = None
-        return Date(min_date=min_date, max_date=max_date)
 
     @staticmethod
     def add_arguments(parser):

--- a/augur/filtering/matchers/length.py
+++ b/augur/filtering/matchers/length.py
@@ -1,0 +1,24 @@
+import re
+
+from augur.filtering.matchers.base_matcher import BaseMatcher
+
+
+class Length(BaseMatcher):
+    def __init__(self, *, min_length):
+        self.min_length = int(min_length)
+
+    def is_affected(self, sequence):
+        return sequence.length < self.min_length
+
+    @classmethod
+    def build(cls, matcher_args):
+        arg_matches = re.search(r"min=([^,]*)", matcher_args)
+        min_length = arg_matches.groups()[0] if arg_matches else None
+
+        return cls(min_length=min_length)
+
+    @staticmethod
+    def add_arguments(parser):
+        parser.add_argument(
+            "--min-length", type=int, help="minimal length of the sequences"
+        )

--- a/augur/filtering/matchers/length.py
+++ b/augur/filtering/matchers/length.py
@@ -10,13 +10,6 @@ class Length(BaseMatcher):
     def is_affected(self, sequence):
         return sequence.length < self.min_length
 
-    @classmethod
-    def build(cls, matcher_args):
-        arg_matches = re.search(r"min=([^,]*)", matcher_args)
-        min_length = arg_matches.groups()[0] if arg_matches else None
-
-        return cls(min_length=min_length)
-
     @staticmethod
     def add_arguments(parser):
         parser.add_argument(

--- a/augur/filtering/matchers/metadata.py
+++ b/augur/filtering/matchers/metadata.py
@@ -4,8 +4,16 @@ from augur.filtering.matchers.base_matcher import BaseMatcher
 
 
 class Metadata(BaseMatcher):
-    def __init__(self, *, conditions):
-        self.conditions = conditions
+    def __init__(self, *, clause):
+        self.conditions = []
+        for condition in clause.split(","):
+            matches = re.search(r"(\w+)(=|!=)(\w+)", condition)
+            if matches is None:
+                raise AttributeError(
+                    f"Malformed condition`{condition}`. "
+                    "Must be of form `property=value` or `property!=value`"
+                )
+            self.conditions.append(matches.groups())
 
     def is_affected(self, sequence):
         return any(
@@ -31,20 +39,6 @@ class Metadata(BaseMatcher):
 
         # Should be impossible
         raise
-
-    @classmethod
-    def build(cls, matcher_args):
-        conditions = []  # TODO list of namedtuples maybe. or just a new class.
-        for condition in matcher_args.split(","):
-            matches = re.search(r"(\w+)(=|!=)(\w+)", condition)
-            if matches is None:
-                raise AttributeError(
-                    f"Malformed condition`{condition}`. "
-                    "Must be of form `property=value` or `property!=value`"
-                )
-            conditions.append(matches.groups())
-
-        return cls(conditions=conditions)
 
     @staticmethod
     def add_arguments(parser):

--- a/augur/filtering/matchers/metadata.py
+++ b/augur/filtering/matchers/metadata.py
@@ -1,0 +1,65 @@
+import re
+
+from augur.filtering.matchers.base_matcher import BaseMatcher
+
+
+class Metadata(BaseMatcher):
+    def __init__(self, *, conditions):
+        self.conditions = conditions
+
+    def is_affected(self, sequence):
+        return any(
+            [
+                self.sequence_matches_condition(sequence, key, value, comparator)
+                for key, comparator, value in self.conditions
+            ]
+        )
+
+    @staticmethod
+    def sequence_matches_condition(sequence, key, value, comparator):
+        if key not in sequence.metadata:
+            # sequences that lack the specified metadata column are always excluded
+            # TODO is that right? regardless, it should be documented in the argument help
+            return True
+
+        sequence_value = sequence.metadata[key]
+        if comparator == "=":
+            return sequence_value.lower() == value.lower()
+
+        if comparator == "!=":
+            return sequence_value.lower() != value.lower()
+
+        # Should be impossible
+        raise
+
+    @classmethod
+    def build(cls, matcher_args):
+        conditions = []  # TODO list of namedtuples maybe. or just a new class.
+        for condition in matcher_args.split(","):
+            matches = re.search(r"(\w+)(=|!=)(\w+)", condition)
+            if matches is None:
+                raise AttributeError(
+                    f"Malformed condition`{condition}`. "
+                    "Must be of form `property=value` or `property!=value`"
+                )
+            conditions.append(matches.groups())
+
+        return cls(conditions=conditions)
+
+    @staticmethod
+    def add_arguments(parser):
+        parser.add_argument(
+            "--exclude-where",
+            nargs="+",
+            help="Exclude samples matching these conditions. Ex: `host=rat` or "
+            "`host!=rat`. Multiple values are processed as OR (matching any of "
+            "those specified will be excluded), not AND",
+        )
+        parser.add_argument(
+            "--include-where",
+            nargs="+",
+            help="Include samples with these values. ex: host=rat. Multiple values "
+            "are processed as OR (having any of those specified will be included), "
+            "not AND. This rule is applied last and ensures any sequences matching "
+            "these rules will be included.",
+        )

--- a/augur/filtering/matchers/name.py
+++ b/augur/filtering/matchers/name.py
@@ -1,0 +1,44 @@
+from augur.filtering.matchers.base_matcher import BaseMatcher
+
+
+def read_names(filename):
+    with open(filename, "r") as file:
+        return [
+            line
+            for line in (strip_comment(line) for line in file.readlines())
+            if line != ""
+        ]
+
+
+def strip_comment(line):
+    return line.partition("#")[0].strip()
+
+
+class Name(BaseMatcher):
+    def __init__(self, *, names):
+        self.names = set(names)
+
+    def is_affected(self, sequence):
+        return sequence.name in self.names
+
+    @classmethod
+    def build(cls, matcher_args):
+        scheme, _, location = matcher_args.partition("=")
+
+        if scheme == "file":
+            return cls(names=read_names(location))
+        else:
+            raise
+
+    @staticmethod
+    def add_arguments(parser):
+        parser.add_argument(
+            "--exclude",
+            type=str,
+            help="file with list of strains that are to be excluded",
+        )
+        parser.add_argument(
+            "--include",
+            type=str,
+            help="file with list of strains that are to be included regardless of priorities or subsampling",
+        )

--- a/augur/filtering/matchers/name.py
+++ b/augur/filtering/matchers/name.py
@@ -15,20 +15,11 @@ def strip_comment(line):
 
 
 class Name(BaseMatcher):
-    def __init__(self, *, names):
-        self.names = set(names)
+    def __init__(self, *, filename):
+        self.names = set(read_names(filename))
 
     def is_affected(self, sequence):
         return sequence.name in self.names
-
-    @classmethod
-    def build(cls, matcher_args):
-        scheme, _, location = matcher_args.partition("=")
-
-        if scheme == "file":
-            return cls(names=read_names(location))
-        else:
-            raise
 
     @staticmethod
     def add_arguments(parser):

--- a/augur/filtering/matchers/nonnucleotide.py
+++ b/augur/filtering/matchers/nonnucleotide.py
@@ -5,10 +5,6 @@ class Nonnucleotide(BaseMatcher):
     def is_affected(self, sequence):
         return not sequence.has_only_nucleotide_symbols
 
-    @classmethod
-    def build(cls, _matcher_args):
-        return cls()
-
     @staticmethod
     def add_arguments(parser):
         parser.add_argument(

--- a/augur/filtering/matchers/nonnucleotide.py
+++ b/augur/filtering/matchers/nonnucleotide.py
@@ -1,0 +1,18 @@
+from augur.filtering.matchers.base_matcher import BaseMatcher
+
+
+class Nonnucleotide(BaseMatcher):
+    def is_affected(self, sequence):
+        return not sequence.has_only_nucleotide_symbols
+
+    @classmethod
+    def build(cls, _matcher_args):
+        return cls()
+
+    @staticmethod
+    def add_arguments(parser):
+        parser.add_argument(
+            "--non-nucleotide",
+            action="store_true",
+            help="exclude sequences that contain illegal characters",
+        )

--- a/augur/filtering/subsampler.py
+++ b/augur/filtering/subsampler.py
@@ -1,0 +1,132 @@
+from collections import defaultdict
+import functools
+import random
+
+
+class Subsampler:
+    def __init__(self, *, priorities_fname, group_by, sequences_per_group, seed=None):
+        self.priorities_fname = priorities_fname
+        self.discriminators = group_by
+        self.sequences_per_group = sequences_per_group
+        self.seed = seed
+
+    def is_affected(self, sequences):
+        """
+        Subsampling sorts sequences into groups by metadata fields specified in --group-by and then take at
+        most --sequences-per-group from each group. Within each group, sequences are optionally sorted by a
+        priority score specified in a file --priority.
+        The random seed may be specified by --subsample-seed.
+        """
+        return False  # TODO
+        if self.seed:
+            random.seed(self.seed)
+
+        seq_names_by_group = self.divide_into_groups(sequences)
+
+        # If didnt find any categories specified, all seqs will be in 'unknown' - but don't sample this!
+        if len(seq_names_by_group) == 1 and ("unknown" in seq_names_by_group or ("unknown",) in seq_names_by_group):
+            print(f"WARNING: The specified group-by categories ({self.discriminators}) were not found. No sequences-per-group sampling will be done.")
+            if any([x in self.discriminators for x in ['year', 'month']]):
+                print("Note that using 'year' or 'year month' requires a column called 'date'.")
+            print("\n")
+        else:
+            # Check to see if some categories are missing to warn the user
+            group_by = set(['date' if cat in ['year', 'month'] else cat
+                            for cat in self.discriminators])
+            missing_cats = [cat for cat in group_by if cat not in meta_columns]
+            if missing_cats:
+                print("WARNING:")
+                if any([cat != 'date' for cat in missing_cats]):
+                    print("\tSome of the specified group-by categories couldn't be found: ",
+                          ", ".join([str(cat) for cat in missing_cats if cat != 'date']))
+                if any([cat == 'date' for cat in missing_cats]):
+                    print("\tA 'date' column could not be found to group-by year or month.")
+                print("\tFiltering by group may behave differently than expected!\n")
+
+            if args.priority: # read priorities
+                priorities = read_priority_scores(args.priority)
+
+            # subsample each groups, either by taking the sequences_per_group highest priority strains or
+            # sampling at random from the sequences in the group
+            seq_subsample = []
+            for group, sequences_in_group in seq_names_by_group.items():
+                if args.priority: #sort descending by priority
+                    seq_subsample.extend(sorted(sequences_in_group, key=lambda x:priorities[x], reverse=True)[:spg])
+                else:
+                    seq_subsample.extend(sequences_in_group if len(sequences_in_group)<=self.sequences_per_group
+                                         else random.sample(sequences_in_group, self.sequences_per_group))
+
+            num_excluded_subsamp = len(self.sequence_names) - len(seq_subsample)
+            return seq_subsample
+
+    def divide_into_groups(self, sequences):
+        groups = defaultdict(list)
+
+        for sequence in sequences:
+            group_name = self.group_name_for_sequence(sequence)
+            groups[group_name].append(sequence)
+
+        return groups
+
+    def group_name_for_sequence(self, sequence):
+        """
+        Group names are roughly a tuple of the specified discriminators.
+        "month" and "year" are special cases.
+        """
+        group_name = []
+        for discriminator in self.discriminators:
+            if discriminator in sequence.metadata:
+                # if the discriminator is a metadata column, append it to the group name
+                group_name.append(sequence.metadata[discriminator])
+            elif discriminator in ["month", "year"] and "date" in sequence.metadata:
+                # if the discriminator is "month" or "year", append the actual value to the group name
+                try:
+                    year = int(sequence.metadata["date"].split("-")[0])
+                except ValueError:
+                    # TODO does the sequence actually get skipped like the message says? Is that desired?
+                    print(f"WARNING: Tried to --group-by year, but sample has no valid year. Skipping it. {sequence}")
+                    continue
+
+                if discriminator == "month":
+                    try:
+                        month = int(sequence.metadata["date"].split("-")[1])
+                    except ValueError:
+                        month = random.randint(1, 12)
+                    group_name.append((year, month))
+                else:
+                    group_name.append(year)
+            else:
+                # otherwise, this discriminator causes an "unknown"
+                group_name.append("unknown")
+
+        return tuple(group_name)
+
+    @property
+    @functools.lru_cache()
+    def priority_scores(self):
+        # TODO raise exception if some samples do not have a priority? User could inadvertantly leave some samples unprioritized.
+        priorities = defaultdict(float)
+
+        try:
+            with open(self.args.priority) as pfile:
+                for name, priority in (
+                    line.strip().split() for line in pfile.readlines()
+                ):
+                    priorities[name]: float(priority)
+        except Exception as e:
+            print(
+                f"ERROR: missing or malformed priority scores file {self.args.priority}",
+                file=sys.stderr,
+            )
+            raise e
+
+        return priorities
+
+    @classmethod
+    def build(cls, context):
+        return cls(
+            priorities_fname=context.args.priority,
+            group_by=context.args.group_by,
+            sequences_per_group=context.args.sequences_per_group,
+            seed=context.args.subsample_seed,
+        )

--- a/augur/filtering/vcf_selector.py
+++ b/augur/filtering/vcf_selector.py
@@ -1,0 +1,64 @@
+import functools
+import os
+
+from augur.utils import run_shell_command, shquote
+
+
+class VCFSelector:
+    """
+    Use vcftools to select the specified samples from `samplefile` and write an output file.
+    """
+
+    def __init__(self, *, selected_samples, samplefile, output_fname):
+        self.selected_samples = selected_samples
+        self.samplefile = samplefile
+        self.output_fname = output_fname
+
+    def write_output_vcf(self):
+        print("Filtering samples using VCFTools with the call:")
+        print(" ".join(self.vcftools_command))
+        run_shell_command(" ".join(self.vcftools_command), raise_errors=True)
+        # remove vcftools log file
+        try:
+            os.remove("out.log")
+        except OSError:
+            pass
+
+    @property
+    @functools.lru_cache()
+    def vcftools_command(self):
+        return (
+            ["vcftools"]
+            + self.vcftools_args_select_samples
+            + self.vcftools_args_input_file
+            + ["--recode", "--stdout"]
+            + self.vcftools_args_output_redirect
+        )
+
+    @property
+    def vcftools_args_select_samples(self):
+        return [
+            f(x)
+            for x in self.selected_samples
+            for f in (lambda _: "--indv", lambda sample: sample.name)
+        ]
+
+    @property
+    def vcftools_args_input_file(self):
+        fname = shquote(self.samplefile.filename)
+
+        if self.samplefile.is_compressed_vcf:
+            return ["--gzvcf", fname]
+        else:
+            return ["--vcf", fname]
+
+    @property
+    def vcftools_args_output_redirect(self):
+        fname = shquote(self.output_fname)
+
+        if fname.lower().endswith(".gz"):
+            gzip_pipe = "| gzip -c"
+        else:
+            gzip_pipe = ""
+
+        return [gzip_pipe, ">", fname]

--- a/augur/sequence.py
+++ b/augur/sequence.py
@@ -1,0 +1,59 @@
+import functools
+
+
+# TODO move this
+NUCLEOTIDE_SYMBOLS = {
+    "A",
+    "C",
+    "G",
+    "T",
+    "-",
+    "N",
+    "R",
+    "Y",
+    "S",
+    "W",
+    "K",
+    "M",
+    "D",
+    "H",
+    "B",
+    "V",
+    "?",
+}
+
+
+# TODO rename this class to Sample
+class Sequence:
+    """
+    A sequence sample.
+
+    name : str
+    sequence : str
+    metadata : dict
+        extra data not included in a FASTA or VCF file
+    bio_seq : Bio.Seq.Seq
+        optional original record from Bio, to be written out after filtering
+    """
+
+    def __init__(self, *, name, sequence, metadata, bio_seq=None):
+        self.name = name
+        self.sequence = sequence
+        self.metadata = metadata
+        self.bio_seq = bio_seq
+
+    @property
+    def date(self):
+        return self.metadata.get("date")
+
+    @property
+    @functools.lru_cache()
+    def length(self):
+        return sum(
+            1 for s in self.sequence if s in {"a", "t", "g", "c", "A", "T", "G", "C"}
+        )
+
+    @property
+    @functools.lru_cache()
+    def has_only_nucleotide_symbols(self):
+        return any(site not in NUCLEOTIDE_SYMBOLS for site in self.sequence.upper())

--- a/augur/sequence_file.py
+++ b/augur/sequence_file.py
@@ -1,0 +1,85 @@
+from Bio import SeqIO
+import functools
+
+from augur.sequence import Sequence
+from augur.utils import read_metadata
+
+
+# TODO rename this to SampleFile
+class SequenceFile:
+    """
+    Represents a file containing sequences (TODO or samples?) in FASTA, VCF, or gzipped VCF format.
+    """
+    def __init__(self, filename, metadata_filename):
+        self.filename = filename
+        self.metadata_filename = metadata_filename
+
+    @property
+    @functools.lru_cache()
+    def sequences(self):
+        """
+        An array of Sequence objects representing the input sequences adorned with input metadata.
+        Input sequences that lack metadata are not included.
+        """
+        if self.is_vcf:
+            # Note that VCFs do not contain actual sequences, so we'll use None
+            return [
+                Sequence(name=name, sequence=None, metadata=self.metadata[name])
+                for name in self.read_sequence_names_from_vcf()
+                if name in self.metadata
+            ]
+        elif self.is_fasta:
+            return [
+                Sequence(
+                    name=bio_seq.id,
+                    sequence=bio_seq.seq,
+                    metadata=self.metadata[bio_seq.id],
+                    bio_seq=bio_seq,
+                )
+                for bio_seq in SeqIO.parse(self.filename, "fasta")
+                if bio_seq.id in self.metadata
+            ]
+        else:
+            raise  # TODO specific exception class for unsupported format
+
+    def read_sequence_names_from_vcf(self):
+        with self.open_vcf() as file:
+            chrom_line = next(line for line in file if line.startswith("#C"))
+            headers = chrom_line.strip().split("\t")
+
+            return headers[headers.index("FORMAT") + 1 :]
+
+    def open_vcf(self):
+        if self.is_compressed_vcf:
+            import gzip
+
+            return gzip.open(self.filename, mode="rt")
+
+        return open(self.filename)
+
+    @property
+    @functools.lru_cache()
+    def metadata(self):
+        meta_dict, _meta_columns = read_metadata(self.metadata_filename)
+        return meta_dict
+
+    @property
+    def is_vcf(self):
+        return self.is_compressed_vcf or self.is_uncompressed_vcf
+
+    @property
+    def is_compressed_vcf(self):
+        return self.lower_filename.endswith(".vcf.gz")
+
+    @property
+    def is_uncompressed_vcf(self):
+        return self.lower_filename.endswith(".vcf")
+
+    @property
+    def is_fasta(self):
+        # TODO is this reliable?
+        return self.lower_filename.endswith(".fasta")
+
+    @property
+    def lower_filename(self):
+        return self.filename.lower()

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -12,12 +12,12 @@ from collections import defaultdict
 from pkg_resources import resource_stream
 from io import TextIOWrapper
 from textwrap import dedent
-from .__version__ import __version__
 import packaging.version as packaging_version
-from .validate import validate, ValidateError, load_json_schema
 
-class AugurException(Exception):
-    pass
+from augur.exceptions import AugurException
+from .validate import validate, ValidateError, load_json_schema
+from .__version__ import __version__
+
 
 @contextmanager
 def open_file(fname, mode):

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
             "pylint >=1.7.6, ==1.7.*",
             "pytest >=5.4.1, ==5.4.*",
             "pytest-cov >=2.8.1, ==2.8.*",
+            "pytest-factoryboy >=2.0.3, ==2.0.*",
             "pytest-mock >= 2.0.0, ==2.0.*",
             "recommonmark >=0.5.0, ==0.*",
             "Sphinx >=2.0.1, ==2.*",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from pathlib    import Path
-from setuptools import setup
+import setuptools
 import sys
 
 min_version = (3, 6)
@@ -26,7 +26,8 @@ with version_file.open() as f:
 with readme_file.open(encoding = "utf-8") as f:
     long_description = f.read()
 
-setup(
+
+setuptools.setup(
     name = "nextstrain-augur",
     version = __version__,
     author = "Nextstrain developers",
@@ -41,7 +42,7 @@ setup(
         "Change Log": "https://github.com/nextstrain/augur/blob/master/CHANGES.md#next",
         "Source": "https://github.com/nextstrain/augur",
     },
-    packages = ['augur'],
+    packages = setuptools.find_packages(),
     package_data = {'augur': ['data/*']},
     data_files = [("", ["LICENSE.txt"])],
     python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import factory
+import inspect
+import pytest_factoryboy
+
+import tests.factories
+
+# register all of the factory.Factory subclasses in tests.factories
+for (name, factory_class) in inspect.getmembers(tests.factories):
+    if inspect.isclass(factory_class) and issubclass(factory_class, factory.Factory):
+        pytest_factoryboy.register(factory_class)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,34 @@
+import factory
+import random
+
+import augur
+
+import pytest
+
+
+class SequenceFactory(factory.Factory):
+    class Meta:
+        model = augur.sequence.Sequence
+
+    name = factory.Sequence(lambda n: f"seq{n}")
+    sequence = str.join("", random.choices("ACGT", k=50))
+    metadata = {}  # TODO
+    bio_seq = factory.Sequence(lambda n: f"bio_seq{n}")
+
+
+class SamplefileFactory(factory.Factory):
+    class Meta:
+        model = augur.sequence_file.SequenceFile
+        exclude = ("sample_names",)
+
+    filename = factory.Sequence(lambda n: f"seq{n}")
+    metadata_filename = factory.Sequence(lambda n: f"seq{n}")
+
+
+class VCFSelectorFactory(factory.Factory):
+    class Meta:
+        model = augur.filtering.vcf_selector.VCFSelector
+
+    selected_samples = set(SequenceFactory.build_batch(3))
+    samplefile = SamplefileFactory.create(filename="input.vcf")
+    output_fname = "output.vcf"

--- a/tests/filtering/matchers/test_date.py
+++ b/tests/filtering/matchers/test_date.py
@@ -1,0 +1,86 @@
+import argparse
+import datetime
+
+from augur.filtering.matchers.date import Date
+
+import pytest
+
+
+@pytest.fixture
+def all_sequences(sequence_factory):
+    return {
+        sequence_factory.build(metadata={"date": "1991-3-1"}),
+        sequence_factory.build(metadata={"date": "2000-3-10"}),
+        sequence_factory.build(metadata={"date": "2000-3-XX"}),
+        sequence_factory.build(metadata={"date": "2009-3-1"}),
+        sequence_factory.build(metadata={}),
+    }
+
+
+class TestDateMatcher:
+    @pytest.mark.parametrize(
+        "arg_string, expected_min, expected_max",
+        [
+            ("date:min=2000-01-01", datetime.date(year=2000, month=1, day=1), None),
+            ("date:max=2000-02-02", None, datetime.date(year=2000, month=2, day=2)),
+            (
+                "date:min=2000-03-03,max=2000-04-04",
+                datetime.date(year=2000, month=3, day=3),
+                datetime.date(year=2000, month=4, day=4),
+            ),
+            (
+                "date:min=2003,max=2004",
+                datetime.date(year=2003, month=1, day=1),
+                datetime.date(year=2004, month=1, day=1),
+            ),
+        ],
+    )
+    def test_build(self, mocker, arg_string, expected_min, expected_max):
+        matcher = Date.build(arg_string)
+
+        assert isinstance(matcher, Date)
+        assert matcher.min_date == expected_min
+        assert matcher.max_date == expected_max
+
+    def test_is_affected_min_only(self, all_sequences):
+        matcher = Date(min_date=datetime.date(year=2000, month=3, day=22))
+        assert {seq.date: matcher.is_affected(seq) for seq in all_sequences} == {
+            "1991-3-1": True,
+            "2000-3-10": True,
+            "2000-3-XX": False,
+            "2009-3-1": False,
+            None: False,
+        }
+
+    def test_is_affected_max_only(self, all_sequences):
+        matcher = Date(max_date=datetime.date(year=2000, month=3, day=5))
+        assert {seq.date: matcher.is_affected(seq) for seq in all_sequences} == {
+            "1991-3-1": False,
+            "2000-3-10": True,
+            "2000-3-XX": False,
+            "2009-3-1": True,
+            None: False,
+        }
+
+    def test_is_affected_min_and_max(self, all_sequences):
+        matcher = Date(
+            min_date=datetime.date(year=2000, month=3, day=20),
+            max_date=datetime.date(year=2000, month=3, day=22),
+        )
+        assert {seq.date: matcher.is_affected(seq) for seq in all_sequences} == {
+            "1991-3-1": True,
+            "2000-3-10": True,
+            "2000-3-XX": False,
+            "2009-3-1": True,
+            None: False,
+        }
+
+    def test_is_affected_both_none(self, all_sequences):
+        matcher = Date(min_date=None, max_date=None)
+        assert {seq.date: matcher.is_affected(seq) for seq in all_sequences} == {
+            "1991-3-1": False,
+            "2000-3-10": False,
+            "2000-3-XX": False,
+            "2009-3-1": False,
+            None: False,
+        }

--- a/tests/filtering/matchers/test_date.py
+++ b/tests/filtering/matchers/test_date.py
@@ -19,31 +19,34 @@ def all_sequences(sequence_factory):
 
 class TestDateMatcher:
     @pytest.mark.parametrize(
-        "arg_string, expected_min, expected_max",
+        "min_arg, max_arg, expected_min, expected_max",
         [
-            ("date:min=2000-01-01", datetime.date(year=2000, month=1, day=1), None),
-            ("date:max=2000-02-02", None, datetime.date(year=2000, month=2, day=2)),
+            ("2000-01-01", None, datetime.date(year=2000, month=1, day=1), None),
+            (None, "2000-02-02", None, datetime.date(year=2000, month=2, day=2)),
             (
-                "date:min=2000-03-03,max=2000-04-04",
+                "2000-03-03",
+                "2000-04-04",
                 datetime.date(year=2000, month=3, day=3),
                 datetime.date(year=2000, month=4, day=4),
             ),
             (
-                "date:min=2003,max=2004",
+                "2003",
+                "2004",
                 datetime.date(year=2003, month=1, day=1),
                 datetime.date(year=2004, month=1, day=1),
             ),
         ],
     )
-    def test_build(self, mocker, arg_string, expected_min, expected_max):
-        matcher = Date.build(arg_string)
+    def test_init(self, mocker, min_arg, max_arg, expected_min, expected_max):
+        matcher = Date(min_date=min_arg, max_date=max_arg)
 
         assert isinstance(matcher, Date)
         assert matcher.min_date == expected_min
         assert matcher.max_date == expected_max
 
     def test_is_affected_min_only(self, all_sequences):
-        matcher = Date(min_date=datetime.date(year=2000, month=3, day=22))
+        matcher = Date(min_date="2000-03-22")
+
         assert {seq.date: matcher.is_affected(seq) for seq in all_sequences} == {
             "1991-3-1": True,
             "2000-3-10": True,
@@ -53,7 +56,8 @@ class TestDateMatcher:
         }
 
     def test_is_affected_max_only(self, all_sequences):
-        matcher = Date(max_date=datetime.date(year=2000, month=3, day=5))
+        matcher = Date(max_date="2000-03-05")
+
         assert {seq.date: matcher.is_affected(seq) for seq in all_sequences} == {
             "1991-3-1": False,
             "2000-3-10": True,
@@ -63,10 +67,8 @@ class TestDateMatcher:
         }
 
     def test_is_affected_min_and_max(self, all_sequences):
-        matcher = Date(
-            min_date=datetime.date(year=2000, month=3, day=20),
-            max_date=datetime.date(year=2000, month=3, day=22),
-        )
+        matcher = Date(min_date="2000-03-20", max_date="2000-03-22")
+
         assert {seq.date: matcher.is_affected(seq) for seq in all_sequences} == {
             "1991-3-1": True,
             "2000-3-10": True,
@@ -77,6 +79,7 @@ class TestDateMatcher:
 
     def test_is_affected_both_none(self, all_sequences):
         matcher = Date(min_date=None, max_date=None)
+
         assert {seq.date: matcher.is_affected(seq) for seq in all_sequences} == {
             "1991-3-1": False,
             "2000-3-10": False,

--- a/tests/filtering/matchers/test_length.py
+++ b/tests/filtering/matchers/test_length.py
@@ -1,0 +1,35 @@
+import argparse
+
+from augur.filtering.matchers.length import Length
+
+import pytest
+
+
+@pytest.fixture
+def all_sequences(sequence_factory):
+    return {
+        sequence_factory.build(name="ten", sequence="aaaataaaat"),
+        sequence_factory.build(name="five", sequence="aaaat"),
+        sequence_factory.build(name="zero", sequence=""),
+    }
+
+
+class TestLengthMatcher:
+    def test_build(self, mocker):
+        matcher = Length.build("min=5")
+
+        assert isinstance(matcher, Length)
+        assert matcher.min_length == 5
+
+    def test_is_affected(self, all_sequences):
+        matcher = Length(min_length=5)
+        assert {seq.name: matcher.is_affected(seq) for seq in all_sequences} == {
+            "ten": False,
+            "five": False,
+            "zero": True,
+        }
+
+    def test_is_affected_none_min_length(self, all_sequences):
+        with pytest.raises(TypeError):
+            matcher = Length(min_length=None)
+            matcher.is_affected(all_sequences[0])

--- a/tests/filtering/matchers/test_length.py
+++ b/tests/filtering/matchers/test_length.py
@@ -15,12 +15,6 @@ def all_sequences(sequence_factory):
 
 
 class TestLengthMatcher:
-    def test_build(self, mocker):
-        matcher = Length.build("min=5")
-
-        assert isinstance(matcher, Length)
-        assert matcher.min_length == 5
-
     def test_is_affected(self, all_sequences):
         matcher = Length(min_length=5)
         assert {seq.name: matcher.is_affected(seq) for seq in all_sequences} == {

--- a/tests/filtering/matchers/test_metadata.py
+++ b/tests/filtering/matchers/test_metadata.py
@@ -1,0 +1,65 @@
+import argparse
+
+from augur.filtering.matchers.metadata import Metadata
+
+import pytest
+
+
+@pytest.fixture
+def all_sequences(sequence_factory):
+    return {
+        sequence_factory.build(metadata={"color": "red"}),
+        sequence_factory.build(metadata={"color": "blue"}),
+        sequence_factory.build(metadata={"color": "green"}),
+    }
+
+
+class TestMetadataMatcher:
+    @pytest.mark.parametrize(
+        "matcher_args, expected_conditions",
+        [
+            ("color=red", [("color", "=", "red")]),
+            ("color!=red", [("color", "!=", "red")]),
+            ("color=red,size=med", [("color", "=", "red"), ("size", "=", "med")]),
+        ],
+    )
+    def test_build(self, matcher_args, expected_conditions):
+        matcher = Metadata.build(matcher_args)
+
+        assert isinstance(matcher, Metadata)
+        assert matcher.conditions == expected_conditions
+
+    @pytest.mark.parametrize(
+        "matcher_args, expected_exception",
+        [
+            ("color=", AttributeError),
+            ("color==red", AttributeError),
+            ("color", AttributeError),
+        ],
+    )
+    def test_build_bad_arg_string(self, mocker, matcher_args, expected_exception):
+        with pytest.raises(expected_exception):
+            Metadata.build(matcher_args)
+
+    @pytest.mark.parametrize(
+        "matcher_args, expected_matches",
+        [
+            ("color=red", {"red"}),
+            ("color!=red", {"blue", "green"}),
+            ("color!=red,color!=blue", {"red", "blue", "green"}),  # yes, an OR of the != conditions covers the entire set
+            ("color=red,color=blue", {"red", "blue"}),
+            ("power=high", {"red", "blue", "green"}),
+        ],
+    )
+    def test_is_affected(self, all_sequences, matcher_args, expected_matches):
+        matcher = Metadata.build(matcher_args)
+        assert (
+            set(
+                [
+                    seq.metadata["color"]
+                    for seq in all_sequences
+                    if matcher.is_affected(seq)
+                ]
+            )
+            == expected_matches
+        )

--- a/tests/filtering/matchers/test_metadata.py
+++ b/tests/filtering/matchers/test_metadata.py
@@ -16,33 +16,33 @@ def all_sequences(sequence_factory):
 
 class TestMetadataMatcher:
     @pytest.mark.parametrize(
-        "matcher_args, expected_conditions",
+        "clause, expected_conditions",
         [
             ("color=red", [("color", "=", "red")]),
             ("color!=red", [("color", "!=", "red")]),
             ("color=red,size=med", [("color", "=", "red"), ("size", "=", "med")]),
         ],
     )
-    def test_build(self, matcher_args, expected_conditions):
-        matcher = Metadata.build(matcher_args)
+    def test_init(self, clause, expected_conditions):
+        matcher = Metadata(clause=clause)
 
         assert isinstance(matcher, Metadata)
         assert matcher.conditions == expected_conditions
 
     @pytest.mark.parametrize(
-        "matcher_args, expected_exception",
+        "clause, expected_exception",
         [
             ("color=", AttributeError),
             ("color==red", AttributeError),
             ("color", AttributeError),
         ],
     )
-    def test_build_bad_arg_string(self, mocker, matcher_args, expected_exception):
+    def test_init_malformed_clause(self, mocker, clause, expected_exception):
         with pytest.raises(expected_exception):
-            Metadata.build(matcher_args)
+            Metadata(clause=clause)
 
     @pytest.mark.parametrize(
-        "matcher_args, expected_matches",
+        "clause, expected_matches",
         [
             ("color=red", {"red"}),
             ("color!=red", {"blue", "green"}),
@@ -51,8 +51,8 @@ class TestMetadataMatcher:
             ("power=high", {"red", "blue", "green"}),
         ],
     )
-    def test_is_affected(self, all_sequences, matcher_args, expected_matches):
-        matcher = Metadata.build(matcher_args)
+    def test_is_affected(self, all_sequences, clause, expected_matches):
+        matcher = Metadata(clause=clause)
         assert (
             set(
                 [

--- a/tests/filtering/matchers/test_name.py
+++ b/tests/filtering/matchers/test_name.py
@@ -1,0 +1,89 @@
+import argparse
+
+from augur.filtering.matchers.name import Name
+
+import pytest
+
+
+@pytest.fixture
+def all_sequences(sequence_factory):
+    return {
+        sequence_factory.build(name="a"),
+        sequence_factory.build(name="b"),
+        sequence_factory.build(name="c"),
+        sequence_factory.build(name="d"),
+        sequence_factory.build(name="e"),
+    }
+
+
+class TestNameMatcher:
+    def test_build(self, mocker):
+        mock_read_names = mocker.patch(
+            "augur.filtering.matchers.name.read_names",
+            mocker.MagicMock(return_value=["a", "b"]),
+        )
+
+        matcher_obj = Name.build("file=include.txt")
+
+        mock_read_names.assert_called_once_with("include.txt")
+        assert matcher_obj.names == {"a", "b"}
+
+    def test_read_names(self, mocker):
+        mocker.patch("builtins.open", mocker.mock_open(read_data="a\nb #comment\n\nc"))
+
+        assert Name.build("file=_").names == {"a", "b", "c"}
+
+    def test_read_names_unsupported_scheme(self, mocker):
+        mocker.patch("builtins.open", mocker.mock_open(read_data="a\nb #comment\n\nc"))
+
+        with pytest.raises(Exception):
+            assert Name.build("list=a,b.c")
+
+    def test_read_names_empty_file(self, mocker):
+        mocker.patch("builtins.open", mocker.mock_open(read_data=""))
+
+        assert Name.build("file=_").names == set()
+
+    def test_read_names_no_such_file(self, mocker):
+        with pytest.raises(FileNotFoundError):
+            assert Name.build("file=does_not_exist.txt").names == set()
+
+    def test_is_affected_names_in_sequences(self, all_sequences):
+        matcher_obj = Name(names=["b", "c"])
+        assert {seq.name: matcher_obj.is_affected(seq) for seq in all_sequences} == {
+            "a": False,
+            "b": True,
+            "c": True,
+            "d": False,
+            "e": False,
+        }
+
+    def test_is_affected_names_not_in_sequences(self, all_sequences):
+        matcher_obj = Name(names=["g"])
+        assert {seq.name: matcher_obj.is_affected(seq) for seq in all_sequences} == {
+            "a": False,
+            "b": False,
+            "c": False,
+            "d": False,
+            "e": False,
+        }
+
+    def test_is_affected_empty_names(self, all_sequences):
+        matcher_obj = Name(names=[])
+        assert {seq.name: matcher_obj.is_affected(seq) for seq in all_sequences} == {
+            "a": False,
+            "b": False,
+            "c": False,
+            "d": False,
+            "e": False,
+        }
+
+    def test_is_affected_none_names(self, all_sequences):
+        matcher_obj = Name(names=[])
+        assert {seq.name: matcher_obj.is_affected(seq) for seq in all_sequences} == {
+            "a": False,
+            "b": False,
+            "c": False,
+            "d": False,
+            "e": False,
+        }

--- a/tests/filtering/matchers/test_name.py
+++ b/tests/filtering/matchers/test_name.py
@@ -17,39 +17,32 @@ def all_sequences(sequence_factory):
 
 
 class TestNameMatcher:
-    def test_build(self, mocker):
-        mock_read_names = mocker.patch(
-            "augur.filtering.matchers.name.read_names",
-            mocker.MagicMock(return_value=["a", "b"]),
-        )
+    def test_init(self, mocker):
+        mocker.patch("builtins.open", mocker.mock_open(read_data="a\nb"))
 
-        matcher_obj = Name.build("file=include.txt")
+        matcher_obj = Name(filename="_")
 
-        mock_read_names.assert_called_once_with("include.txt")
         assert matcher_obj.names == {"a", "b"}
 
     def test_read_names(self, mocker):
         mocker.patch("builtins.open", mocker.mock_open(read_data="a\nb #comment\n\nc"))
 
-        assert Name.build("file=_").names == {"a", "b", "c"}
+        assert Name(filename="_").names == {"a", "b", "c"}
 
-    def test_read_names_unsupported_scheme(self, mocker):
-        mocker.patch("builtins.open", mocker.mock_open(read_data="a\nb #comment\n\nc"))
-
-        with pytest.raises(Exception):
-            assert Name.build("list=a,b.c")
-
-    def test_read_names_empty_file(self, mocker):
+    def test_read_names_none_file(self, mocker):
         mocker.patch("builtins.open", mocker.mock_open(read_data=""))
 
-        assert Name.build("file=_").names == set()
+        assert Name(filename=None).names == set()
 
     def test_read_names_no_such_file(self, mocker):
         with pytest.raises(FileNotFoundError):
-            assert Name.build("file=does_not_exist.txt").names == set()
+            assert Name(filename="does_not_exist.txt").names == set()
 
-    def test_is_affected_names_in_sequences(self, all_sequences):
-        matcher_obj = Name(names=["b", "c"])
+    def test_is_affected_names_in_sequences(self, mocker, all_sequences):
+        mocker.patch("augur.filtering.matchers.name.read_names", lambda _: ["b", "c"])
+
+        matcher_obj = Name(filename="_")
+
         assert {seq.name: matcher_obj.is_affected(seq) for seq in all_sequences} == {
             "a": False,
             "b": True,
@@ -58,8 +51,11 @@ class TestNameMatcher:
             "e": False,
         }
 
-    def test_is_affected_names_not_in_sequences(self, all_sequences):
-        matcher_obj = Name(names=["g"])
+    def test_is_affected_names_not_in_sequences(self, mocker, all_sequences):
+        mocker.patch("augur.filtering.matchers.name.read_names", lambda _: ["g"])
+
+        matcher_obj = Name(filename="_")
+
         assert {seq.name: matcher_obj.is_affected(seq) for seq in all_sequences} == {
             "a": False,
             "b": False,
@@ -68,18 +64,11 @@ class TestNameMatcher:
             "e": False,
         }
 
-    def test_is_affected_empty_names(self, all_sequences):
-        matcher_obj = Name(names=[])
-        assert {seq.name: matcher_obj.is_affected(seq) for seq in all_sequences} == {
-            "a": False,
-            "b": False,
-            "c": False,
-            "d": False,
-            "e": False,
-        }
+    def test_is_affected_empty_names(self, mocker, all_sequences):
+        mocker.patch("augur.filtering.matchers.name.read_names", lambda _: [])
 
-    def test_is_affected_none_names(self, all_sequences):
-        matcher_obj = Name(names=[])
+        matcher_obj = Name(filename="_")
+
         assert {seq.name: matcher_obj.is_affected(seq) for seq in all_sequences} == {
             "a": False,
             "b": False,

--- a/tests/filtering/matchers/test_nonnucleotide.py
+++ b/tests/filtering/matchers/test_nonnucleotide.py
@@ -1,0 +1,27 @@
+import argparse
+
+from augur.filtering.matchers.nonnucleotide import Nonnucleotide
+
+import pytest
+
+
+@pytest.fixture
+def all_sequences(sequence_factory):
+    return {
+        sequence_factory.build(name="good symbols", sequence="ACGT-NRYSWKMDHBV?"),
+        sequence_factory.build(name="bad symbols", sequence="L"),
+        sequence_factory.build(name="empty seq", sequence=""),
+    }
+
+
+class TestNonnucleotideMatcher:
+    def test_build(self):
+        assert isinstance(Nonnucleotide.build(None), Nonnucleotide)
+
+    def test_affected_sequences(self, all_sequences):
+        matcher = Nonnucleotide()
+        assert {seq.name: matcher.is_affected(seq) for seq in all_sequences} == {
+            "good symbols": True,
+            "bad symbols": False,
+            "empty seq": True,
+        }

--- a/tests/filtering/matchers/test_nonnucleotide.py
+++ b/tests/filtering/matchers/test_nonnucleotide.py
@@ -15,9 +15,6 @@ def all_sequences(sequence_factory):
 
 
 class TestNonnucleotideMatcher:
-    def test_build(self):
-        assert isinstance(Nonnucleotide.build(None), Nonnucleotide)
-
     def test_affected_sequences(self, all_sequences):
         matcher = Nonnucleotide()
         assert {seq.name: matcher.is_affected(seq) for seq in all_sequences} == {

--- a/tests/filtering/test_vcf_selector.py
+++ b/tests/filtering/test_vcf_selector.py
@@ -1,0 +1,69 @@
+from augur.filtering.vcf_selector import VCFSelector
+
+import pytest
+
+
+class TestVCFSelector:
+    def test_vcf_command(
+        self, vcf_selector_factory, samplefile_factory, sequence_factory
+    ):
+        vcf_selector = vcf_selector_factory.build(
+            selected_samples=[sequence_factory.build(name=name) for name in ["a", "b"]],
+            samplefile=samplefile_factory.build(filename="input.vcf.gz"),
+            output_fname="output.vcf",
+        )
+
+        assert vcf_selector.vcftools_command == [
+            "vcftools",
+            "--indv",
+            "a",
+            "--indv",
+            "b",
+            "--gzvcf",
+            "input.vcf.gz",
+            "--recode",
+            "--stdout",
+            "",
+            ">",
+            "output.vcf",
+        ]
+
+    def test_vcf_args_select_samples(self, vcf_selector_factory, sequence_factory):
+        vcf_selector = vcf_selector_factory.build(
+            selected_samples=[sequence_factory.build(name=name) for name in ["a", "b"]]
+        )
+
+        assert vcf_selector.vcftools_args_select_samples == [
+            "--indv",
+            "a",
+            "--indv",
+            "b",
+        ]
+
+    @pytest.mark.parametrize(
+        "test_fname, expected_option",
+        [("input.vcf", "--vcf"), ("input.vcf.gz", "--gzvcf")],
+    )
+    def test_vcf_args_input_file(
+        self, vcf_selector_factory, samplefile_factory, test_fname, expected_option
+    ):
+        vcf_selector = vcf_selector_factory.build(
+            samplefile=samplefile_factory.build(filename=test_fname)
+        )
+
+        assert vcf_selector.vcftools_args_input_file == [expected_option, test_fname]
+
+    @pytest.mark.parametrize(
+        "test_fname, expected_pipe",
+        [("output.vcf", ""), ("output.vcf.gz", "| gzip -c")],
+    )
+    def test_vcf_args_output_redirect(
+        self, vcf_selector_factory, test_fname, expected_pipe
+    ):
+        vcf_selector = vcf_selector_factory.build(output_fname=test_fname)
+
+        assert vcf_selector.vcftools_args_output_redirect == [
+            expected_pipe,
+            ">",
+            test_fname,
+        ]

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,105 +1,143 @@
-import augur.filter
+from augur.filter import Filterer
+from augur.filtering.matchers import MATCHER_CLASSES
+from augur.sequence import Sequence
 
+import argparse
 import pytest
 
 
 @pytest.fixture
-def mock_priorities_file_valid(mocker):
-    mocker.patch(
-        "builtins.open", mocker.mock_open(read_data="strain1 5\nstrain2 6\nstrain3 8\n")
+def mock_args(mocker):
+    # TODO needed?
+    def _mock_args(args_dict):
+        return argparse.Namespace(**args_dict)
+
+    return _mock_args
+
+
+def build_args(**args):
+    return argparse.Namespace(
+        **{
+            "sequences": "tests/builds/tb/data/lee_2015.vcf",
+            "metadata": "tests/builds/tb/data/meta.tsv",
+            "min_date": None,
+            "max_date": None,
+            "min_length": None,
+            "non_nucleotide": None,
+            "exclude": None,
+            "exclude_where": None,
+            "include": None,
+            "include_where": None,
+            **args
+        }
     )
 
 
 @pytest.fixture
-def mock_priorities_file_malformed(mocker):
-    mocker.patch("builtins.open", mocker.mock_open(read_data="strain1 X\n"))
+def mock_translate_args(mocker):
+    mocker.patch("augur.filter.Filterer.translate_args", lambda _: {
+        "exclude": ["metadata:key!=val", "name:file=tests/builds/tb/data/dropped_strains.txt"],
+        "include": ["length:min=5"],
+    })
 
 
-@pytest.fixture
-def mock_run_shell_command(mocker):
-    mocker.patch("augur.filter.run_shell_command")
+class TestFilterer:
+    def test_run(self):
+        # TODO end-to-end
+        pass
 
+    @pytest.mark.parametrize(
+        "args, expected_exclude, expected_include",
+        [
+            (
+                build_args(min_length=5, min_date=2000),
+                ["date:min=2000", "length:min=5"],
+                [],
+            ),
+            (
+                build_args(non_nucleotide=True, include="include_file.txt"),
+                ["non-nucleotide"],
+                ["name:file=include_file.txt"],
+            ),
+            (
+                build_args(exclude="exclude_file.txt", include_where="key=val"),
+                ["name:file=exclude_file.txt"],
+                ["metadata:key=val"],
+            ),
+            (
+                build_args(exclude_where="key!=val"),
+                ["metadata:key!=val"],
+                [],
+            ),
+        ]
+    )
+    def test_translate_args(self, args, expected_exclude, expected_include):
+        assert Filterer(args).translate_args() == {
+            "exclude": expected_exclude,
+            "include": expected_include,
+        }
 
-class TestFilter:
-    def test_read_vcf_compressed(self):
-        seq_keep, all_seq = augur.filter.read_vcf(
-            "tests/builds/tb/data/lee_2015.vcf.gz"
+    def test_enabled_matchers_exclude(self, mock_translate_args):
+        enabled_matchers = Filterer(build_args()).enabled_matchers("exclude")
+
+        assert len(enabled_matchers) == 2
+        assert enabled_matchers[0].__class__ == MATCHER_CLASSES["metadata"]
+        assert enabled_matchers[0].conditions == [("key", "!=", "val")]
+        assert enabled_matchers[1].__class__ == MATCHER_CLASSES["name"]
+        assert enabled_matchers[1].names == {"G22696"}
+
+    def test_enabled_matchers_include(self, mock_translate_args):
+        enabled_matchers = Filterer(build_args()).enabled_matchers("include")
+
+        assert len(enabled_matchers) == 1
+        assert enabled_matchers[0].__class__ == MATCHER_CLASSES["length"]
+        assert enabled_matchers[0].min_length == 5
+
+    def test_filter_sequences(self):
+        pass
+
+    def test_no_exclusion_matches(self):
+        pass
+
+    def test_any_inclusion_matches(self):
+        pass
+
+    def test_subsample(self):
+        # TODO
+        pass
+
+    def test_write_output_file_vcf(self, mocker, sequence_factory):
+        samples = sequence_factory.build_batch(3)
+
+        filterer = Filterer(build_args(output="output.vcf"))
+        filterer.resulting_sequences = samples
+        filterer.sequence_file = mocker.Mock()
+        vcf_selector_class = mocker.patch("augur.filter.VCFSelector")
+
+        filterer.write_output_file()
+
+        vcf_selector_class.assert_called_once_with(
+            selected_samples=samples,
+            samplefile=filterer.sequence_file,
+            output_fname="output.vcf",
         )
 
-        assert len(seq_keep) == 150
-        assert seq_keep[149] == "G22733"
-        assert seq_keep == all_seq
+    def test_write_output_file_fasta(self, mocker, sequence_factory):
+        samples = sequence_factory.build_batch(3)
+        filterer = Filterer(build_args(sequences="tests/builds/tb/data/ref.fasta", output="output.fasta"))
+        filterer.resulting_sequences = samples
+        bio_seqio = mocker.patch("augur.filter.SeqIO")
 
-    def test_read_vcf_uncompressed(self):
-        seq_keep, all_seq = augur.filter.read_vcf("tests/builds/tb/data/lee_2015.vcf")
+        filterer.write_output_file()
 
-        assert len(seq_keep) == 150
-        assert seq_keep[149] == "G22733"
-        assert seq_keep == all_seq
-
-    def test_read_priority_scores_valid(self, mock_priorities_file_valid):
-        # builtins.open is stubbed, but we need a valid file to satisfy the existence check
-        priorities = augur.filter.read_priority_scores(
-            "tests/builds/tb/data/lee_2015.vcf"
+        bio_seqio.write.assert_called_once_with(
+            [sample.bio_seq for sample in samples],
+            "output.fasta",
+            "fasta",
         )
 
-        assert priorities == {"strain1": 5, "strain2": 6, "strain3": 8}
+    def test_print_summary(self):
+        pass
 
-    def test_read_priority_scores_malformed(self, mock_priorities_file_malformed):
-        with pytest.raises(ValueError):
-            # builtins.open is stubbed, but we need a valid file to satisfy the existence check
-            augur.filter.read_priority_scores("tests/builds/tb/data/lee_2015.vcf")
-
-    def test_read_priority_scores_does_not_exist(self):
-        with pytest.raises(FileNotFoundError):
-            augur.filter.read_priority_scores("/does/not/exist.txt")
-
-    def test_write_vcf_compressed_input(self, mock_run_shell_command):
-        augur.filter.write_vcf(
-            "tests/builds/tb/data/lee_2015.vcf.gz", "output_file.vcf.gz", []
-        )
-
-        augur.filter.run_shell_command.assert_called_once_with(
-            "vcftools --gzvcf tests/builds/tb/data/lee_2015.vcf.gz --recode --stdout | gzip -c > output_file.vcf.gz",
-            raise_errors=True,
-        )
-
-    def test_write_vcf_uncompressed_input(self, mock_run_shell_command):
-        augur.filter.write_vcf(
-            "tests/builds/tb/data/lee_2015.vcf", "output_file.vcf.gz", []
-        )
-
-        augur.filter.run_shell_command.assert_called_once_with(
-            "vcftools --vcf tests/builds/tb/data/lee_2015.vcf --recode --stdout | gzip -c > output_file.vcf.gz",
-            raise_errors=True,
-        )
-
-    def test_write_vcf_compressed_output(self, mock_run_shell_command):
-        augur.filter.write_vcf(
-            "tests/builds/tb/data/lee_2015.vcf", "output_file.vcf.gz", []
-        )
-
-        augur.filter.run_shell_command.assert_called_once_with(
-            "vcftools --vcf tests/builds/tb/data/lee_2015.vcf --recode --stdout | gzip -c > output_file.vcf.gz",
-            raise_errors=True,
-        )
-
-    def test_write_vcf_uncompressed_output(self, mock_run_shell_command):
-        augur.filter.write_vcf(
-            "tests/builds/tb/data/lee_2015.vcf", "output_file.vcf", []
-        )
-
-        augur.filter.run_shell_command.assert_called_once_with(
-            "vcftools --vcf tests/builds/tb/data/lee_2015.vcf --recode --stdout  > output_file.vcf",
-            raise_errors=True,
-        )
-
-    def test_write_vcf_dropped_samples(self, mock_run_shell_command):
-        augur.filter.write_vcf(
-            "tests/builds/tb/data/lee_2015.vcf", "output_file.vcf", ["x", "y", "z"]
-        )
-
-        augur.filter.run_shell_command.assert_called_once_with(
-            "vcftools --remove-indv x --remove-indv y --remove-indv z --vcf tests/builds/tb/data/lee_2015.vcf --recode --stdout  > output_file.vcf",
-            raise_errors=True,
-        )
+    def check_vcftools(self):
+        pass

--- a/tests/test_sequence_file.py
+++ b/tests/test_sequence_file.py
@@ -1,0 +1,50 @@
+from augur.sequence_file import SequenceFile
+
+import pytest
+
+
+@pytest.fixture
+def mock_metadata(mocker):
+    def _mock_metadata(names):
+        mocker.patch(
+            "augur.sequence_file.read_metadata",
+            lambda x: ({name: {"name": name, "date": "5"} for name in names}, []),
+        )
+
+    return _mock_metadata
+
+
+class TestSequenceFile:
+    def test_sequences_vcf(self, mock_metadata):
+        mock_metadata(["G22565", "G22566", "G22567", "G22568", "G22569", "G22571"])
+
+        sequences = SequenceFile("tests/builds/tb/data/lee_2015.vcf", "").sequences
+
+        assert len(sequences) == 6
+        assert sequences[5].name == "G22571"
+        assert sequences[5].metadata["date"] == "5"
+
+    def test_sequences_vcf_gz(self, mock_metadata):
+        mock_metadata(["G22565", "G22566", "G22567", "G22568", "G22569", "G22571"])
+
+        sequences = SequenceFile("tests/builds/tb/data/lee_2015.vcf.gz", "").sequences
+
+        assert len(sequences) == 6
+        assert sequences[5].name == "G22571"
+        assert sequences[5].metadata["date"] == "5"
+
+    def test_sequences_fasta(self, mock_metadata):
+        mock_metadata(["AAK51718.1"])
+
+        sequences = SequenceFile(
+            "tests/data/fitness_model/AAK51718.fasta", ""
+        ).sequences
+
+        assert len(sequences) == 1
+        assert str(sequences[0].sequence)[:5] == "MKTII"
+        assert sequences[0].metadata["date"] == "5"
+
+    def test_sequences_unsupported_format(self, mocker):
+        # TODO make classes for all of these exceptions
+        with pytest.raises(Exception):
+            SequenceFile("path/to/file.json", "").sequences

--- a/tests/test_subsample.py
+++ b/tests/test_subsample.py
@@ -1,0 +1,18 @@
+"""
+    def test_read_priority_scores_valid(self, mock_priorities_file_valid):
+        # builtins.open is stubbed, but we need a valid file to satisfy the existence check
+        priorities = augur.filter.read_priority_scores(
+            "tests/builds/tb/data/lee_2015.vcf"
+        )
+
+        assert priorities == {"strain1": 5, "strain2": 6, "strain3": 8}
+
+    def test_read_priority_scores_malformed(self, mock_priorities_file_malformed):
+        with pytest.raises(ValueError):
+            # builtins.open is stubbed, but we need a valid file to satisfy the existence check
+            augur.filter.read_priority_scores("tests/builds/tb/data/lee_2015.vcf")
+
+    def test_read_priority_scores_does_not_exist(self):
+        with pytest.raises(FileNotFoundError):
+            augur.filter.read_priority_scores("/does/not/exist.txt")
+"""


### PR DESCRIPTION
Previously, most of `filter.py` was in a single, monolithic function that would have been extremely difficult to test. This changeset is an attempt to rewrite the whole module in some kind of object-oriented pattern.

The rough idea:
1. `filter` parses arguments and reads any necessary files, then populates the variable `filter_chain`.
1. `filter_chain` is a list of objects that either add or subtract sequences from the original set.
1. Each filter object embodies its own logic for filtering operations (eg, exclude by name, exclude by date, include by metadata, etc).

Using eight separate classes for the separate filtering operations makes for some more maintainable and testable code. The intention is to have no behavior changes.

This PR currently is not runnable, but is hopefully finished enough for people to give feedback. Is this an acceptable direction to take `filter.py`?