### PR TITLE
Break `utils.ambiuous_date_to_date_range` to new class

### DIFF
--- a/augur/util_support/date_disambiguator.py
+++ b/augur/util_support/date_disambiguator.py
@@ -1,0 +1,92 @@
+import calendar
+import datetime
+import functools
+import re
+
+
+def tuple_to_date(year, month, day):
+    month = min(month, 12)
+    day = min(day, max_day_for_year_month(year, month))
+
+    return datetime.date(year=year, month=month, day=day)
+
+
+def max_day_for_year_month(year, month):
+    return calendar.monthrange(year, month)[1]
+
+
+def resolve_uncertain_int(uncertain_string, min_or_max):
+    """
+    Takes a string representation of an integer with uncertain places
+    occupied by the character `X`. Returns the minimum or maximum
+    possible integer.
+    """
+    if min_or_max == "min":
+        result = int(uncertain_string.replace("X", "0"))
+    elif min_or_max == "max":
+        result = int(uncertain_string.replace("X", "9"))
+    else:
+        raise "Tried to resolve an uncertain integer to something other than `min` or `max`."
+
+    if result == 0:
+        # A date component cannot be 0. Well, year can, but...
+        result = 1
+
+    return result
+
+
+class DateDisambiguator:
+    """Transforms a date string with uncertainty into the range of possible dates."""
+
+    def __init__(self, uncertain_date, fmt="%Y-%m-%d", min_max_year=None):
+        self.uncertain_date = uncertain_date
+        self.fmt = fmt
+        self.min_max_year = min_max_year
+
+    def range(self):
+        min_date = tuple_to_date(
+            resolve_uncertain_int(self.uncertain_date_components["Y"], "min"),
+            resolve_uncertain_int(self.uncertain_date_components["m"], "min"),
+            resolve_uncertain_int(self.uncertain_date_components["d"], "min"),
+        )
+
+        max_date = tuple_to_date(
+            resolve_uncertain_int(self.uncertain_date_components["Y"], "max"),
+            resolve_uncertain_int(self.uncertain_date_components["m"], "max"),
+            resolve_uncertain_int(self.uncertain_date_components["d"], "max"),
+        )
+        max_date = min(max_date, datetime.date.today())
+
+        return (min_date, max_date)
+
+    @property
+    @functools.lru_cache()
+    def uncertain_date_components(self):
+        matches = re.search(self.regex, self.uncertain_date)
+
+        if matches is None:
+            raise ValueError(
+                f"Malformed uncertain date `{self.uncertain_date}` for format `{self.fmt}`"
+            )
+
+        return dict(zip(self.fmt_components, matches.groups()))
+
+    @property
+    @functools.lru_cache()
+    def fmt_components(self):
+        # The `re` module doesn't capture repeated groups, so we'll do it without regexes
+        return [component[0] for component in self.fmt.split("%") if len(component) > 0]
+
+    @property
+    def regex(self):
+        """
+        Returns regex defined by the format string.
+        Currently only supports %Y, %m, and %d.
+        """
+        return re.compile(
+            "^"
+            + self.fmt.replace("%Y", "(....)")
+            .replace("%m", "(..?)")
+            .replace("%d", "(..?)")
+            + "$"
+        )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from pathlib    import Path
-from setuptools import setup
+import setuptools
 import sys
 
 min_version = (3, 6)
@@ -26,7 +26,9 @@ with version_file.open() as f:
 with readme_file.open(encoding = "utf-8") as f:
     long_description = f.read()
 
