### PR TITLE
Augur Mask: Add additional options from NCOV mask-alignment.py script

### DIFF
--- a/augur/mask.py
+++ b/augur/mask.py
@@ -132,6 +132,7 @@ def mask_fasta(mask_sites, in_file, out_file, mask_from_beginning=0, mask_from_e
 def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF or FASTA format")
     parser.add_argument('--mask', dest="mask_file", required=False, help="locations to be masked in BED file format")
+    parser.add_argument("--mask-sites", nargs='+', type = int,  help="list of sites to mask")
     parser.add_argument('--output', '-o', help="output file")
     parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",
                         help="Leave intermediate files around. May be useful for debugging")
@@ -164,6 +165,8 @@ def run(args):
             return 1
 
     mask_sites = []
+    if args.mask_sites:
+        mask_sites.extend(args.mask_sites)
     if args.mask_file:
         mask_sites.extend(read_bed_file(args.mask_file))
 

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -33,7 +33,7 @@ def read_bed_file(mask_file):
     bed = pd.read_csv(mask_file, sep='\t', header=None, usecols=[1,2])
     for idx, row in bed.iterrows():
         try:
-            sites_to_mask.extend(list(range(int(row[1]), int(row[2])+1)))
+            sites_to_mask.extend(range(int(row[1]), int(row[2])))
         except ValueError as err:
             # Skip unparseable lines, including header lines.
             print("Could not read line %d of BED file %s: %s. Continuing." % (idx, mask_file, err))

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -164,11 +164,12 @@ def run(args):
             print("ERROR: {} is an empty file.".format(args.mask_file))
             return 1
 
-    mask_sites = []
+    mask_sites = set()
     if args.mask_sites:
-        mask_sites.extend(args.mask_sites)
+        mask_sites.update(args.mask_sites)
     if args.mask_file:
-        mask_sites.extend(read_bed_file(args.mask_file))
+        mask_sites.update(read_bed_file(args.mask_file))
+    mask_sites = sorted(mask_sites)
 
     # For both FASTA and VCF masking, we need a proper separate output file
     if args.output is not None:

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -135,8 +135,8 @@ def mask_fasta(mask_sites, in_file, out_file, mask_from_beginning=0, mask_from_e
 def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF or FASTA format")
     parser.add_argument('--mask', dest="mask_file", required=False, help="locations to be masked in BED file format")
-    parser.add_argument('--mask-from-beginning', type=int, help="FASTA Only: Number of sites to mask from beginning")
-    parser.add_argument('--mask-from-end', type=int, help="FASTA Only: Number of sites to mask from end")
+    parser.add_argument('--mask-from-beginning', type=int, default=0, help="FASTA Only: Number of sites to mask from beginning")
+    parser.add_argument('--mask-from-end', type=int, default=0, help="FASTA Only: Number of sites to mask from end")
     parser.add_argument("--mask-sites", nargs='+', type = int,  help="1-indexed list of sites to mask")
     parser.add_argument('--output', '-o', help="output file")
     parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -159,7 +159,7 @@ def run(args):
     if args.mask_file:
         if not os.path.isfile(args.mask_file):
             print("ERROR: File {} does not exist!".format(args.mask_file))
-        return 1
+            return 1
         if os.path.getsize(args.mask_file) == 0:
             print("ERROR: {} is an empty file.".format(args.mask_file))
             return 1

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -131,7 +131,7 @@ def mask_fasta(mask_sites, in_file, out_file, mask_from_beginning=0, mask_from_e
 
 def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in VCF or FASTA format")
-    parser.add_argument('--mask', required=True, help="locations to be masked in BED file format")
+    parser.add_argument('--mask', dest="mask_file", required=False, help="locations to be masked in BED file format")
     parser.add_argument('--output', '-o', help="output file")
     parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",
                         help="Leave intermediate files around. May be useful for debugging")
@@ -151,18 +151,21 @@ def run(args):
     if not os.path.isfile(args.sequences):
         print("ERROR: File {} does not exist!".format(args.sequences))
         return 1
-    if not os.path.isfile(args.mask):
-        print("ERROR: File {} does not exist!".format(args.mask))
-        return 1
     if os.path.getsize(args.sequences) == 0:
         print("ERROR: {} is empty. Please check how this file was produced. "
               "Did an error occur in an earlier step?".format(args.sequences))
         return 1
-    if os.path.getsize(args.mask) == 0:
-        print("ERROR: {} is an empty file.".format(args.mask))
+    if args.mask_file:
+        if not os.path.isfile(args.mask_file):
+            print("ERROR: File {} does not exist!".format(args.mask_file))
         return 1
+        if os.path.getsize(args.mask_file) == 0:
+            print("ERROR: {} is an empty file.".format(args.mask_file))
+            return 1
 
-    mask_sites = read_bed_file(args.mask)
+    mask_sites = []
+    if args.mask_file:
+        mask_sites.extend(read_bed_file(args.mask_file))
 
     # For both FASTA and VCF masking, we need a proper separate output file
     if args.output is not None:

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -137,7 +137,7 @@ def register_arguments(parser):
     parser.add_argument('--mask', dest="mask_file", required=False, help="locations to be masked in BED file format")
     parser.add_argument('--mask-from-beginning', type=int, help="FASTA Only: Number of sites to mask from beginning")
     parser.add_argument('--mask-from-end', type=int, help="FASTA Only: Number of sites to mask from end")
-    parser.add_argument("--mask-sites", nargs='+', type = int,  help="list of sites to mask")
+    parser.add_argument("--mask-sites", nargs='+', type = int,  help="1-indexed list of sites to mask")
     parser.add_argument('--output', '-o', help="output file")
     parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",
                         help="Leave intermediate files around. May be useful for debugging")
