### PR TITLE
Remove support for deprecated --output flag, now --output-node-data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Major Changes
 
 * Drop support for Python 3.4 and 3.5 [#482][]
+* Drop support for `--output` flag in augur ancestral, clades, sequence-traits, traits, and translate in favor of `--output-node-data` flag [#529][]
 
 ### Features
 
@@ -52,6 +53,7 @@
 [#495]: https://github.com/nextstrain/augur/pull/495
 [#501]: https://github.com/nextstrain/augur/pull/501
 [#508]: https://github.com/nextstrain/augur/pull/508
+[#529]: https://github.com/nextstrain/augur/pull/529
 
 ## 6.4.3 (25 March 2020)
 

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -99,7 +99,6 @@ def register_arguments(parser):
     parser.add_argument('--tree', '-t', required=True, help="prebuilt Newick")
     parser.add_argument('--alignment', '-a', help="alignment in fasta or VCF format")
     parser.add_argument('--output-node-data', type=str, help='name of JSON file to save mutations and ancestral sequences to')
-    parser.add_argument('--output', '-o', type=str, help='DEPRECATED. Same as --output-node-data')
     parser.add_argument('--output-sequences', type=str, help='name of FASTA file to save ancestral sequences to (FASTA alignments only)')
     parser.add_argument('--inference', default='joint', choices=["joint", "marginal"],
                                     help="calculate joint or marginal maximum likelihood ancestral sequence states")

--- a/augur/clades.py
+++ b/augur/clades.py
@@ -184,7 +184,6 @@ def register_arguments(parser):
     parser.add_argument('--reference', nargs='+', help='fasta files containing reference and tip nucleotide and/or amino-acid sequences ')
     parser.add_argument('--clades', type=str, help='TSV file containing clade definitions by amino-acid')
     parser.add_argument('--output-node-data', type=str, help='name of JSON file to save clade assignments to')
-    parser.add_argument('--output', '-o', type=str, help='DEPRECATED. Same as --output-node-data')
 
 
 def run(args):

--- a/augur/sequence_traits.py
+++ b/augur/sequence_traits.py
@@ -300,7 +300,6 @@ def register_arguments(parser):
     parser.add_argument('--count', type=str, choices=['traits','mutations'], default='traits', help='Whether to count traits (ex: # drugs resistant to) or mutations')
     parser.add_argument('--label', type=str, default="# Traits", help='How to label the counts (ex: Drug_Resistance)')
     parser.add_argument('--output-node-data', type=str, help='name of JSON file to save sequence features to')
-    parser.add_argument('--output', '-o', type=str, help='DEPRECATED. Same as --output-node-data')
 
 
 def run(args):

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -118,7 +118,6 @@ def register_arguments(parser):
                              ' are the equilibrium frequencies and t_i are apparent ones.'
                              '(or rather the time spent in a particular state on the tree)')
     parser.add_argument('--output-node-data', type=str, help='name of JSON file to save trait inferences to')
-    parser.add_argument('--output', '-o', type=str, help='DEPRECATED. Same as --output-node-data')
     parser.epilog = "Note that missing data must be represented by a `?` character. Missing data will currently be inferred."
 
 def run(args):

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -308,7 +308,6 @@ def register_arguments(parser):
                         help='GenBank or GFF file containing the annotation')
     parser.add_argument('--genes', nargs='+', help="genes to translate (list or file containing list)")
     parser.add_argument('--output-node-data', type=str, help='name of JSON file to save aa-mutations to')
-    parser.add_argument('--output', '-o', type=str, help='DEPRECATED. Same as --output-node-data')
     parser.add_argument('--alignment-output', type=str, help="write out translated gene alignments. "
                                    "If a VCF-input, a .vcf or .vcf.gz will be output here (depending on file ending). If fasta-input, specify the file name "
                                    "like so: 'my_alignment_%%GENE.fasta', where '%%GENE' will be replaced by the name of the gene")

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -52,10 +52,7 @@ def myopen(fname, mode):
         return open(fname, mode)
 
 def get_json_name(args, default=None):
-    if args.output:
-        print("WARNING: the --output flag will be deprecated in the next major augur release. Use --output-node-data instead.", file=sys.stderr)
-        return args.output
-    elif args.output_node_data:
+    if args.output_node_data:
         return args.output_node_data
     else:
         if default:

--- a/docs/faq/clades.md
+++ b/docs/faq/clades.md
@@ -33,7 +33,7 @@ rule clades:
         augur clades --tree {input.tree} \
             --mutations {input.nuc_muts} {input.aa_muts} \
             --clades {input.clades} \
-            --output {output.clade_data}
+            --output-node-data {output.clade_data}
         """
 ```
 As input, this command requires the tree, the output of the ancestral reconstruction steps and the translation step (assuming your clades are defined using translations), as well as the file with clade definitions.

--- a/docs/tutorials/tb_tutorial.md
+++ b/docs/tutorials/tb_tutorial.md
@@ -257,7 +257,7 @@ rule ancestral:
             --alignment {input.alignment} \
             --vcf-reference {input.ref} \
             --inference {params.inference} \
-            --output {output.nt_data} \
+            --output-node-data {output.nt_data} \
             --output-vcf {output.vcf_out}
         """
 ```
@@ -297,7 +297,7 @@ rule translate:
             --ancestral-sequences {input.vcf} \
             --genes {input.genes} \
             --reference-sequence {input.gene_ref} \
-            --output {output.aa_data} \
+            --output-node-data {output.aa_data} \
             --alignment-output {output.vcf_out} \
             --vcf-reference-output {output.vcf_ref}
         """
@@ -325,7 +325,7 @@ rule traits:
         augur traits --tree {input.tree} \
             --metadata {input.meta} \
             --columns {params.traits} \
-            --output {output}
+            --output-node-data {output}
         """
 ```
 
@@ -362,7 +362,7 @@ rule clades:
         augur clades --tree {input.tree} \
             --mutations {input.nuc_muts} {input.aa_muts} \
             --clades {input.clades} \
-            --output {output.clade_data}
+            --output-node-data {output.clade_data}
         """
 ```
 
@@ -430,7 +430,7 @@ rule seqtraits:
             --features {input.drms} \
             --count {params.count} \
             --label {params.label} \
-            --output {output.drm_data}
+            --output-node-data {output.drm_data}
         """
 ```
 

--- a/tests/builds/add_to_alignment/Snakefile
+++ b/tests/builds/add_to_alignment/Snakefile
@@ -79,7 +79,7 @@ rule ancestral:
         augur ancestral \
             --tree {input.tree} \
             --alignment {input.alignment} \
-            --output {output.node_data} \
+            --output-node-data {output.node_data} \
             --inference {params.inference}
         """
 
@@ -97,7 +97,7 @@ rule translate:
             --tree {input.tree} \
             --ancestral-sequences {input.node_data} \
             --reference-sequence {input.reference} \
-            --output {output.node_data} \
+            --output-node-data {output.node_data} \
         """
 
 auspice_config = {

--- a/tests/builds/tb/Snakefile
+++ b/tests/builds/tb/Snakefile
@@ -106,7 +106,7 @@ rule ancestral:
     shell:
         """
         augur ancestral --tree {input.tree} --alignment {input.alignment} \
-            --output {output.nt_data} --inference {params.inference} \
+            --output-node-data {output.nt_data} --inference {params.inference} \
             --output-vcf {output.vcf_out} --vcf-reference {input.ref}
         """
 
@@ -124,7 +124,7 @@ rule translate:
     shell:
         """
         augur translate --tree {input.tree} --genes {input.genes} --vcf-reference {input.ref} \
-            --ancestral-sequences {input.vcf} --output {output.aa_data} --reference-sequence {input.gene_ref} \
+            --ancestral-sequences {input.vcf} --output-node-data {output.aa_data} --reference-sequence {input.gene_ref} \
             --alignment-output {output.vcf_out} --vcf-reference-output {output.fasta_out}
         """
 
@@ -162,7 +162,7 @@ rule clades:
         """
         augur clades --tree {input.tree} \
             --mutations {input.nuc_muts} {input.aa_muts} \
-            --output {output.clade_data} --clades {input.clades}
+            --output-node-data {output.clade_data} --clades {input.clades}
         """
 
 rule traits:
@@ -175,7 +175,7 @@ rule traits:
         traits = 'location cluster'
     shell:
         'augur traits --tree {input.tree} --metadata {input.meta}'
-        ' --columns {params.traits} --output {output}'
+        ' --columns {params.traits} --output-node-data {output}'
 
 rule export_v1:
     message: "Exporting data files for for auspice using nextflu compatible schema"

--- a/tests/builds/tb_drm/Snakefile
+++ b/tests/builds/tb_drm/Snakefile
@@ -96,7 +96,7 @@ rule ancestral:
     shell:
         """
         augur ancestral --tree {input.tree} --alignment {input.alignment} \
-            --output {output.nt_data} --inference {params.inference} \
+            --output-node-data {output.nt_data} --inference {params.inference} \
             --output-vcf {output.vcf_out} --vcf-reference {input.ref}
         """
 
@@ -114,7 +114,7 @@ rule translate:
     shell:
         """
         augur translate --tree {input.tree} --genes {input.genes} --vcf-reference {input.ref} \
-            --ancestral-sequences {input.vcf} --output {output.aa_data} --reference-sequence {input.gene_ref} \
+            --ancestral-sequences {input.vcf} --output-node-data {output.aa_data} --reference-sequence {input.gene_ref} \
             --alignment-output {output.vcf_out} --vcf-reference-output {output.vcf_ref}
         """
 
@@ -128,7 +128,7 @@ rule traits:
         traits = 'country region'
     shell:
         'augur traits --tree {input.tree} --metadata {input.meta}'
-        ' --columns {params.traits} --output {output}'
+        ' --columns {params.traits} --output-node-data {output}'
 
 rule seqtraits:
     input:
@@ -149,7 +149,7 @@ rule seqtraits:
             --vcf-reference {input.ref} \
             --translations {input.trans_align} \
             --vcf-translate-reference {input.trans_ref} \
-            --features {input.drms} --output {output.drm_data} \
+            --features {input.drms} --output-node-data {output.drm_data} \
             --count {params.count} --label {params.label}
         """
 

--- a/tests/builds/zika/Snakefile
+++ b/tests/builds/zika/Snakefile
@@ -136,7 +136,7 @@ rule ancestral:
             --tree {input.tree} \
             --alignment {input.alignment} \
             --infer-ambiguous \
-            --output {output.node_data} \
+            --output-node-data {output.node_data} \
             --inference {params.inference}
         """
 
@@ -154,7 +154,7 @@ rule translate:
             --tree {input.tree} \
             --ancestral-sequences {input.node_data} \
             --reference-sequence {input.reference} \
-            --output {output.node_data} \
+            --output-node-data {output.node_data} \
         """
 
 rule traits:
@@ -174,7 +174,7 @@ rule traits:
             --tree {input.tree} \
             --weights {params.weights} \
             --metadata {input.metadata} \
-            --output {output.node_data} \
+            --output-node-data {output.node_data} \
             --columns {params.columns} \
             --sampling-bias-correction {params.sampling_bias_correction} \
             --confidence


### PR DESCRIPTION
### Description of proposed changes    

Updates augur commands that previously included `--output` as an option for node
data outputs to only support the `--output-node-data` flag. However, a side
effect of how argparse infers arguments will actually prevent most users who
currently rely on `--output` from having to change most of their commands. The
augur ancestral command is the only exception.

This commit also updates end-to-end tests based on builds and documentation to
refer to the `--output-node-data` flag.

### Related issue(s)  

Related to #518 

### Testing

All tests pass after updating the output flags.