### PR TITLE
Rate confidence arguments passed down to treetime

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -59,7 +59,7 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='a
     # uncertainty of the the clock rate is relevant if confidence intervals are estimated
     if confidence and clock_std:
         vary_rate = clock_std # if standard devivation of clock is specified, use that
-    elif confidence and covariance:
+    elif (clock_rate is None) and confidence and covariance:
         vary_rate = True      # if run in covariance mode, standard deviation can be estimated
     else:
         vary_rate = False     # otherwise, rate uncertainty will be ignored


### PR DESCRIPTION
### Description of proposed changes    
@pauloluniyi ran into an issue where augur failed during refine due to inconsistent arguments handed off to treetime. (requesting confidence intervals with rate uncertainty for a fixed rate without specifying uncertainty for the rate).

This commit checks that no rate is provided, i.e. the rate is estimated from the data, before requesting confidence intervals with rate uncertainty. 


### Related issue(s)  
Fixes #547 
Related to https://github.com/neherlab/treetime/issues/118  

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
