### PR TITLE
[tree] allow VCF input without exclude-sites arg

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -214,7 +214,7 @@ def write_out_informative_fasta(compress_seq, alignment, stripFile=None):
     positions = compress_seq['positions']
 
     #If want to exclude sites from initial treebuild, read in here
-    strip_pos = load_mask_sites(stripFile)
+    strip_pos = load_mask_sites(stripFile) if stripFile else []
 
     #Get sequence names
     seqNames = list(sequences.keys())


### PR DESCRIPTION
Previous behavior expected that any VCF input to `augur tree` would have a (bed-like) exclude-sites file, however this is should not be necessary. This commit allows such functionality, resulting
in a FASTA for tree-building with no positions removed.

P.S. If you wish to achieve this behavior before this PR is merged you can do so by creating an empty file without a `.bed` extension and passing that to `--exclude-sites`

### Testing
No testing implemented.
Tested locally by removing the `--exclude-sites {input.sites}` argument from [this test](https://github.com/nextstrain/augur/blob/master/tests/builds/tb/Snakefile#L73).

