### PR TITLE
Refactor augur.align and add tests

### DIFF
--- a/augur/align.py
+++ b/augur/align.py
@@ -27,30 +27,30 @@ def register_arguments(parser):
     parser.add_argument('--existing-alignment', metavar="FASTA", default=False, help="An existing alignment to which the sequences will be added. The ouput alignment will be the same length as this existing alignment.")
     parser.add_argument('--debug', action="store_true", default=False, help="Produce extra files (e.g. pre- and post-aligner files) which can help with debugging poor alignments.")
 
-def prepare(args):
-    seqs = read_sequences(*args.sequences)
-    seqs_to_align_fname = args.output + "to_align.fasta"
+def prepare(sequences, existing_alignment, output, reference_name, reference_sequence):
+    seqs = read_sequences(*sequences)
+    seqs_to_align_fname = output + "to_align.fasta"
 
     # Load existing alignment
     existing_aln = None
     existing_aln_fname = None
-    if args.existing_alignment:
-        existing_aln_fname = args.existing_alignment
-        existing_aln = read_alignment(args.existing_alignment)
+    if existing_alignment:
+        existing_aln_fname = existing_alignment
+        existing_aln = read_alignment(existing_alignment)
 
     # Load reference alignment
     ref_name = None
     ref_seq = None
-    if args.reference_name:
-        ref_name = args.reference_name
+    if reference_name:
+        ref_name = reference_name
         ensure_reference_strain_present(ref_name, existing_aln, seqs)
-    elif args.reference_sequence:
-        ref_seq = read_reference(args.reference_sequence)
+    elif reference_sequence:
+        ref_seq = read_reference(reference_sequence)
         ref_name = ref_seq.id
 
     if existing_aln:
         # Strip the existing sequences from the new sequences, add the reference to the alignment
-        seqs_to_align_fname = args.output + "new_seqs_to_align.fasta"
+        seqs_to_align_fname = output + "new_seqs_to_align.fasta"
         seqs = prune_seqs_matching_alignment(seqs, existing_aln)
         write_seqs(list(seqs.values()), seqs_to_align_fname)
         if ref_seq:
@@ -88,11 +88,11 @@ def run(args):
 
     try:
         check_arguments(args)
-        existing_aln_fname, seqs_to_align_fname, ref_name = prepare(args)
+        existing_aln_fname, seqs_to_align_fname, ref_name = prepare(args.sequences, args.existing_alignment, args.output, args.reference_name, args.reference_sequence)
         # -- existing_aln_fname, seqs_to_align_fname, ref_name --
 
         # before aligning, make a copy of the data that the aligner receives as input (very useful for debugging purposes)
-        if args.debug and not existing_aln:
+        if args.debug and not existing_aln_fname:
             copyfile(seqs_to_align_fname, args.output+".pre_aligner.fasta")
 
         # generate alignment command & run

--- a/augur/align.py
+++ b/augur/align.py
@@ -320,13 +320,13 @@ def write_seqs(seqs, fname):
 
 def prune_seqs_matching_alignment(seqs, aln):
     """
-    Return a set of seqs excluding those set via `exclude` & print a warning
+    Return a set of seqs excluding those already in the alignment & print a warning
     message for each sequence which is exluded.
     """
     ret = []
-    exclude_names = {s.name for s in aln}
+    aln_names = {s.name for s in aln}
     for seq in seqs:
-        if seq.name in exclude_names:
+        if seq.name in aln_names:
             print("Excluding {} as it is already present in the alignment".format(name))
         else:
             ret.append(seq)

--- a/augur/align.py
+++ b/augur/align.py
@@ -95,23 +95,7 @@ def run(args):
         if args.debug:
             copyfile(args.output, args.output+".post_aligner.fasta")
 
-        # -- ref_name --
-        # reads the new alignment
-        seqs = read_alignment(args.output)
-
-        # convert the aligner output to upper case and remove auto reverse-complement prefix
-        prettify_alignment(seqs)
-
-        # if we've specified a reference, strip out all the columns not present in the reference
-        # this will overwrite the alignment file
-        if ref_name:
-            seqs = strip_non_reference(seqs, ref_name, keep_reference=not args.remove_reference)
-        if args.fill_gaps:
-            make_gaps_ambiguous(seqs)
-
-        # write the modified sequences back to the alignment file
-        write_seqs(seqs, args.output)
-
+        postprocess(args.output, ref_name, not args.remove_reference, args.fill_gaps)
 
     except AlignmentError as e:
         print(str(e))
