### PR TITLE
Use setuptools.find_packages() in setup.py (was: Prepend `bin/` to PATH in test build runner script)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from pathlib    import Path
-from setuptools import setup
+import setuptools
 import sys
 
 min_version = (3, 6)
@@ -26,7 +26,8 @@ with version_file.open() as f:
 with readme_file.open(encoding = "utf-8") as f:
     long_description = f.read()
 
-setup(
+
+setuptools.setup(
     name = "nextstrain-augur",
     version = __version__,
     author = "Nextstrain developers",
@@ -41,7 +42,7 @@ setup(
         "Change Log": "https://github.com/nextstrain/augur/blob/master/CHANGES.md#next",
         "Source": "https://github.com/nextstrain/augur",
     },
-    packages = ['augur'],
+    packages = setuptools.find_packages(),
     package_data = {'augur': ['data/*']},
     data_files = [("", ["LICENSE.txt"])],
     python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),


### PR DESCRIPTION
### Description of proposed changes    
This causes the command `augur` (invoked by snakemake) to always be the dev helper script `bin/augur` when running the test builds. No functional changes to the app.

### Related issue(s)  
none

### Testing
The test build script should run on systems where augur is not even installed—only the repo needs to be checked out. You can simulate this by making sure `augur` is not in your PATH and trying the test build runner.

Edit: cherry-picking this change into #526 allowed that build to pass. Now that I think about it, I'm not sure how the test builds _ever_ worked without this. What `augur` executable is snakemake invoking in the Travis container? Is it a Conda thing?