### PR TITLE
Allow various UTF formats in the config file if on Python 3.6 or later.

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -360,8 +360,12 @@ def read_config(fname):
         print("ERROR: config file %s not found."%fname)
         return defaultdict(dict)
 
+    # From Python 3.6, json can load various UTF formats from a file opened in
+    # binary mode. See note at bottom of
+    # https://docs.python.org/3/library/json.html#json.load
+    mode = 'r' if sys.version_info < (3, 6) else 'rb'
     try:
-        with open(fname) as ifile:
+        with open(fname, mode) as ifile:
             config = json.load(ifile)
     except json.decoder.JSONDecodeError as err:
         print("FATAL ERROR:")

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -360,12 +360,8 @@ def read_config(fname):
         print("ERROR: config file %s not found."%fname)
         return defaultdict(dict)
 
-    # From Python 3.6, json can load various UTF formats from a file opened in
-    # binary mode. See note at bottom of
-    # https://docs.python.org/3/library/json.html#json.load
-    mode = 'r' if sys.version_info < (3, 6) else 'rb'
     try:
-        with open(fname, mode) as ifile:
+        with open(fname, 'rb') as ifile:
             config = json.load(ifile)
     except json.decoder.JSONDecodeError as err:
         print("FATAL ERROR:")

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -50,7 +50,11 @@ def load_json_schema(path):
     return jsonschema.Draft6Validator(schema)
 
 def load_json(path):
-    with open(path) as fh:
+    # From Python 3.6, json can load various UTF formats from a file opened in
+    # binary mode. See note at bottom of
+    # https://docs.python.org/3/library/json.html#json.load
+    mode = 'r' if sys.version_info < (3, 6) else 'rb'
+    with open(path, mode) as fh:
         try:
             jsonToValidate = json.load(fh)
         except json.JSONDecodeError:

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -50,11 +50,7 @@ def load_json_schema(path):
     return jsonschema.Draft6Validator(schema)
 
 def load_json(path):
-    # From Python 3.6, json can load various UTF formats from a file opened in
-    # binary mode. See note at bottom of
-    # https://docs.python.org/3/library/json.html#json.load
-    mode = 'r' if sys.version_info < (3, 6) else 'rb'
-    with open(path, mode) as fh:
+    with open(path, 'rb') as fh:
         try:
             jsonToValidate = json.load(fh)
         except json.JSONDecodeError:


### PR DESCRIPTION
The various UTF formats can be handled by the `json` module if the input file is opened in binary mode. See the note See note at the bottom of https://docs.python.org/3/library/json.html#json.load

The diff here passes `rb` as a mode if on Python >= 3.6

I don't see anywhere to add tests for this.  But... the change works for me and I see the non-ASCII chars correctly displayed by auspice.

Fixes #498.