@@ -174,7 +174,8 @@ def run(args):
 
     mask_sites = set()
     if args.mask_sites:
-        mask_sites.update(args.mask_sites)
+        # Mask sites passed in as 1-indexed
+        mask_sites.update(site - 1 for site in args.mask_sites)
     if args.mask_file:
         mask_sites.update(read_bed_file(args.mask_file))
     mask_sites = sorted(mask_sites)

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -116,12 +116,15 @@ def mask_fasta(mask_sites, in_file, out_file, mask_from_beginning=0, mask_from_e
     with open_file(out_file, "w") as oh:
         for record in alignment:
             # Convert to a mutable sequence to enable masking with Ns.
+            sequence_length = len(record.seq)
+            beginning, end = mask_from_beginning, mask_from_end
+            if beginning + end > sequence_length:
+                beginning, end = sequence_length, 0
             sequence = MutableSeq(
-                "N" * mask_from_beginning + 
-                str(record.seq)[mask_from_beginning:-mask_from_end or None] + 
-                "N" * mask_from_end
+                "N" * beginning +
+                str(record.seq)[beginning:-end or None] +
+                "N" * end
             )
-            sequence_length = len(sequence)
             # Replace all excluded sites with Ns.
             for site in mask_sites:
                 if site < sequence_length:

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -156,18 +156,18 @@ def run(args):
     # Check files exist and are not empty
     if not os.path.isfile(args.sequences):
         print("ERROR: File {} does not exist!".format(args.sequences))
-        return 1
+        sys.exit(1)
     if os.path.getsize(args.sequences) == 0:
         print("ERROR: {} is empty. Please check how this file was produced. "
               "Did an error occur in an earlier step?".format(args.sequences))
-        return 1
+        sys.exit(1)
     if args.mask_file:
         if not os.path.isfile(args.mask_file):
             print("ERROR: File {} does not exist!".format(args.mask_file))
-            return 1
+            sys.exit(1)
         if os.path.getsize(args.mask_file) == 0:
             print("ERROR: {} is an empty file.".format(args.mask_file))
-            return 1
+            sys.exit(1)
     if not any((args.mask_file, args.mask_from_beginning, args.mask_from_end, args.mask_sites)):
         print("No masking sites provided. Must include one of --mask, --mask-from-beginning, --mask-from-end, or --mask-sites")
         sys.exit(1)

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -67,7 +67,8 @@ def mask_vcf(mask_sites, in_file, out_file, cleanup=True):
               "Please check the file is valid VCF format.")
         sys.exit(1)
 
