### PR TITLE
Filter priority hotfix

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -56,10 +56,10 @@ def write_vcf(input_filename, output_filename, dropped_samps):
 def read_priority_scores(fname):
     try:
         with open(fname) as pfile:
-            return {
+            return defaultdict(float, {
                 elems[0]: float(elems[1])
                 for elems in (line.strip().split() for line in pfile.readlines())
-            }
+            })
     except Exception as e:
         print(f"ERROR: missing or malformed priority scores file {fname}", file=sys.stderr)
         raise e

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -44,6 +44,8 @@ class TestFilter:
         )
 
         assert priorities == {"strain1": 5, "strain2": 6, "strain3": 8}
+        assert priorities["strain1"] == 5
+        assert priorities["strain42"] == 0, "Default priority is 0 for unlisted sequences"
 
     def test_read_priority_scores_malformed(self, mock_priorities_file_malformed):
         with pytest.raises(ValueError):


### PR DESCRIPTION
### Description of proposed changes    
Fixes a regression introduced by "Allow exception to bubble up when
priority file is bad." (63d6cb2) which accidentally changed the return
type of `read_priority_scores()` from `defaultdict(float)` to dict.

The calling code looks up sequences unconditionally in the priorities
dictionary and thus `defaultdict(float)` provides an appropriate fallback
value when no priority is explicitly given in the provided file.

### Related issue(s)  
Broke the nextstrain/ncov build on Augur 7.0.1.

### Testing
- [x] Updated unit tests with a failing case and then made it pass with a fix.
- [x] Run actual nextstrain/ncov build step with fix to ensure it works.