### PR TITLE
Update schemas to allow display defaults for transmission lines

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -136,6 +136,9 @@
                 "branch_label": {
                     "type": "string",
                     "enum": ["clade", "aa", "none"]
+                },
+                "transmission_lines": {
+                    "type": "boolean"
                 }
             }
         },

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -225,6 +225,10 @@
                         "branch_label": {
                             "description": "What branch label should be displayed by default.",
                             "type": "string"
+                        },
+                        "transmission_lines": {
+                            "description": "Should transmission lines (if available) be displaye by default",
+                            "type": "boolean"
                         }
                     }
                 },

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -721,22 +721,16 @@ def set_display_defaults(data_json, config):
         ["geo_resolution", "geoResolution"],
         ["color_by", "colorBy"],
         ["distance_measure", "distanceMeasure"],
-        ["map_triplicate", "mapTriplicate"],
-        ["layout", "layout"],
-        ["branch_label", "branch_label"]
+        ["map_triplicate", "mapTriplicate"]
     ]
 
-    display_defaults = {}
+    for [v2_key, v1_key] in [x for x in v1_v2_keys if x[1] in defaults]:
+        deprecated("[config file] '{}' has been replaced with '{}'".format(v1_key, v2_key))
+        defaults[v2_key] = defaults[v1_key]
+        del defaults[v1_key]
 
-    for [v2_key, v1_key] in v1_v2_keys:
-        if v2_key in defaults:
-            display_defaults[v2_key] = defaults[v2_key]
-        elif v1_key in defaults:
-            deprecated("[config file] '{}' has been replaced with '{}'".format(v1_key, v2_key))
-            display_defaults[v2_key] = defaults[v1_key]
-
-    if display_defaults:
-        data_json['meta']["display_defaults"] = display_defaults
+    if defaults:
+        data_json['meta']["display_defaults"] = defaults
 
 def set_maintainers(data_json, config, cmd_line_maintainers):
     # Command-line args overwrite the config file

--- a/tests/builds/various_export_settings/Snakefile
+++ b/tests/builds/various_export_settings/Snakefile
@@ -6,6 +6,7 @@ rule all:
         time_only = "auspice/v2_time-only-tree.json",
         div_only = "auspice/v2_div-only-tree.json",
         bool_metadata = "auspice/v2_boolean-metadata.json",
+        no_transmission_lines = "auspice/v2_no-transmission-lines.json",
         default_layout = "auspice/v2_default-layout.json",
         footer = "auspice/v2_custom-footer.json",
         filter_not_color = "auspice/v2_filters-not-colors.json"
@@ -216,6 +217,25 @@ rule export_filter_which_isnt_a_coloring:
         config = "config/filters.json"
     output:
         auspice = rules.all.input.filter_not_color,
+    shell:
+        """
+        augur export v2 \
+            --tree {input.tree} \
+            --node-data {input.branch_lengths} \
+            --metadata {input.metadata} \
+            --auspice-config {input.config} \
+            --output {output.auspice}
+        """
+
+rule export_no_transmission_lines:
+    message: "Exporting (v2) with transmission lines toggled off"
+    input:
+        tree = {rules.refine_with_temporal_information.output.tree},
+        branch_lengths = {rules.refine_with_temporal_information.output.node_data},
+        metadata = {rules.parse.output.metadata},
+        config = "config/no-transmission-lines.json"
+    output:
+        auspice = rules.all.input.no_transmission_lines,
     shell:
         """
         augur export v2 \

--- a/tests/builds/various_export_settings/config/no-transmission-lines.json
+++ b/tests/builds/various_export_settings/config/no-transmission-lines.json
@@ -1,0 +1,20 @@
+{
+  "title": "transmission lines should be toggled off",
+  "colorings": [
+    {
+      "key": "num_date",
+      "title": "Sampling date",
+      "type": "continuous"
+    },
+    {
+      "key": "country",
+      "type": "ordinal"
+    }
+  ],
+  "panels": ["map"],
+  "filters": [],
+  "geo_resolutions": ["country"],
+  "display_defaults": {
+    "transmission_lines": false
+  }
+}


### PR DESCRIPTION
Schemas and test builds updated to allow one to define a display default
in a dataset JSON to toggle on/off the transmission lines (if available).
See the corresponding auspice PR https://github.com/nextstrain/auspice/pull/1152.

Additionally, the logic for setting display_defaults within `augur export v2` is
improved so that we no longer have to define the valid keys in the source code.
Invalid keys are still identified via validating the JSONs against schemas.