-setup(
+
+
+setuptools.setup(
     name = "nextstrain-augur",
     version = __version__,
     author = "Nextstrain developers",
@@ -41,7 +43,7 @@ setup(
         "Change Log": "https://github.com/nextstrain/augur/blob/master/CHANGES.md#next",
         "Source": "https://github.com/nextstrain/augur",
     },
-    packages = ['augur'],
+    packages = setuptools.find_packages(),
     package_data = {'augur': ['data/*']},
     data_files = [("", ["LICENSE.txt"])],
     python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,12 +19,6 @@ class TestUtils:
             datetime.date(year=2000, month=1, day=31),
         )
 
-    def test_ambiguous_date_to_date_range_ambiguous_month(self):
-        assert utils.ambiguous_date_to_date_range("2000-XX-5", "%Y-%m-%d") == (
-            datetime.date(year=2000, month=1, day=5),
-            datetime.date(year=2000, month=12, day=5),
-        )
-
     def test_ambiguous_date_to_date_range_ambiguous_month_and_day(self):
         assert utils.ambiguous_date_to_date_range("2000-XX-XX", "%Y-%m-%d") == (
             datetime.date(year=2000, month=1, day=1),

--- a/tests/util_support/test_date_disambiguator.py
+++ b/tests/util_support/test_date_disambiguator.py
@@ -1,0 +1,73 @@
+import datetime
+
+from augur.util_support import date_disambiguator
+from augur.util_support.date_disambiguator import DateDisambiguator
+
+from freezegun import freeze_time
+import pytest
+
+
+class TestDateDisambiguator:
+    @freeze_time("2111-05-05")
+    @pytest.mark.parametrize(
+        "date_str, expected_range",
+        [
+            ("2000-01-01", (datetime.date(2000, 1, 1), datetime.date(2000, 1, 1))),
+            ("2000-02-XX", (datetime.date(2000, 2, 1), datetime.date(2000, 2, 29))),
+            ("2000-XX-05", (datetime.date(2000, 1, 5), datetime.date(2000, 12, 5))),
+            ("2X00-5-5", (datetime.date(2000, 5, 5), datetime.date(2111, 5, 5))),
+        ],
+    )
+    def test_range(self, date_str, expected_range):
+        assert DateDisambiguator(date_str).range() == expected_range
+
+    @pytest.mark.parametrize(
+        "date_str, fmt",
+        [
+            ("2005-02-XX", "%Y-%m-%d"),
+            ("2005/02/XX", "%Y/%m/%d"),
+            ("2005-XX-02", "%Y-%d-%m"),
+            ("200502XX", "%Y%m%d"),
+        ],
+    )
+    def test_range_separators(self, date_str, fmt):
+        assert DateDisambiguator(date_str, fmt=fmt).range() == (
+            datetime.date(2005, 2, 1),
+            datetime.date(2005, 2, 28),
+        )
+
+    @pytest.mark.parametrize(
+        "date_str, expected_components",
+        [
+            ("2000-01-01", {"Y": "2000", "m": "01", "d": "01"}),
+            ("2000-XX-01", {"Y": "2000", "m": "XX", "d": "01"}),
+            ("2000-XX-XX", {"Y": "2000", "m": "XX", "d": "XX"}),
+            ("200X-XX-2X", {"Y": "200X", "m": "XX", "d": "2X"}),
+        ],
+    )
+    def test_uncertain_date_components(self, date_str, expected_components):
+        assert (
+            DateDisambiguator(date_str).uncertain_date_components == expected_components
+        )
+
+    def test_uncertain_date_components_error(self):
+        with pytest.raises(ValueError, match="Malformed uncertain date"):
+            DateDisambiguator("5-5-5-5-5").uncertain_date_components
+
+    @pytest.mark.parametrize(
+        "date_str, min_or_max, expected",
+        [
+            ("2000", "min", 2000),
+            ("2000", "max", 2000),
+            ("200X", "min", 2000),
+            ("200X", "max", 2009),
+            ("20X0", "max", 2090),
+            ("X000", "max", 9000),
+            ("XXXX", "min", 1),
+            ("XXXX", "max", 9999),
+        ],
+    )
+    def test_resolve_uncertain_int(self, date_str, min_or_max, expected):
+        assert (
+            date_disambiguator.resolve_uncertain_int(date_str, min_or_max) == expected
+        )


### PR DESCRIPTION
### Description of proposed changes    
Rewrite `utils.ambiguous_date_to_date_range` as a new class.

This slightly expands the function's capabilities: any `X` character anywhere in the string will be disambiguated, rather than just at the least significant positions. It should be fully backwards-compatible.

### Related issue(s)  
none

### Testing
Unit tests included.