### PR TITLE
Bump treetime

### DIFF
--- a/augur/traits.py
+++ b/augur/traits.py
@@ -64,12 +64,12 @@ def mugration_inference(tree=None, seq_meta=None, field='country', confidence=Tr
         for node in T.find_clades():
             node.__setattr__(field, unique_states[0])
         return T, None, {}
-    elif len(unique_states)<180:
+    elif len(unique_states)<300:
         tt, letter_to_state, reverse_alphabet = \
             reconstruct_discrete_traits(T, traits, missing_data=missing,
                  sampling_bias_correction=sampling_bias_correction, weights=weights)
     else:
-        print("ERROR: 180 or more distinct discrete states found. TreeTime is currently not set up to handle that many states.")
+        print("ERROR: 300 or more distinct discrete states found. TreeTime is currently not set up to handle that many states.")
         sys.exit(1)
 
     if tt is None:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "jsonschema >=3.0.0, ==3.*",
         "packaging >=19.2",
         "pandas >=0.20.0, ==0.*",
-        "phylo-treetime >=0.7.2, ==0.7.*",
+        "phylo-treetime >=0.7.4, ==0.7.*",
         "snakemake >=5.4.0, <5.11"
     ],
     extras_require = {


### PR DESCRIPTION
This is very small pull request to do two related things:

1. Upgrade TreeTime to v0.7.4. This has some bug fixes to `augur traits --weights` that would be nice to have.

2. Bump the maximum number of states allowed by `augur traits` from 180 to 300. Three hundred is arbitrary here, but I did test in the ~280 range with the Seattle flu trees last fall. We're now at 174 divisions in the live `ncov` build and I don't want trait inference to break. The 180 was originally in place because it was the cap in TreeTime. This was removed in the upgrade from TreeTime v0.7.3 to v0.7.4.