-    exclude = [chrom_name + "\t" + str(pos) for pos in mask_sites]
+    # mask_sites is zero-indexed, VCFTools expects 1-indexed.
+    exclude = [chrom_name + "\t" + str(pos + 1) for pos in mask_sites]
     temp_mask_file = in_file + "_maskTemp"
     with open_file(temp_mask_file, 'w') as fh:
         fh.write("\n".join(exclude))

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -218,6 +218,30 @@ class TestMask:
         for record in output:
             assert record.seq == "N" * len(record.seq)
 
+    def test_run_handle_missing_sequence_file(self, vcf_file, argparser):
+        os.remove(vcf_file)
+        args = argparser("-s %s" % vcf_file)
+        with pytest.raises(SystemExit):
+            mask.run(args)
+
+    def test_run_handle_empty_sequence_file(self, vcf_file, argparser):
+        open(vcf_file,"w").close()
+        args = argparser("-s %s --mask-sites 1" % vcf_file)
+        with pytest.raises(SystemExit):
+            mask.run(args)
+
+    def test_run_handle_missing_mask_file(self, vcf_file, bed_file, argparser):
+        os.remove(bed_file)
+        args = argparser("-s %s --mask %s" % (vcf_file, bed_file))
+        with pytest.raises(SystemExit):
+            mask.run(args)
+
+    def test_run_handle_empty_mask_file(self, vcf_file, bed_file, argparser):
+        open(bed_file, "w").close()
+        args = argparser("-s %s --mask %s" % (vcf_file, bed_file))
+        with pytest.raises(SystemExit):
+            mask.run(args)
+
     def test_run_recognize_vcf(self, bed_file, vcf_file, argparser, mp_context):
         """Ensure we're handling vcf files correctly"""
         args = argparser("--mask=%s -s %s --no-cleanup" % (bed_file, vcf_file))

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -119,7 +119,7 @@ class TestMask:
             mask.mask_vcf([], bad_vcf, "")
     
     def test_mask_vcf_creates_maskfile(self, vcf_file, mp_context):
-        """mask_vcf should create and use a mask file from the given list of sites"""
+        """mask_vcf should create a 1-indexed mask file from the 0-indexed list of sites"""
         mask_file = vcf_file + "_maskTemp"
         def shell_has_maskfile(call, **kwargs):
             assert mask_file in call
@@ -128,7 +128,7 @@ class TestMask:
         mask.mask_vcf([1,5], vcf_file, vcf_file, cleanup=False)
         assert os.path.isfile(mask_file), "Mask file was not written!"
         with open(mask_file) as fh:
-            assert fh.read() == "SEQ	1\nSEQ	5", "Incorrect mask file written!"
+            assert fh.read() == "SEQ	2\nSEQ	6", "Incorrect mask file written!"
     
     def test_mask_vcf_handles_gz(self, vcf_file, mp_context):
         """mask_vcf should recognize when the in or out files are .gz and call out accordingly"""
@@ -145,7 +145,7 @@ class TestMask:
 
     def test_mask_vcf_removes_matching_sites(self, vcf_file, out_file):
         """mask_vcf should remove the given sites from the VCF file"""
-        mask.mask_vcf([5,6], vcf_file, out_file)
+        mask.mask_vcf([4,5], vcf_file, out_file)
         with open(out_file) as after, open(vcf_file) as before:
             assert len(after.readlines()) == len(before.readlines()) - 1, "Too many lines removed!"
             assert "SEQ\t5" not in after.read(), "Correct sites not removed!"
@@ -372,6 +372,7 @@ class TestMask:
             assert output.readline().startswith("#CHROM\tPOS\t") # have a header
             for line in output.readlines():
                 site = int(line.split("\t")[1]) # POS column
+                site = site - 1 # shift to zero-indexed site
                 assert site not in TEST_BED_SEQUENCE
 
     def test_e2e_vcf_with_options(self, vcf_file, bed_file, out_file, argparser):
@@ -385,4 +386,5 @@ class TestMask:
             assert output.readline().startswith("#CHROM\tPOS\t") # have a header
             for line in output.readlines():
                 site = int(line.split("\t")[1]) # POS column
+                site = site - 1 #re-zero-index the VCF sites
                 assert site not in expected_removals

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -46,11 +46,11 @@ def vcf_file(tmpdir):
         fh.write(TEST_VCF)
     return vcf_file
 
