### PR TITLE
Remove snakemake as a dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
 - fasttree
 - iqtree
 - vcftools
-- snakemake
 - pip
 - pip:
   - .

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,7 @@ setuptools.setup(
         "jsonschema >=3.0.0, ==3.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",
-        "phylo-treetime >=0.7.4, ==0.7.*",
-        "snakemake >=5.4.0, <5.11"
+        "phylo-treetime >=0.7.4, ==0.7.*"
     ],
     extras_require = {
         'full': [
@@ -72,6 +71,7 @@ setuptools.setup(
             "pytest-cov >=2.8.1, ==2.8.*",
             "pytest-mock >= 2.0.0, ==2.0.*",
             "recommonmark >=0.5.0, ==0.*",
+            "snakemake >=5.4.0, ==5.*",
             "Sphinx >=2.0.1, ==2.*",
             "sphinx-argparse >=0.2.5, ==0.*",
             "sphinx-markdown-tables >= 0.0.9",

--- a/tests/builds/add_to_alignment/Snakefile
+++ b/tests/builds/add_to_alignment/Snakefile
@@ -134,7 +134,7 @@ rule export:
         auspice = rules.all.input.auspice
     shell:
         """
-        snakemake check
+        snakemake --cores 1 check
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \

--- a/tests/builds/tb_drm/Snakefile
+++ b/tests/builds/tb_drm/Snakefile
@@ -140,7 +140,7 @@ rule seqtraits:
     output:
         drm_data = "results/drms.json",
     params:
-        count = "traits",
+        trait_count = "traits",
         label = "Drug_Resistance"
     shell:
         """
@@ -150,7 +150,7 @@ rule seqtraits:
             --translations {input.trans_align} \
             --vcf-translate-reference {input.trans_ref} \
             --features {input.drms} --output-node-data {output.drm_data} \
-            --count {params.count} --label {params.label}
+            --count {params.trait_count} --label {params.label}
         """
 
 rule export:


### PR DESCRIPTION
Technically augur does not depend on snakemake to run and including it here can
cause confusion and/or issues installing either augur or snakemake. This commit
removes the snakemake dependency and leaves the installation of snakemake up to
the user.
