### PR TITLE
print treetime version

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -41,7 +41,9 @@ def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
         treetime.TreeAnc instance
     """
 
-    from treetime import TreeAnc
+    from treetime import TreeAnc, version as treetime_version
+    print(f"augur ancestral is using TreeTime version {treetime_version}")
+
     tt = TreeAnc(tree=tree, aln=aln, ref=ref, gtr='JC69',
                  fill_overhangs=fill_overhangs, verbose=1)
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -166,6 +166,8 @@ def run(args):
     else:
         aln = args.alignment
 
+    from treetime import version as treetime_version
+    print(f"augur refine is using TreeTime version {treetime_version}")
 
     # if not specified, construct default output file name with suffix _tt.nwk
     if args.output_tree:

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -161,6 +161,10 @@ def run(args):
     mugration_states = defaultdict(dict)
     models = defaultdict(dict)
     out_prefix = '.'.join(args.tree.split('.')[:-1])
+
+    from treetime import version as treetime_version
+    print(f"augur traits is using TreeTime version {treetime_version}")
+
     for column in args.columns:
         T, gtr, alphabet = mugration_inference(tree=tree_fname, seq_meta=traits,
                                                field=column, confidence=args.confidence,


### PR DESCRIPTION
Depending on the install mechanism it seems possible to have an older-than-asked-for treetime
version in use, which can lead to confusing errors. Here we print the version of treetime
used for the commands which use it (excluding those which use a helper command such as `read_vcf`)
This is printed before the treetime command is run so that it's visible if that fails.