@@ -120,6 +104,23 @@ def run(args):
     # finally, remove any temporary files
     for fname in temp_files_to_remove:
         os.remove(fname)
+
+def postprocess(output_file, ref_name, keep_reference, fill_gaps):
+    # -- ref_name --
+    # reads the new alignment
+    seqs = read_alignment(output_file)
+    # convert the aligner output to upper case and remove auto reverse-complement prefix
+    prettify_alignment(seqs)
+
+    # if we've specified a reference, strip out all the columns not present in the reference
+    # this will overwrite the alignment file
+    if ref_name:
+        seqs = strip_non_reference(seqs, ref_name, keep_reference=keep_reference)
+    if fill_gaps:
+        make_gaps_ambiguous(seqs)
+
+    # write the modified sequences back to the alignment file
+    write_seqs(seqs, output_file)
 
 #####################################################################################################
 

--- a/augur/align.py
+++ b/augur/align.py
@@ -27,7 +27,7 @@ def register_arguments(parser):
     parser.add_argument('--existing-alignment', metavar="FASTA", default=False, help="An existing alignment to which the sequences will be added. The ouput alignment will be the same length as this existing alignment.")
     parser.add_argument('--debug', action="store_true", default=False, help="Produce extra files (e.g. pre- and post-aligner files) which can help with debugging poor alignments.")
 
-def prepare(sequences, existing_alignment, output, reference_name, reference_sequence):
+def prepare(sequences, existing_alignment, output, ref_name, ref_seq_fname):
     seqs = read_sequences(*sequences)
     seqs_to_align_fname = output + "to_align.fasta"
 