-TEST_BED_SEQUENCE = [1,2,4,6,7,8,9,10]
+TEST_BED_SEQUENCE = [1,4,6,7,8,9]
 # IF YOU UPDATE ONE OF THESE, UPDATE THE OTHER.
 TEST_BED="""\
 SEQ1	1	2	IG18_Rv0018c-Rv0019c	
-SEQ1	4	4	IG18_Rv0018c-Rv0019c	
+SEQ1	4	5	IG18_Rv0018c-Rv0019c	
 SEQ1	6	8	IG18_Rv0018c-Rv0019c	
 SEQ1	7	10	IG18_Rv0018c-Rv0019c	
 """
@@ -101,7 +101,7 @@ class TestMask:
         """read_bed_file should ignore header rows if they exist"""
         with open(bed_file, "w") as fh:
             fh.write("CHROM\tSTART\tEND\n")
-            fh.write("SEQ\t5\t6")
+            fh.write("SEQ\t5\t7")
         assert mask.read_bed_file(bed_file) == [5,6]
 
     def test_read_bed_file(self, bed_file):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -211,6 +211,13 @@ class TestMask:
             assert seq.seq[-3:] == "NNN"
             assert seq.seq[2:-3] == original.seq[2:-3]
 
+    @pytest.mark.parametrize("beginning,end", ((1000,0), (0,1000),(1000,1000)))
+    def test_mask_fasta_from_beginning_and_end_too_long(self, fasta_file, out_file, beginning, end):
+        mask.mask_fasta([], fasta_file, out_file, mask_from_beginning=beginning, mask_from_end=end)
+        output = SeqIO.parse(out_file, "fasta")
+        for record in output:
+            assert record.seq == "N" * len(record.seq)
+
     def test_run_recognize_vcf(self, bed_file, vcf_file, argparser, mp_context):
         """Ensure we're handling vcf files correctly"""
         args = argparser("--mask=%s -s %s --no-cleanup" % (bed_file, vcf_file))

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -298,14 +298,16 @@ class TestMask:
     def test_run_with_mask_sites(self, vcf_file, out_file, argparser, mp_context):
         args = argparser("--mask-sites 2 8 -s %s -o %s" % (vcf_file, out_file))
         def check_mask_sites(mask_sites, *args, **kwargs):
-            assert mask_sites == [2,8]
+            # mask-sites are passed to the CLI as one-indexed
+            assert mask_sites == [1,7]
         mp_context.setattr(mask, "mask_vcf", check_mask_sites)
         mask.run(args)
 
     def test_run_with_mask_sites_and_mask_file(self, vcf_file, out_file, bed_file, argparser, mp_context):
         args = argparser("--mask-sites 20 21 --mask %s -s %s -o %s" % (bed_file, vcf_file, out_file))
         def check_mask_sites(mask_sites, *args, **kwargs):
-            assert mask_sites == sorted(set(TEST_BED_SEQUENCE + [20,21]))
+            # mask-sites are passed to the CLI as one-indexed
+            assert mask_sites == sorted(set(TEST_BED_SEQUENCE + [19,20]))
         mp_context.setattr(mask, "mask_vcf", check_mask_sites)
         mask.run(args)
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -277,3 +277,22 @@ class TestMask:
             assert mask_sites == sorted(set(TEST_BED_SEQUENCE + [20,21]))
         mp_context.setattr(mask, "mask_vcf", check_mask_sites)
         mask.run(args)
+
+    def test_run_requires_some_masking(self, vcf_file, argparser):
+        args = argparser("-s %s" % vcf_file)
+        with pytest.raises(SystemExit) as err:
+            mask.run(args)
+
+    @pytest.mark.parametrize("op", ("beginning", "end"))
+    def test_run_vcf_cannot_mask_beginning_or_end(self, vcf_file, argparser, op):
+        args = argparser("-s %s --mask-from-%s 2" % (vcf_file, op))
+        with pytest.raises(SystemExit) as err:
+            mask.run(args)
+
+    def test_run_fasta_mask_from_beginning_or_end(self, fasta_file, out_file, argparser, mp_context):
+        args = argparser("-s %s -o %s --mask-from-beginning 2 --mask-from-end 3" % (fasta_file, out_file))
+        def check_mask_from(*args, mask_from_beginning=0, mask_from_end=0):
+            assert mask_from_beginning == 2
+            assert mask_from_end == 3
+        mp_context.setattr(mask, "mask_fasta", check_mask_from)
+        mask.run(args)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -263,4 +263,17 @@ class TestMask:
         args = argparser("--mask=%s --sequences=%s --output=%s" %(bed_file, vcf_file, out_file))
         mask.run(args)
         assert os.path.exists(out_file), "Output file incorrectly deleted"
