### PR TITLE
Travis: Trigger Docker image rebuilds only once, instead of thrice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - (pytest -c pytest.python3.ini  --cov-report= --cov=augur)
   - (bash tests/builds/runner.sh)
 after_success:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && $TRAVIS_BRANCH = "release" ]]; then
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && $TRAVIS_BRANCH == "release" ]]; then
       ./devel/travis-rebuild-docker-image;
     fi
   # upload to codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+version: ~> 1.0
 language: generic
 
 # See <https://docs.travis-ci.com/user/build-stages/> for more information on

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,43 @@
-language: python
-sudo: required
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
-  - conda env create -f environment.yml
-  - source activate augur
-install:
-  - pip3 install -e .[dev]
-script:
-  - (pytest -c pytest.python3.ini  --cov-report= --cov=augur)
-  - (bash tests/builds/runner.sh)
-after_success:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && $TRAVIS_BRANCH == "release" ]]; then
-      ./devel/travis-rebuild-docker-image;
-    fi
-  # upload to codecov
-  - bash <(curl -s https://codecov.io/bash) -f "!*.gcov" -X gcov -e TRAVIS_PYTHON_VERSION -y ci/codecov.yml|| echo "Codecov did not collect coverage reports"
+language: generic
+
+# See <https://docs.travis-ci.com/user/build-stages/> for more information on
+# how build stages work.
+stages:
+  - test
+
+  # See <https://docs.travis-ci.com/user/conditions-v1> for more on the "if" syntax.
+  - name: deploy
+    if: branch = release and type != pull_request
+
+jobs:
+  include:
+    - &test
+      stage: test
+      language: python
+      python: 3.6
+      before_install:
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - hash -r
+        - conda config --set always_yes yes --set changeps1 no
+        - conda update -q conda
+        - conda info -a
+        - conda env create -f environment.yml
+        - source activate augur
+      install:
+        - pip3 install -e .[dev]
+      script:
+        - (pytest -c pytest.python3.ini  --cov-report= --cov=augur)
+        - (bash tests/builds/runner.sh)
+      after_success:
+        # upload to codecov
+        - bash <(curl -s https://codecov.io/bash) -f "!*.gcov" -X gcov -e TRAVIS_PYTHON_VERSION -y ci/codecov.yml|| echo "Codecov did not collect coverage reports"
+
+    - <<: *test
+      python: 3.7
+    - <<: *test
+      python: 3.8
+
+    - stage: deploy
+      script: ./devel/travis-rebuild-docker-image

--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -132,8 +132,20 @@ need [a PyPi account][] and [twine][] installed to do the latter.
 
 Branches and PRs are tested by Travis CI jobs configured in `.travis.yml`.
 
+The set of "test" stage jobs are explicitly defined instead of auto-expanded
+from the implicit job property matrix. Since top-level properties are inherited
+by all jobs regardless of build stage, making the matrix explicit is less
+confusing and easier to reason about. YAML's anchor (&foo) and alias merge key
+(<<: *foo) syntax let us do this without repeating ourselves unnecessarily. The
+config is valid YAML and jobs end up as expected when pasted into
+https://config.travis-ci.com/explore.
+
 New releases, via pushes to the `release` branch, trigger a new [docker-base][]
-build to keep the Docker image up-to-date.
+build to keep the Docker image up-to-date. This trigger is implemented with a
+second build stage, "deploy", which is implicitly conditioned on the previous
+"test" stage's successful completion and explicitly conditioned on a non-PR
+trigger on the "release" branch. Note that currently we cannot test this
+"deploy" stage without making a release.
 
 [docker-base]: https://github.com/nextstrain/docker-base
 


### PR DESCRIPTION
The recent addition of two more major Python versions to our test matrix caused the Docker image rebuild to be triggered by each job.

This is now avoided using a second build stage, "deploy", which is implicitly conditioned on the previous "test" stage's successful completion and explicitly conditioned on a non-PR trigger on the "release" branch.

The set of "test" stage jobs are explicitly defined instead of auto-expanded from the implicit job property matrix.  Since top-level properties are inherited by _all_ jobs regardless of build stage, making the matrix explicit is less confusing and easier to reason about. YAML's anchor (`&foo`) and alias merge key (`<<: *foo`) syntax let us do this without repeating ourselves unnecessarily.

The config is valid YAML and jobs end up as expected when pasted into <https://config.travis-ci.com/explore>.  But it will be quite hard to test the "deploy" stage fully without making a release. :/