### PR TITLE
Fix version-specific errors in functional tests

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -163,6 +163,9 @@ local repository.  It ends with instructions for you on how to push the release
 commit/tag/branch and how to upload the built distributions to PyPi.  You'll
 need [a PyPi account][] and [twine][] installed to do the latter.
 
+After you create a new release and before you push it to GitHub, run all tests with `./run_tests.sh` to confirm that nothing broke with the new release.
+If any tests fail, run the `./devel/rewind-release` script to undo the release, then fix the tests before trying again.
+
 [signed]: https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work
 [a PyPi account]: https://pypi.org/account/register/
 [twine]: https://pypi.org/project/twine

--- a/scripts/diff_jsons.py
+++ b/scripts/diff_jsons.py
@@ -13,6 +13,7 @@ if __name__ == "__main__":
     parser.add_argument("first_json", help="first JSON to compare")
     parser.add_argument("second_json", help="second JSON to compare")
     parser.add_argument("--significant-digits", type=int, default=5, help="number of significant digits to use when comparing numeric values")
+    parser.add_argument("--exclude-paths", nargs="+", help="list of paths to exclude from consideration when performing a diff", default=["root['generated_by']['version']"])
 
     args = parser.parse_args()
 
@@ -26,6 +27,7 @@ if __name__ == "__main__":
         deepdiff.DeepDiff(
             first_json,
             second_json,
-            significant_digits=args.significant_digits
+            significant_digits=args.significant_digits,
+            exclude_paths=args.exclude_paths
         )
     )

--- a/tests/builds/zika.t
+++ b/tests/builds/zika.t
@@ -88,7 +88,7 @@ Calculate tip frequencies from the tree.
   >  --pivot-interval 3 \
   >  --output "$TMP/out/zika_tip-frequencies.json" > /dev/null
 
-  $ diff -u "auspice/zika_tip-frequencies.json" "$TMP/out/zika_tip-frequencies.json"
+  $ diff -u --ignore-matching-lines version "auspice/zika_tip-frequencies.json" "$TMP/out/zika_tip-frequencies.json"
 
 Infer ancestral sequences from the tree.
 
@@ -99,7 +99,7 @@ Infer ancestral sequences from the tree.
   >  --output-node-data "$TMP/out/nt_muts.json" \
   >  --inference joint > /dev/null
 
-  $ diff -u "results/nt_muts.json" "$TMP/out/nt_muts.json"
+  $ diff -u --ignore-matching-lines version "results/nt_muts.json" "$TMP/out/nt_muts.json"
 
 Infer ancestral traits from the tree.
 
@@ -125,21 +125,21 @@ Translate inferred ancestral and observed nucleotide sequences to amino acid mut
 
   $ augur translate \
   >  --tree "results/tree.nwk" \
-  >  --ancestral-sequences "results/nt_muts.json" \
+  >  --ancestral-sequences "$TMP/out/nt_muts.json" \
   >  --reference-sequence "config/zika_outgroup.gb" \
   >  --output-node-data "$TMP/out/aa_muts.json" > /dev/null
 
-  $ diff -u "results/aa_muts.json" "$TMP/out/aa_muts.json"
+  $ diff -u --ignore-matching-lines version "results/aa_muts.json" "$TMP/out/aa_muts.json"
 
 Export JSON files as v1 auspice outputs.
 
   $ augur export v1 \
   >  --tree "results/tree.nwk" \
   >  --metadata "results/metadata.tsv" \
-  >  --node-data "results/branch_lengths.json" \
-  >              "results/traits.json" \
-  >              "results/nt_muts.json" \
-  >              "results/aa_muts.json" \
+  >  --node-data "$TMP/out/branch_lengths.json" \
+  >              "$TMP/out/traits.json" \
+  >              "$TMP/out/nt_muts.json" \
+  >              "$TMP/out/aa_muts.json" \
   >  --colors "config/colors.tsv" \
   >  --auspice-config "config/auspice_config_v1.json" \
   >  --output-tree "$TMP/out/v1_zika_tree.json" \
@@ -147,7 +147,6 @@ Export JSON files as v1 auspice outputs.
   >  --output-sequence "$TMP/out/v1_zika_seq.json" > /dev/null
 
   $ augur validate export-v1 "$TMP/out/v1_zika_meta.json" "$TMP/out/v1_zika_tree.json" > /dev/null
-  $ diff -u "auspice/v1_zika_tree.json" "$TMP/out/v1_zika_tree.json"
 
 Compare auspice metadata files, but ignore the "updated" field since this changes with the date the export command is run.
 
@@ -158,10 +157,10 @@ Export JSON files as v2 auspice outputs.
   $ augur export v2 \
   >  --tree "results/tree.nwk" \
   >  --metadata "results/metadata.tsv" \
-  >  --node-data "results/branch_lengths.json" \
-  >              "results/traits.json" \
-  >              "results/nt_muts.json" \
-  >              "results/aa_muts.json" \
+  >  --node-data "$TMP/out/branch_lengths.json" \
+  >              "$TMP/out/traits.json" \
+  >              "$TMP/out/nt_muts.json" \
+  >              "$TMP/out/aa_muts.json" \
   >  --colors "config/colors.tsv" \
   >  --auspice-config "config/auspice_config_v2.json" \
   >  --output "$TMP/out/v2_zika.json" \
@@ -169,10 +168,6 @@ Export JSON files as v2 auspice outputs.
   >  --panels tree map entropy frequencies > /dev/null
 
   $ augur validate export-v2 "$TMP/out/v2_zika.json" > /dev/null
-
-Ignore the date the auspice output was "updated", but consider all other differences.
-
-  $ diff -u --ignore-matching-lines updated "auspice/v2_zika.json" "$TMP/out/v2_zika.json"
 
 Switch back to the original directory where testing started.
 


### PR DESCRIPTION
The functional tests based on an example Zika build broke when upgrading augur
to a new major version number. The errors were all related to unexpected diff
outputs where the expected JSON output contained a "generated_by" entry with the
old version number and the actual outputs contained the new version number.

This commit makes the following changes to address these errors now and
hopefully prevent them from occurring again after the next major version
release:

1. Ignore "version" keys in diffs of JSON outputs when using UNIX diff

2. Ignore the entire "generated_by" entry of JSONs using diff_jsons.py

3. Run augur commands that expect JSON input with the newly generated JSONs in
the Cram temporary directory instead of the expected JSON outputs used for
earlier steps. This change will force the input JSONs to be generated by the
same augur version as the command using them as inputs.

4. Stop diffing auspice JSON outputs. As long as these files validate by the
auspice JSON schemas, their specific outputs are less relevant.

This commit also adds a note to the release instructions in the DEV_DOCS about
running tests after creating a release and before making it public to catch
these kinds of mistakes in the future.