+    
+    def test_run_with_mask_sites(self, vcf_file, out_file, argparser, mp_context):
+        args = argparser("--mask-sites 2 8 -s %s -o %s" % (vcf_file, out_file))
+        def check_mask_sites(mask_sites, *args, **kwargs):
+            assert mask_sites == [2,8]
+        mp_context.setattr(mask, "mask_vcf", check_mask_sites)
+        mask.run(args)
+
+    def test_run_with_mask_sites_and_mask_file(self, vcf_file, out_file, bed_file, argparser, mp_context):
+        args = argparser("--mask-sites 20 21 --mask %s -s %s -o %s" % (bed_file, vcf_file, out_file))
+        def check_mask_sites(mask_sites, *args, **kwargs):
+            assert mask_sites == sorted(set(TEST_BED_SEQUENCE + [20,21]))
+        mp_context.setattr(mask, "mask_vcf", check_mask_sites)
         mask.run(args)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -183,6 +183,34 @@ class TestMask:
                 if idx != 5:
                     assert site == original[idx], "Incorrect sites modified!"
     
+    def test_mask_fasta_from_beginning(self, tmpdir, fasta_file, sequences):
+        out_file = str(tmpdir / "output.fasta")
+        mask.mask_fasta([], fasta_file, out_file, mask_from_beginning=3)
+        output = SeqIO.parse(out_file, "fasta")
+        for seq in output:
+            original = sequences[seq.id]
+            assert seq.seq[:3] == "NNN"
+            assert seq.seq[3:] == original.seq[3:]
+
+    def test_mask_fasta_from_end(self, tmpdir, fasta_file, sequences):
+        out_file = str(tmpdir / "output.fasta")
+        mask.mask_fasta([], fasta_file, out_file, mask_from_end=3)
+        output = SeqIO.parse(out_file, "fasta")
+        for seq in output:
+            original = sequences[seq.id]
+            assert seq.seq[-3:] == "NNN"
+            assert seq.seq[:-3] == original.seq[:-3]
+
+    def test_mask_fasta_from_beginning_and_end(self, tmpdir, fasta_file, sequences):
+        out_file = str(tmpdir / "output.fasta")
+        mask.mask_fasta([], fasta_file, out_file, mask_from_beginning=2, mask_from_end=3)
+        output = SeqIO.parse(out_file, "fasta")
+        for seq in output:
+            original = sequences[seq.id]
+            assert seq.seq[:2] == "NN"
+            assert seq.seq[-3:] == "NNN"
+            assert seq.seq[2:-3] == original.seq[2:-3]
+
     def test_run_recognize_vcf(self, bed_file, vcf_file, argparser, mp_context):
         """Ensure we're handling vcf files correctly"""
         args = argparser("--mask=%s -s %s --no-cleanup" % (bed_file, vcf_file))
@@ -206,7 +234,7 @@ class TestMask:
     def test_run_handle_missing_outfile(self, bed_file, fasta_file, argparser, mp_context):
         args = argparser("--mask=%s -s %s" % (bed_file, fasta_file))
         expected_outfile = os.path.join(os.path.dirname(fasta_file), "masked_" + os.path.basename(fasta_file))
-        def check_outfile(mask_sites, in_file, out_file):
+        def check_outfile(mask_sites, in_file, out_file, **kwargs):
             assert out_file == expected_outfile
             with open(out_file, "w") as fh:
                 fh.write("test_string")


### PR DESCRIPTION
### Description of proposed changes    
This PR adds the `--mask-sites`, `--mask-from-beginning`, and `--mask-from-end` args to `augur mask`.

`--mask-from-beginning` and `--mask-from-end` are gated to only apply to FASTA files.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Related to conversation in #459 and #148 

### Testing
Ran full test suite, updated tests to test for new cases.

Also expanded existing test coverage, now at 100% coverage 🕺

### Thank you for contributing to Nextstrain!
