### PR TITLE
Execute Cram via pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 __pycache__/
 .cache/
 .coverage
+.coverage_pytest_cram*
 htmlcov/
 augur.egg-info/
 .mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
         - pip install -e .[dev]
       script:
         - (pytest -c pytest.python3.ini  --cov-report= --cov=augur)
+        - (pytest -vv -s tests/test_cram.py --cov-report=term --cov augur)
         - (cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
         - (bash tests/builds/runner.sh)
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - pip install -e .[dev]
       script:
         - (pytest -c pytest.python3.ini  --cov-report= --cov=augur)
-        - (pytest -vv -s tests/test_cram.py --cov-report=term --cov augur)
+        - (COVERAGE_FILE=.coverage_pytest_cram pytest -vv -s tests/test_cram.py --cov-report=term --cov augur)
         - (cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
         - (bash tests/builds/runner.sh)
       after_success:

--- a/pytest.python3.ini
+++ b/pytest.python3.ini
@@ -25,6 +25,9 @@ addopts =
     # output short traceback
     --tb=short
 
+    # ignore Cram tests executed via pytest
+    --ignore=tests/test_cram.py
+
 testpaths =
     augur/
     tests/

--- a/tests/test_cram.py
+++ b/tests/test_cram.py
@@ -1,0 +1,41 @@
+import pytest
+import pathlib
+import cram
+import os
+
+# Coverage.py warning: No data was collected. (no-data-collected)
+import augur
+
+
+# Locate all Cram tests to be executed.
+test_dir = "./tests/"
+cram_tests = list(pathlib.Path(test_dir).glob("**/*.t"))
+
+
+def get_ids(args):
+    """
+    Convert PosixPaths representing individual Cram test files to string.
+    This allows Pytest to include each Cram test's filepath and success/failure status in the pytest output.
+    """
+    return str(args)
+
+
+class TestCram:
+    """
+    Pytest wrapper for Cram CLI tests.
+    This test executes each Cram test defined under tests/, and fails if Cram returns any diffs.
+
+    To generate a coverage report for all Cram CLI tests, execute this command:
+        pytest -vv -s tests/test_cram.py --cov-report=term --cov augur
+    """
+
+    @pytest.mark.parametrize("cram_test_file", cram_tests, ids=get_ids)
+    def test_all(self, tmpdir, cram_test_file):
+        # cram.main() sets these environment variables, but cram.testfile() does not.
+        # If they're unset, cram tests can't (e.g.) write to $TMP/out from here.
+        for s in ("TMPDIR", "TEMP", "TMP"):
+            os.environ[s] = str(tmpdir)
+        # cram expects a bytes literal here, e.g. b"tests/cli/ancestral/add_to_alignment/ancestral/ancestral.t"
+        ins, outs, diffs = cram.testfile(path=bytes(cram_test_file), shell="/bin/bash")
+        diff_list = list(diffs)
+        assert len(diff_list) == 0, f"Cram diffs: {diff_list}"


### PR DESCRIPTION
### Description of proposed changes
@huddlej As discussed in PR #[543](https://github.com/nextstrain/augur/pull/543#issuecomment-628087365), here's the PR to add just the pytest wrapper for the Cram functional tests, including coverage report.

One noteworthy change:  When I submitted this in #543, I got different coverage numbers on my local machine vs. Travis.  In this PR, that's no longer the case - I'm now seeing 41% overall coverage both locally and on Travis.  Not sure why or how that fixed itself - but, seems to be working now.

This PR does the following:

- Adds a Pytest wrapper, `tests/test_cram.py`, to execute all Cram CLI tests located under `tests/`.
- Updates `.travis.yml` to execute this test independently from existing Augur unit tests, and to generate a coverage report showing code coverage *just* for the Cram tests.  
- Updates `pytest.python3.ini` to exclude the pytest Cram wrapper when executing unit tests. 
- Updates `.gitignore` to ignore the coverage datafile `.coverage_pytest_cram`.


Couple of additional notes:
- The `.travis.yml` and `.gitignore` changes are worth calling out.  pytest-cov writes a coverage-data file to the default location, `.coverage`; Travis then uploads this to codecov.io.  I don't want the Cram coverage data to overwrite the unit-test coverage data.  So, to keep these separate, I've updated `.travis.yml` to set `COVERAGE_FILE=.coverage_pytest_cram` when I call `pytest`.  

On my Travis and Codecov accounts, this seems to work as intended.  Codecov correctly shows ~19% unit-test coverage, not the ~40% coverage you'd see if Codecov were picking up the Cram-test coverage data.  But, the [Codecov bash uploader](https://docs.codecov.io/docs/about-the-codecov-bash-uploader) is a little vague about how it detects coverage files.  So, you might want to keep an eye on this.  I've added a note for this in the 'Testing' section below.

- In `.travis.yml`, I've left in place the call to execute Cram tests in the 'normal' way (`cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t`).  This is redundant to the pytest-Cram call, of course - I kept the original just as a control, to prove that pytest-Cram and normal-Cram are both running and succeeding.  Up to you guys, but my instinct would be to keep both calls side-by-side for a while, then delete the normal-cram call when everybody's comfortable with pytest-Cram.


    
### Related issue(s)  
Related to #542 #543   

### Testing
Locally:
`COVERAGE_FILE=.coverage_pytest_cram pytest -vv -s tests/test_cram.py --cov-report=term --cov augur`

On Travis:
Run a build.  Observe that `tests/test_cram.py` executes `tests/builds/zika.t` and `tests/functional/mask.t`, and both tests pass ([example](https://travis-ci.com/github/alpha29/augur/jobs/334527614#L980)).  Observe that this writes a coverage report to terminal, currently showing 41% coverage ([example](https://travis-ci.com/github/alpha29/augur/jobs/334527614#L1025)).

Check [codecov.io](https://codecov.io/gh/nextstrain/augur/tree/master/augur) to verify that it's still showing coverage for *just* the `augur` unit tests.  Should be ~19% or so - if it's ~40%, then Codecov may have unexpectedly pulled pytest-Cram's coverage data into the mix.
