### PR TITLE
Add unit tests for `utils.run_shell_command`

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -594,12 +594,11 @@ def run_shell_command(cmd, raise_errors = False, extra_env = None):
             env = env)
 
     except subprocess.CalledProcessError as error:
+        extra = "\nAre you sure this program is installed?" if error.returncode == 127 else ""
         print_error(
-            "{out}\nshell exited {rc} when running: {cmd}{extra}",
-            out = error.output,
-            rc  = error.returncode,
-            cmd = cmd,
-            extra = "\nAre you sure this program is installed?" if error.returncode==127 else "",
+            f"{error.output}\n"
+            f"shell exited {error.returncode} when running: "
+            f"{cmd}{extra}"
         )
         if raise_errors:
             raise
@@ -607,8 +606,9 @@ def run_shell_command(cmd, raise_errors = False, extra_env = None):
             return False
 
     except FileNotFoundError as error:
+        shell = " and ".join(shellexec)
         print_error(
-            """
+            f"""
             Unable to run shell commands using {shell}!
 
             Augur requires {shell} to be installed.  Please open an issue on GitHub

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,29 @@
 import datetime
 
 from augur.utils import ambiguous_date_to_date_range
+from augur.utils import run_shell_command
 
 from freezegun import freeze_time
+import pytest
+
+
+@pytest.fixture
+def mock_check_output(mocker):
+    return mocker.patch("subprocess.check_output")
+
+
+@pytest.fixture
+def mock_check_output_raise_called_process_error(mocker):
+    import subprocess
+
+    return mocker.patch(
+        "subprocess.check_output", side_effect=subprocess.CalledProcessError(5, 6)
+    )
+
+
+@pytest.fixture
+def mock_check_output_raise_file_not_found_error(mocker):
+    return mocker.patch("subprocess.check_output", side_effect=FileNotFoundError)
 
 
 class TestUtils:
@@ -36,3 +57,74 @@ class TestUtils:
             datetime.date(year=2000, month=2, day=1),
             datetime.date(year=2000, month=2, day=20),
         )
+
+    def test_run_shell_command(self, mocker, mock_check_output):
+        run_shell_command("great-command")
+
+        mock_check_output.assert_called_once_with(
+            ["/bin/bash", "-c", "set -euo pipefail; great-command"],
+            shell=mocker.ANY,
+            stderr=mocker.ANY,
+            env=mocker.ANY,
+        )
+
+    def test_run_shell_command_not_posix(self, mocker, mock_check_output):
+        mocker.patch("os.name", "certainly not posix, that's for sure")
+
+        run_shell_command("great-command")
+
+        mock_check_output.assert_called_once_with(
+            ["env", "bash", "-c", "set -euo pipefail; great-command"],
+            shell=mocker.ANY,
+            stderr=mocker.ANY,
+            env=mocker.ANY,
+        )
+
+    def test_run_shell_command_extra_env(self, mocker, mock_check_output):
+        run_shell_command("great-command", False, {"x": 6})
+
+        assert mock_check_output.call_args[1]["env"]["x"] == 6
+
+    def test_run_shell_command_called_process_error(
+        self, mocker, mock_check_output_raise_called_process_error
+    ):
+        print_error = mocker.patch("augur.utils.print_error")
+
+        run_shell_command("great-command")
+
+        print_error.assert_called_with(
+            "None\nshell exited 5 when running: great-command"
+        )
+
+    def test_run_shell_command_called_process_error_raise(
+        self, mock_check_output_raise_called_process_error
+    ):
+        import subprocess
+
+        with pytest.raises(subprocess.CalledProcessError):
+            run_shell_command("great-command", True)
+
+    def test_run_shell_command_called_process_error_no_raise(
+        self, mock_check_output_raise_called_process_error
+    ):
+        assert run_shell_command("great-command", False) is False
+
+    def test_run_shell_command_file_not_found(
+        self, mocker, mock_check_output_raise_file_not_found_error
+    ):
+        print_error = mocker.patch("augur.utils.print_error")
+
+        run_shell_command("great-command")
+
+        assert "Unable to run shell commands using" in print_error.call_args[0][0]
+
+    def test_run_shell_command_file_not_found_raise(
+        self, mock_check_output_raise_file_not_found_error
+    ):
+        with pytest.raises(FileNotFoundError):
+            run_shell_command("great-command", True)
+
+    def test_run_shell_command_file_not_found_no_raise(
+        self, mock_check_output_raise_file_not_found_error
+    ):
+        assert run_shell_command("great-command", False) is False


### PR DESCRIPTION
### Description of proposed changes    
- Add unit test coverage to `utils.run_shell_command`.
- Use fstrings in `utils.run_shell_command`, now that Python 3.6 is the minimum supported version.

### Related issue(s)  
nope

### Testing
yep