### PR TITLE
docs: Reference Python 3.6 as minimum supported version

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -26,7 +26,7 @@ Please see the [project board](https://github.com/orgs/nextstrain/projects/6) fo
 
 ## Contributing code
 
-We currently target compatibility with Python 3.4 and higher. As Python releases new versions,
+We currently target compatibility with Python 3.6 and higher. As Python releases new versions,
 the minimum target compatibility may be increased in the future.
 
 Versions for this project, Augur, from 3.0.0 onwards aim to follow the

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The output of augur is a series of JSONs that can be used to visualize your resu
 
 ## Installation
 
-Augur is written in Python 3 and requires at least Python 3.4.
+Augur is written in Python 3 and requires at least Python 3.6.
 
 To install, run:
 ```bash

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -9,7 +9,7 @@
 
 ## Using pip from PyPi
 
-Augur is written in Python 3 and requires at least Python 3.4.
+Augur is written in Python 3 and requires at least Python 3.6.
 It's published on [PyPi](https://pypi.org) as [nextstrain-augur](https://pypi.org/project/nextstrain-augur), so you can install it with `pip` like so:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "License :: OSI Approved :: GNU Affero General Public License v3",
 
-        # Python 3 only; pathlib is >=3.4
+        # Python 3 only
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6"
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
### Description of proposed changes    
Updates documentation to reflect the minimum supported Python version.

Fixes: 472e7be ("API: make Python 3.6 the minimum python")

### Related issue(s)  
Related to #482 

### Testing
* Confirmed that documentation builds 

### Thank you for contributing to Nextstrain!
