### PR TITLE
Match bounds for observations in frequency estimator classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* frequencies: Avoid interpolation of a single data point during frequency estimation with sparse data [#569][]
+
+[#569]: https://github.com/nextstrain/augur/pull/569
 
 ## 8.0.0 (8 June 2020)
 

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -214,7 +214,7 @@ class frequency_estimator(object):
 
         self.pivots = make_pivots(pivots, self.tps)
 
-        good_tps = (self.tps>self.pivots[0])&(self.tps<self.pivots[-1])
+        good_tps = (self.tps>=self.pivots[0])&(self.tps<self.pivots[-1])
         self.tps = self.tps[good_tps]
         self.obs = self.obs[good_tps]
 


### PR DESCRIPTION
## Description of proposed changes

Resolves an edge case bug where there are enough observations to pass the upstream filters of the `freq_est_clipped` class but not enough observations to pass the `frequency_estimator` class's more restrictive lower bound. This bug manifests as an attempt to interpolate with a single observation.

In `freq_est_clipped`, the constructor checks for “good” timepoint observations by requiring these observations to occur within the bounds of the pivots. Observations are valid if they are equal to or greater than the first pivot ([line 346 of `frequency_estimators.py`](https://github.com/nextstrain/augur/blob/574758c/augur/frequency_estimators.py#L346)).

```python
self.good_tps = (self.tps>=tps_lower_cutoff)&(self.tps<tps_upper_cutoff)&(self.tps<self.pivots[-1])&(self.tps>=self.pivots[0])
```

If too few “good” observations exist, the constructor returns None. If enough exist, the constructor instantiates a `frequency_estimator` object that tries to perform the actual smoothed estimation. This class’s constructor also checks for “good” observations, but it does not exit when there are too few observations because this has presumably happened upstream. However, the check for “good” observations does not allow these observations to have values equal to the first pivot:

```python
good_tps = (self.tps>self.pivots[0])&(self.tps<self.pivots[-1])
```

The more restrictive filter at the `frequency_estimator` step can produce cases where the data pass filters from `freq_est_clipped`, some of these data fail the `frequency_estimator` filters, and then there are not enough data points to perform the smoothed estimation.

This PR addresses this issue by changing the `frequency_estimator` definition of “good” observations to match the definition in the upstream `freq_est_clipped` class.

## Testing

I've tested this with recent seasonal flu data where the issue originally emerged and confirmed it works as expected.