@@ -39,13 +39,10 @@ def prepare(sequences, existing_alignment, output, reference_name, reference_seq
         existing_aln = read_alignment(existing_alignment)
 
     # Load reference alignment
-    ref_name = None
-    ref_seq = None
-    if reference_name:
-        ref_name = reference_name
+    if ref_name:
         ensure_reference_strain_present(ref_name, existing_aln, seqs)
-    elif reference_sequence:
-        ref_seq = read_reference(reference_sequence)
+    elif ref_seq_fname:
+        ref_seq = read_reference(ref_seq_fname)
         ref_name = ref_seq.id
 
     if existing_aln:

--- a/augur/align.py
+++ b/augur/align.py
@@ -324,7 +324,7 @@ def prune_seqs_matching_alignment(seqs, aln):
     aln_names = {s.name for s in aln}
     for seq in seqs:
         if seq.name in aln_names:
-            print("Excluding {} as it is already present in the alignment".format(name))
+            print("Excluding {} as it is already present in the alignment".format(seq.name))
         else:
             ret.append(seq)
     return ret

--- a/augur/align.py
+++ b/augur/align.py
@@ -44,44 +44,47 @@ def run(args):
     try:
         check_arguments(args)
         seqs = read_sequences(*args.sequences)
-        existing_aln = read_alignment(args.existing_alignment) if args.existing_alignment else None
+        seqs_to_align_fname = args.output + "to_align.fasta"
 
-        # if we have been given a reference (strain) name, make sure it is present
-        ref_name = args.reference_name
+        # Load existing alignment
+        existing_aln = None
+        existing_aln_fname = None
+        if args.existing_alignment:
+            existing_aln_fname = args.existing_alignment
+            existing_aln = read_alignment(args.existing_alignment)
+
+        # Load reference alignment
+        ref_name = None
+        ref_seq = None
         if args.reference_name:
+            ref_name = args.reference_name
             ensure_reference_strain_present(ref_name, existing_aln, seqs)
-
-        # If given an existing alignment, then add the reference sequence to this if desired (and if it is the same length)
-        if existing_aln and args.reference_sequence:
-            existing_aln_fname = args.existing_alignment + ".ref.fasta"
+        elif args.reference_sequence:
             ref_seq = read_reference(args.reference_sequence)
-            if len(ref_seq) != existing_aln.get_alignment_length():
-                raise AlignmentError("ERROR: Provided existing alignment ({}bp) is not the same length as the reference sequence ({}bp)".format(existing_aln.get_alignment_length(), len(ref_seq)))
-            existing_aln.append(ref_seq)
-            write_seqs(existing_aln, existing_aln_fname)
-            temp_files_to_remove.append(existing_aln_fname)
             ref_name = ref_seq.id
-        else:
-            existing_aln_fname = args.existing_alignment # may be False
 
-        ## Create a single file of sequences for alignment (or to be added to the alignment).
-        ## Add in the reference file to the sequences _if_ we don't have an existing alignment
-        if args.reference_sequence and not existing_aln:
-            seqs_to_align_fname = args.output+".to_align.fasta"
-            ref_seq = read_reference(args.reference_sequence)
-            # reference sequence needs to be the first one for auto direction adjustment (auto reverse-complement)
-            write_seqs([ref_seq] + list(seqs.values()), seqs_to_align_fname)
-            ref_name = ref_seq.id
-        elif existing_aln:
-            seqs_to_align_fname = args.output+".new_seqs_to_align.fasta"
+        if existing_aln:
+            # Strip the existing sequences from the new sequences, add the reference to the alignment
+            seqs_to_align_fname = args.output + "new_seqs_to_align.fasta"
             seqs = prune_seqs_matching_alignment(seqs, existing_aln)
             write_seqs(list(seqs.values()), seqs_to_align_fname)
+            if ref_seq:
+                if len(ref_seq) != existing_aln.get_alignment_length():
+                    raise AlignmentError("ERROR: Provided existing alignment ({}bp) is not the same length as the reference sequence ({}bp)".format(existing_aln.get_alignment_length(), len(ref_seq)))
+                existing_aln_fname = existing_aln_fname + ".ref.fasta"
+                existing_aln.append(ref_seq)
+                write_seqs(existing_aln, existing_aln_fname)
+                temp_files_to_remove.append(existing_aln_fname)
+        elif ref_seq: # Got a reference sequence but no existing alignment
+            # reference sequence needs to be the first one for auto direction
+            # adjustment (auto reverse-complement)
+            write_seqs([ref_seq] + list(seqs.values()), seqs_to_align_fname)
+            seqs[ref_name] = ref_seq
         else:
-            seqs_to_align_fname = args.output+".to_align.fasta"
             write_seqs(list(seqs.values()), seqs_to_align_fname)
         temp_files_to_remove.append(seqs_to_align_fname)
 
-        check_duplicates(existing_aln, ref_name, seqs)
+        check_duplicates(existing_aln, seqs)
 
         # before aligning, make a copy of the data that the aligner receives as input (very useful for debugging purposes)
         if args.debug and not existing_aln:

--- a/augur/align.py
+++ b/augur/align.py
@@ -28,6 +28,32 @@ def register_arguments(parser):
     parser.add_argument('--debug', action="store_true", default=False, help="Produce extra files (e.g. pre- and post-aligner files) which can help with debugging poor alignments.")
 
 def prepare(sequences, existing_aln_fname, output, ref_name, ref_seq_fname):
+    """Prepare the sequences, existing alignment, and reference sequence for alignment.
+
+    This function:
+        1. Combines all given input sequences into a single file
+        2. Checks to make sure the input sequences don't overlap with the existing alignment, if one exists.
+        3. If given a reference name, check that sequence exists in either the existing alignment, if given, or the input sequences.
+        4. If given a reference sequence, either add it to the existing alignment or prepend it to the input seqeunces.
+        5. Write the input sequences to a single file, and write the alignment back out if we added the reference sequence to it.
+    
+    Parameters
+    ----------
+    sequences : list[str]
+        List of paths to FASTA-formatted sequences to align.
+    existing_aln_fname : str
+        Path of an existing alignment to use, or None
+    output: str
+        Path the aligned sequences will be written out to.
+    ref_name: str
+        The name of the reference sequence, if provided
+    ref_seq_fname: str
+        The path to the reference sequence file. If this is provided, it overrides ref_name.
+    
+    Returns
+    -------
+        tuple: The existing alignment filename, the new sequences filename, and the name of the reference sequence.
+    """
     seqs = read_sequences(*sequences)
     seqs_to_align_fname = output + ".to_align.fasta"
 
@@ -106,6 +132,23 @@ def run(args):
         os.remove(fname)
 
 def postprocess(output_file, ref_name, keep_reference, fill_gaps):
+    """Postprocessing of the combined alignment file.
+
+    Parameters
+    ----------
+    output_file: str
+        The file the new alignment was written to
+    ref_name: str
+        If provided, the name of the reference strain used in the alignment
+    keep_reference: bool
+        If the reference was provided, whether it should be kept in the alignment
+    fill_gaps: bool
+        Replace all gaps in the alignment with "N" to indicate ambiguous sites.
+    
+    Returns
+    -------
+        None - the modified alignment is written directly to output_file
+    """
     # -- ref_name --
     # reads the new alignment
     seqs = read_alignment(output_file)

--- a/augur/align.py
+++ b/augur/align.py
@@ -36,7 +36,7 @@ def prepare(sequences, existing_aln_fname, output, ref_name, ref_seq_fname):
         seqs = prune_seqs_matching_alignment(seqs, existing_aln)
     else:
         existing_aln = None
-        
+
     if ref_seq_fname:
         ref_seq = read_reference(ref_seq_fname)
         ref_name = ref_seq.id
@@ -286,7 +286,6 @@ def make_gaps_ambiguous(aln):
         _seq = str(seq.seq)
         _seq = _seq.replace('-', 'N')
         seq.seq = Seq.Seq(_seq, alphabet=seq.seq.alphabet)
-        
 
 def check_duplicates(*values):
     names = set()

--- a/augur/align.py
+++ b/augur/align.py
@@ -27,16 +27,14 @@ def register_arguments(parser):
     parser.add_argument('--existing-alignment', metavar="FASTA", default=False, help="An existing alignment to which the sequences will be added. The ouput alignment will be the same length as this existing alignment.")
     parser.add_argument('--debug', action="store_true", default=False, help="Produce extra files (e.g. pre- and post-aligner files) which can help with debugging poor alignments.")
 
-def prepare(sequences, existing_alignment, output, ref_name, ref_seq_fname):
+def prepare(sequences, existing_aln_fname, output, ref_name, ref_seq_fname):
     seqs = read_sequences(*sequences)
     seqs_to_align_fname = output + "to_align.fasta"
 
     # Load existing alignment
     existing_aln = None
-    existing_aln_fname = None
-    if existing_alignment:
-        existing_aln_fname = existing_alignment
-        existing_aln = read_alignment(existing_alignment)
+    if existing_aln_fname:
+        existing_aln = read_alignment(existing_aln_fname)
 
     # Load reference alignment
     if ref_name:
@@ -66,8 +64,6 @@ def prepare(sequences, existing_alignment, output, ref_name, ref_seq_fname):
 
     check_duplicates(existing_aln, seqs)
     return existing_aln_fname, seqs_to_align_fname, ref_name
-
-
 
 def run(args):
     '''

--- a/augur/align.py
+++ b/augur/align.py
@@ -29,7 +29,7 @@ def register_arguments(parser):
 
 def prepare(sequences, existing_aln_fname, output, ref_name, ref_seq_fname):
     seqs = read_sequences(*sequences)
-    seqs_to_align_fname = output + "to_align.fasta"
+    seqs_to_align_fname = output + ".to_align.fasta"
 
     # Load existing alignment
     existing_aln = None
@@ -46,7 +46,7 @@ def prepare(sequences, existing_aln_fname, output, ref_name, ref_seq_fname):
 
     if existing_aln:
         # Strip the existing sequences from the new sequences, add the reference to the alignment
-        seqs_to_align_fname = output + "new_seqs_to_align.fasta"
+        seqs_to_align_fname = output + ".new_seqs_to_align.fasta"
         seqs = prune_seqs_matching_alignment(seqs, existing_aln)
         if ref_seq:
             if len(ref_seq) != existing_aln.get_alignment_length():
@@ -80,6 +80,9 @@ def run(args):
     try:
         check_arguments(args)
         existing_aln_fname, seqs_to_align_fname, ref_name = prepare(args.sequences, args.existing_alignment, args.output, args.reference_name, args.reference_sequence)
+        temp_files_to_remove.append(seqs_to_align_fname)
+        if existing_aln_fname != args.existing_alignment:
+            temp_files_to_remove.append(existing_aln_fname)
         # -- existing_aln_fname, seqs_to_align_fname, ref_name --
 
         # before aligning, make a copy of the data that the aligner receives as input (very useful for debugging purposes)

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -90,9 +90,10 @@ class TestAlign:
             ]
         )
         
-        result = align.prune_seqs_matching_alignment(sequence, alignment)
-        assert list(result.keys()) == ["seq2"]
-        assert result["seq2"].seq == sequence["seq2"].seq
+        result = align.prune_seqs_matching_alignment(sequence.values(), alignment)
+        assert [r.name for r in result] == ["seq2"]
+        for r in result:
+            assert r.seq == sequence[r.name].seq
 
     def test_prettify_alignment(self):
         data_file = pathlib.Path('tests/data/align/test_aligned_sequences.fasta')
@@ -148,7 +149,7 @@ class TestAlign:
     def test_read_sequences(self):
         data_file = pathlib.Path('tests/data/align/test_aligned_sequences.fasta')
         result = align.read_sequences(data_file)
-        assert len(result.keys()) == 4
+        assert len(result) == 4
 
     def test_read_seq_compare(self):
         data_file = pathlib.Path("tests/data/align/aa-seq_h3n2_ha_2y_2HA1_dup.fasta")

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -1,16 +1,19 @@
+import argparse
+import functools
 import os
+
+import pytest
+import pathlib
+
+from shlex import quote
 
 from Bio import SeqIO
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
-from shlex import quote
-
 from augur import align
 
-import pytest
-import pathlib
 
 def write_strains(tmpdir, name, strains):
     path = str(tmpdir / name + ".fasta")

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -47,7 +47,7 @@ def test_file(tmpdir, test_seqs):
 
 @pytest.fixture
 def test_with_ref(tmpdir, test_seqs, ref_seq):
-    return write_strains(tmpdir, "test_w_ref", [ref_seq,] + list(existing_aln.values()))
+    return write_strains(tmpdir, "test_w_ref", [ref_seq,] + list(test_seqs.values()))
 
 @pytest.fixture
 def existing_file(tmpdir, existing_aln):
@@ -209,13 +209,108 @@ class TestAlign:
         with pytest.raises(align.AlignmentError):
             assert align.read_sequences(data_file)
 
-    def test_prepare_no_alignment_or_ref(self, test_file, test_seqs, tmpdir, out_file):
+    def test_prepare_no_alignment_or_ref(self, test_file, test_seqs, out_file):
         """
         Strictly we shouldn't see this case, since we should always have a
         ref_name or ref_seq, but it's still good to check the behavior.
         """
-        expected_output = out_file + ".to_align.fasta"
-        align.prepare([test_file,], None, out_file, None, None)
-        assert os.path.isfile(expected_output), "Didn't write sequences where we expected"
-        for name, seq in SeqIO.to_dict(SeqIO.parse(expected_output, "fasta")).items():
+        _, output, _ = align.prepare([test_file,], None, out_file, None, None)
+        assert os.path.isfile(output), "Didn't write sequences where it said"
+        for name, seq in SeqIO.to_dict(SeqIO.parse(output, "fasta")).items():
             assert seq.seq == test_seqs[name].seq
+    
+    def test_prepare_no_alignment_with_named_ref_missing(self, test_file, ref_seq):
+        """We're given a ref_name, but it does not exist in the test file"""
+        with pytest.raises(align.AlignmentError):
+            align.prepare([test_file,], None, "dontcare", ref_seq.id, None)
+
+    def test_prepare_with_alignment_with_named_ref_missing(self, test_with_ref, existing_file, ref_seq):
+        """We're given a ref_name and an existing alignment, but the ref doesn't exist in the existing alignment."""
+        with pytest.raises(align.AlignmentError):
+            align.prepare([test_with_ref,], existing_file, "dontcare", ref_seq.id, None)
+
+    def test_prepare_no_alignment_with_ref_file(self, test_file, test_seqs, ref_file, ref_seq, out_file):
+        _, output_fn, ref_name = align.prepare([test_file,], None, out_file, None, ref_file)
+        assert ref_name == ref_seq.id, "Didn't return strain name from refrence file"
+        assert os.path.isfile(output_fn), "Didn't write sequences where it said"
+        output = list(SeqIO.parse(output_fn, "fasta")) # order matters
+        assert output[0].id == ref_seq.id, "Reference sequence is not the first sequence in ouput file!"
+        output_names = {record.name for record in output}
+        assert all(name in output_names for name in test_seqs), "Some test sequences dropped unexpectedly"
+        for record in output[1:]:
+            assert record.seq == test_seqs[record.id].seq, "Some test sequences changed unexpectedly"
+    
+    def test_prepare_no_alignment_with_ref_name(self, test_with_ref, test_seqs, ref_seq, out_file):
+        _, output_fn, _ = align.prepare([test_with_ref,], None, out_file, ref_seq.id, None)
+        assert os.path.isfile(output_fn), "Didn't write sequences where it said"
+        output = SeqIO.to_dict(SeqIO.parse(output_fn, "fasta"))
+        assert output[ref_seq.id].seq == ref_seq.seq, "Reference sequence was not added to test sequences"
+        for seq in test_seqs:
+            assert seq in output, "Some test sequences dropped unexpectedly"
+            assert output[seq].seq == test_seqs[seq].seq, "Some test sequences changed unexpectedly"
+
+    def test_prepare_with_alignment_with_ref_name(self, test_file, test_seqs, existing_with_ref, existing_aln, ref_seq, out_file):
+        """Test that, given a set of test sequences, an existing alignment, and a reference sequence name, no changes are made."""
+        aln_outfile, seqs_outfile, _ = align.prepare([test_file,], existing_with_ref, out_file, ref_seq.id, None)
+        assert os.path.isfile(aln_outfile), "Didn't write existing alignment where it said"
+        assert aln_outfile == existing_with_ref, "Rewrote the alignment file unexpectedly"
+        # Alignment file should be unchanged
+        aln_output = SeqIO.to_dict(SeqIO.parse(aln_outfile, "fasta"))
+        assert aln_output[ref_seq.id].seq == ref_seq.seq, "Reference sequence dropped from alignment"
+        for seq in existing_aln:
+            assert seq in aln_output, "Some existing alignment sequences dropped unexpectedly"
+            assert aln_output[seq].seq == existing_aln[seq].seq, "Some existing alignment sequences changed unexpectedly"
+        # test sequences should be unchanged
+        assert os.path.isfile(seqs_outfile), "Didn't write test sequences where it said"
+        seq_output = SeqIO.to_dict(SeqIO.parse(seqs_outfile, "fasta"))
+        for seq in test_seqs:
+            assert seq in seq_output, "Some test sequences unexpectedly dropped"
+            assert seq_output[seq].seq == test_seqs[seq].seq, "Some test sequences changed unexpectedly"
+        assert seq_output.keys() == test_seqs.keys()
+
+    def test_prepare_with_alignment_with_ref_seq(self, test_file, test_seqs, existing_file, existing_aln, ref_seq, ref_file, out_file):
+        """Test that, given a set of test sequences, an existing alignment, and a reference sequence, the reference
+        is added to the existing alignment and no other changes are made."""
+        aln_outfile, seqs_outfile, ref_name = align.prepare([test_file,], existing_file, out_file, None, ref_file)
+        assert ref_name == ref_seq.id, "Didn't return strain name from refrence file"
+        assert os.path.isfile(aln_outfile), "Didn't write existing alignment where it said"
+        assert aln_outfile != existing_aln, "Unexpectedly overwrote existing alignment"
+        # Alignment file should have the reference added
+        aln_output = SeqIO.to_dict(SeqIO.parse(aln_outfile, "fasta"))
+        assert aln_output[ref_seq.id].seq == ref_seq.seq, "Reference sequence not added to alignment"
+        for seq in existing_aln:
+            assert seq in aln_output, "Some existing alignment sequences dropped unexpectedly"
+            assert aln_output[seq].seq == existing_aln[seq].seq, "Some existing alignment sequences changed unexpectedly"
+        # test sequences should be unchanged
+        assert os.path.isfile(seqs_outfile), "Didn't write test sequences where it said"
+        seq_output = SeqIO.to_dict(SeqIO.parse(seqs_outfile, "fasta"))
+        for seq in test_seqs:
+            assert seq in seq_output, "Some test sequences unexpectedly dropped"
+            assert seq_output[seq].seq == test_seqs[seq].seq, "Some test sequences changed unexpectedly"
+        assert seq_output.keys() == test_seqs.keys()
+    
+    def test_prepare_no_alignment_multiple_test_seqs(self, test_file, test_seqs, ref_file, ref_seq, out_file):
+        """Test that we can pass multiple sequence files to prepare() and get one unified file back"""
+        # bit of a kludge, but gets us the reference strain in the input files
+        _, seq_outfile, _ = align.prepare([test_file, ref_file], None, out_file, ref_seq.id, None)
+        seq_output = SeqIO.to_dict(SeqIO.parse(seq_outfile, "fasta"))
+        assert seq_output.keys() == set(test_seqs.keys()) | {ref_seq.id}, "Did not combine the two files"
+        assert seq_output[ref_seq.id].seq == ref_seq.seq, "Missing sequence from second file"
+        for seq in test_seqs:
+            assert seq in seq_output, "Some test sequences unexpectedly dropped"
+            assert seq_output[seq].seq == test_seqs[seq].seq, "Some test sequences changed unexpectedly"
+    
+    def test_prepare_with_alignment_with_duplicate_sequences(self, test_file, test_seqs, existing_file, existing_aln, out_file):
+        """Test that sequences matching the alignment are removed from the input sequences"""
+        # Again, we're skipping the ref here. It shouldn't affect the outcome.
+        _, seq_outfile, _ = align.prepare([existing_file, test_file], existing_file, out_file, None, None)
+        seq_output = SeqIO.to_dict(SeqIO.parse(seq_outfile, "fasta"))
+        assert seq_output.keys() == test_seqs.keys(), "Did not strip duplicate sequences from test input!"
+    
+    def test_prepare_with_alignment_ref_sequence_wrong_length(self, test_file, existing_file, ref_seq, ref_file):
+        ref_seq.seq = ref_seq.seq[:-3]
+        with open(ref_file, "w") as fh:
+            SeqIO.write(ref_seq, fh, "fasta")
+        with pytest.raises(align.AlignmentError):
+            align.prepare([test_file,], existing_file, "out", None, ref_file)
+

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -66,6 +66,29 @@ def out_file(tmpdir):
     open(out_file, "w").close()
     return out_file
 
+@pytest.fixture
+def argparser():
+    """Provide an easy way to test command line arguments"""
+    parser = argparse.ArgumentParser()
+    align.register_arguments(parser)
+    def parse(args):
+        return parser.parse_args(args.split(" "))
+    return parse
+
+@pytest.fixture
+def run(argparser, out_file):
+    def run(args):
+        args = argparser(args + " -o %s" % out_file)
+        align.run(args)
+        return SeqIO.to_dict(SeqIO.parse(out_file, "fasta"))
+    return run
+
+@pytest.fixture
+def mp_context(monkeypatch):
+    #This should be moved to conftest once #512 is merged
+    with monkeypatch.context() as mp:
+        yield mp
+
 class TestAlign:
     def test_make_gaps_ambiguous(self):
         alignment = MultipleSeqAlignment(


### PR DESCRIPTION
### Description of proposed changes    
Reworks the augur.align.run() logic, pulling prepare and postprocess out to separate functions to improve testability. Adds many tests.

Note: this is a lot of change, but the only functional change Should be fixing #524 

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #524
Related to #476 

### Testing
Added many tests, and also tested output against the previous version.
I also duplicated some of the testing framework bits made for #512 - I'll consolidate these once either PR is merged.

### Thank you for contributing to Nextstrain!
💃