### PR TITLE
in read_metadata update pandas series object name to reflect name col…

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -123,6 +123,7 @@ def read_metadata(fname, query=None):
                     raise ValueError("Duplicate strain '{}'".format(val.strain))
                 meta_dict[val.strain] = val.to_dict()
             elif hasattr(val, "name"):
+                val = val.rename(val["name"])
                 if val.name in meta_dict:
                     raise ValueError("Duplicate name '{}'".format(val.name))
                 meta_dict[val.name] = val.to_dict()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,6 +107,24 @@ class TestUtils:
             fh.write("\n".join(drm_lines))
         assert utils.read_mask_file(drm_file) == expected_sites
 
+    def test_read_metadata_no_filename(self):
+        expected_result = {}, []
+        assert utils.read_metadata('') == expected_result
+
+    def test_read_metadata_bad_filename(self, tmpdir):
+        bad_filename = "incorrect_path.tsv"
+        expected_result = {}, []
+        
+        meta_fn = str(tmpdir / "metadata.tsv")
+        meta_lines = ["strain\tlocation\tquality",
+                      "c_good\tcolorado\tgood",
+                      "n_bad\tnevada\tbad",]
+        with open(meta_fn, "w") as fh:
+            fh.write("\n".join(meta_lines))
+        
+        utils.read_metadata(bad_filename, query='quality=="good" & location=="colorado"')
+        assert utils.read_metadata('') == expected_result
+
     def test_read_metadata_with_good_query(self, tmpdir):
         meta_fn = str(tmpdir / "metadata.tsv")
         meta_lines = ["strain\tlocation\tquality",
@@ -128,3 +146,43 @@ class TestUtils:
             fh.write("\n".join(meta_lines))
         with pytest.raises(SystemExit):
             utils.read_metadata(meta_fn, query='badcol=="goodval"')
+    
+    def test_read_metadata_duplicate_strain(self, tmpdir):
+        meta_fn = str(tmpdir / "metadata.tsv")
+        meta_lines = ["strain\tlocation\tquality",
+                      "c_good\tcolorado\tgood",
+                      "c_bad\tcolorado\tbad",
+                      "c_bad\tcolorado\tbad",
+                      "n_good\tnevada\tgood"]
+        with open(meta_fn, "w") as fh:
+            fh.write("\n".join(meta_lines))
+        with pytest.raises(ValueError): 
+            utils.read_metadata(meta_fn, query='location=="colorado"')
+
+    def test_read_metadata_duplicate_name(self, tmpdir):
+        meta_fn = str(tmpdir / "metadata.tsv")
+        meta_lines = ["name\tlocation\tquality",
+                      "c_good\tcolorado\tgood",
+                      "c_bad\tcolorado\tbad",
+                      "c_bad\tcolorado\tbad",
+                      "n_good\tnevada\tgood"]
+        with open(meta_fn, "w") as fh:
+            fh.write("\n".join(meta_lines))
+        
+        with pytest.raises(ValueError): 
+            utils.read_metadata(meta_fn)
+        
+    def test_read_metadata_no_strain_or_name(self, tmpdir):
+        expected_result = {}, []
+        
+        meta_fn = str(tmpdir / "metadata.tsv")
+        meta_lines = ["location\tquality",
+                      "colorado\tgood",
+                      "colorado\tbad",
+                      "colorado\tbad",
+                      "nevada\tgood"]
+        with open(meta_fn, "w") as fh:
+            fh.write("\n".join(meta_lines))
+        
+        assert utils.read_metadata('') == expected_result
+


### PR DESCRIPTION
…umn value from metadata

### Description of proposed changes    
Util function read_metadata should throw a value error if the column titled "name" has duplicate values. 

The pandas series object was using it's own default name attribute to check for duplicates. This name was being set to the index of the row instead of the value under the name column.

### Related issue(s)  
Fixes #563 - Metadata file with duplicate values in "name" column does not throw an error.

### Testing
What steps should be taken to test the changes you've proposed?  

1. Create a metadata file with column titled name (instead of a column titled strain) 

2. Add rows to the metadata file such that the name column has duplicate values (rows 0,1 have same value for name). I modified data/metadata.tsv in the zika tutorial.

3. Run augur filter using the metadata file created.
ex: augur filter --sequences data/sequences.fasta --metadata data/metadata_name.tsv --exclude config/dropped_strains.txt --output results/filtered.fasta --group-by country year month --sequences-per-group 20

4. See that error is now thrown. 

### If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  
Unit tests for read_metadata have been added/expanded in test_utils.py

### Thank you for contributing to Nextstrain!
