### PR TITLE
Add unit tests for version.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ Thumbs.db
 # IDE #
 #######
 *sublime*
+/.vscode/
 
 # slurm logs
 builds/flu/slurm_log/*

--- a/augur/version.py
+++ b/augur/version.py
@@ -4,9 +4,15 @@ Print the version of augur.
 
 from .__version__ import __version__
 
+
 def register_arguments(parser):
     pass
 
+
 def run(args):
-    print("augur", __version__)
+    print("augur", _get_version())
     return 0
+
+
+def _get_version():
+    return __version__

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from pathlib    import Path
+from pathlib import Path
 from setuptools import setup
 import sys
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -10,7 +10,10 @@ import pytest
 class TestAlign:
     def test_make_gaps_ambiguous(self):
         alignment = MultipleSeqAlignment(
-            [SeqRecord(Seq("G-AC")), SeqRecord(Seq("----")), SeqRecord(Seq("TAGC"))]
+            [
+                SeqRecord(Seq("G-AC")), SeqRecord(Seq("----")),
+                SeqRecord(Seq("TAGC"))
+            ]
         )
 
         align.make_gaps_ambiguous(alignment)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,30 @@
+from augur import version
+
+
+class MockVersion:
+
+    def get_version(self):
+        return self.version
+
+    def set_version(self, version):
+        self.version = version
+
+    def print_version(self):
+        print(self.version)
+
+
+class TestVersion:
+
+    def test_get_version(self):
+        MockVersion.set_version(self, '0.1.0')
+        self.mock_version = MockVersion.get_version(self)
+        assert self.mock_version.split('.')[0] == '0'
+        assert self.mock_version.split('.')[1] == '1'
+        assert self.mock_version.split('.')[2] == '0'
+
+    def test_get_version_is_not_none(self):
+        assert version._get_version() is not None
+
+    def test_run_with_no_args(self):
+        args = None
+        assert version.run(args) == 0


### PR DESCRIPTION
Add unit tests for version.py to test the version.

Also includes formatting fix for test_align.py, a formatting fix for
an import statement in setup.py, and ignoring the .vscode directory
for developers that use VSCode.

See also: #476

### Testing
Run pytest in the project root.

