### PR TITLE
Filter: Add '--query' for complex queries 

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -183,13 +183,6 @@ def run(args):
             print("ERROR: Could not open file of excluded strains '%s'" % args.exclude, file=sys.stderr)
             sys.exit(1)
 
-    # exclude strains by metadata, using Pandas querying
-    num_excluded_by_query = 0
-    if args.query:
-        filtered = filter_by_query(seq_keep, args.metadata, args.query)
-        num_excluded_by_query = len(seq_keep) - len(filtered)
-        seq_keep = filtered
-
     # exclude strain my metadata field like 'host=camel'
     # match using lowercase
     num_excluded_by_metadata = {}
@@ -211,6 +204,13 @@ def run(args):
                 tmp = [seq_name for seq_name in seq_keep if seq_name not in to_exclude]
                 num_excluded_by_metadata[ex] = len(seq_keep) - len(tmp)
                 seq_keep = tmp
+
+    # exclude strains by metadata, using Pandas querying
+    num_excluded_by_query = 0
+    if args.query:
+        filtered = filter_by_query(seq_keep, args.metadata, args.query)
+        num_excluded_by_query = len(seq_keep) - len(filtered)
+        seq_keep = filtered
 
     # filter by sequence length
     num_excluded_by_length = 0
@@ -385,11 +385,11 @@ def run(args):
     print("\n%i sequences were dropped during filtering" % (len(all_seq) - len(seq_keep),))
     if args.exclude:
         print("\t%i of these were dropped because they were in %s" % (num_excluded_by_name, args.exclude))
-    if args.query:
-        print("\t%i of these were filtered out by the query:\n\t\t\"%s\"" % (num_excluded_by_query, args.query))
     if args.exclude_where:
         for key,val in num_excluded_by_metadata.items():
             print("\t%i of these were dropped because of '%s'" % (val, key))
+    if args.query:
+        print("\t%i of these were filtered out by the query:\n\t\t\"%s\"" % (num_excluded_by_query, args.query))
     if args.min_length:
         print("\t%i of these were dropped because they were shorter than minimum length of %sbp" % (num_excluded_by_length, args.min_length))
     if (args.min_date or args.max_date) and 'date' in meta_columns:

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -64,6 +64,25 @@ def read_priority_scores(fname):
         print(f"ERROR: missing or malformed priority scores file {fname}", file=sys.stderr)
         raise e
 
+def filter_by_query(sequences, metadata_file, query):
+    """Filter a set of sequences using Pandas DataFrame querying against the metadata file.
+
+    Parameters
+    ----------
+    sequences : list[str]
+        List of sequence names to filter
+    metadata_file : str
+        Path to the metadata associated wtih the sequences
+    query : str
+        Query string for the dataframe.
+
+    Returns
+    -------
+    list[str]:
+        List of sequence names that match the given query
+    """
+    filtered_meta_dict, _ = read_metadata(metadata_file, query)
+    return [seq for seq in sequences if seq in filtered_meta_dict]
 
 def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in fasta or VCF format")

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -95,7 +95,7 @@ def ambiguous_date_to_date_range(mydate, fmt, min_max_year=None):
     upper_bound = datetime(year=max_date['year'], month=max_date['month'], day=max_date['day']).date()
     return (lower_bound, upper_bound if upper_bound<today else today)
 
-def read_metadata(fname):
+def read_metadata(fname, query=None):
     if not fname:
         print("ERROR: read_metadata called without a filename")
         return {}, []
@@ -107,6 +107,15 @@ def read_metadata(fname):
             print("Error reading metadata file {}".format(fname))
             print(e)
             sys.exit(2)
+        if query:
+            try:
+                metadata.query(query, inplace=True)
+            except Exception as e:
+                # Would like to make this more specific, but Pandas throws multiple different
+                # errors from panda specific to python generic errors.
+                print("ERROR: Invalid query string: '{}'".format(query))
+                print(e)
+                sys.exit(2)
         meta_dict = {}
         for ii, val in metadata.iterrows():
             if hasattr(val, "strain"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,3 +106,25 @@ class TestUtils:
         with open(drm_file, "w") as fh:
             fh.write("\n".join(drm_lines))
         assert utils.read_mask_file(drm_file) == expected_sites
+
+    def test_read_metadata_with_good_query(self, tmpdir):
+        meta_fn = str(tmpdir / "metadata.tsv")
+        meta_lines = ["strain\tlocation\tquality",
+                      "c_good\tcolorado\tgood",
+                      "c_bad\tcolorado\tbad",
+                      "n_good\tnevada\tgood"]
+        with open(meta_fn, "w") as fh:
+            fh.write("\n".join(meta_lines))
+        meta_dict, _ = utils.read_metadata(meta_fn, query='quality=="good" & location=="colorado"')
+        assert len(meta_dict) == 1
+        assert "c_good" in meta_dict
+
+    def test_read_metadata_bad_query(self, tmpdir):
+        meta_fn = str(tmpdir / "metadata.tsv")
+        meta_lines = ["strain\tlocation\tquality",
+                      "c_good\tcolorado\tgood",
+                      "n_bad\tnevada\tbad",]
+        with open(meta_fn, "w") as fh:
+            fh.write("\n".join(meta_lines))
+        with pytest.raises(SystemExit):
+            utils.read_metadata(meta_fn, query='badcol=="goodval"')


### PR DESCRIPTION
### Description of proposed changes    
Add a `--query` flag to `augur filter` to allow complex querying using Pandas' DataFrame.query method. This is a rehash of #455, cleaned up and updated per comments on that thread.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #244 
Related to #455 

This is a cleanup and re-submit of #455 following conversations there.  

### Testing
Ran through the test suite and added unit tests to check this behavior.

### Thank you for contributing to Nextstrain!
You're welcome! 😊