### PR TITLE
Keep log files produced by augur tree

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -70,7 +70,6 @@ def build_raxml(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_args
         if clean_up:
             os.remove("RAxML_bestTree.%s"%(random_string))
             os.remove("RAxML_info.%s"%(random_string))
-            os.remove("RAxML_log.%s"%(random_string))
             os.remove("RAxML_parsimonyTree.%s"%(random_string))
             os.remove("RAxML_result.%s"%(random_string))
 
@@ -118,8 +117,6 @@ def build_fasttree(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_a
     try:
         run_shell_command(cmd, raise_errors = True, extra_env = extra_env)
         T = Phylo.read(out_file, 'newick')
-        if clean_up:
-            os.remove(log_file)
     except:
         print("ERROR: TREE BUILDING FAILED")
         if os.path.isfile(log_file):
@@ -189,11 +186,10 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
             if substitution_model.lower() == 'none':
                 shutil.copyfile(log_file, out_file.replace(out_file.split('/')[-1],"iqtree.log"))
 
-            for f in [log_file, tmp_aln_file]:
-                if os.path.isfile(f):
-                    os.remove(f)
+            if os.path.isfile(tmp_aln_file):
+                os.remove(tmp_aln_file)
 
-            for ext in [".bionj",".ckp.gz",".iqtree",".log",".mldist",".model.gz",".treefile",".uniqueseq.phy",".model"]:
+            for ext in [".bionj",".ckp.gz",".iqtree",".mldist",".model.gz",".treefile",".uniqueseq.phy",".model"]:
                 if os.path.isfile(tmp_aln_file + ext):
                     os.remove(tmp_aln_file + ext)
     except:

--- a/tests/builds/zika.t
+++ b/tests/builds/zika.t
@@ -10,7 +10,7 @@ Running from the test data directory allows us to use relative paths that won't 
 
 Parse a FASTA whose defline contains metadata into separate sequence and metadata files.
 
-  $ augur parse \
+  $ ../../../bin/augur parse \
   >   --sequences "data/zika.fasta" \
   >   --output-sequences "$TMP/out/sequences.fasta" \
   >   --output-metadata "$TMP/out/metadata.tsv" \
@@ -21,7 +21,7 @@ Parse a FASTA whose defline contains metadata into separate sequence and metadat
 
 Filter sequences by a minimum date and an exclusion list and only keep one sequence per country, year, and month.
 
-  $ augur filter \
+  $ ../../../bin/augur filter \
   >   --sequences "results/sequences.fasta" \
   >   --metadata "results/metadata.tsv" \
   >   --exclude "config/dropped_strains.txt" \
@@ -35,7 +35,7 @@ Filter sequences by a minimum date and an exclusion list and only keep one seque
 
 Align filtered sequences to a specific reference sequence and fill any gaps.
 
-  $ augur align \
+  $ ../../../bin/augur align \
   >  --sequences "results/filtered.fasta" \
   >  --reference-sequence "config/zika_outgroup.gb" \
   >  --output "$TMP/out/aligned.fasta" \
@@ -45,7 +45,7 @@ Align filtered sequences to a specific reference sequence and fill any gaps.
 
 Build a tree from the multiple sequence alignment.
 
-  $ augur tree \
+  $ ../../../bin/augur tree \
   >  --alignment "results/aligned.fasta" \
   >  --output "$TMP/out/tree_raw.nwk" \
   >  --method iqtree \
@@ -54,9 +54,15 @@ Build a tree from the multiple sequence alignment.
   $ python3 "$TESTDIR/../../scripts/diff_trees.py" "results/tree_raw.nwk" "$TMP/out/tree_raw.nwk" --significant-digits 5
   {}
 
+Confirm that tree log file exists.
+
+  $ test -e "results/aligned-delim.iqtree.log"
+  $ echo $?
+  0
+
 Build a time tree from the existing tree topology, the multiple sequence alignment, and the strain metadata.
 
-  $ augur refine \
+  $ ../../../bin/augur refine \
   >  --tree "results/tree_raw.nwk" \
   >  --alignment "results/aligned.fasta" \
   >  --metadata "results/metadata.tsv" \
@@ -81,7 +87,7 @@ Branch lengths and other annotations like dates are too stochastic across runs t
 
 Calculate tip frequencies from the tree.
 
-  $ augur frequencies \
+  $ ../../../bin/augur frequencies \
   >  --method kde \
   >  --tree "results/tree.nwk" \
   >  --metadata "results/metadata.tsv" \
@@ -92,7 +98,7 @@ Calculate tip frequencies from the tree.
 
 Infer ancestral sequences from the tree.
 
-  $ augur ancestral \
+  $ ../../../bin/augur ancestral \
   >  --tree "results/tree.nwk" \
   >  --alignment "results/aligned.fasta" \
   >  --infer-ambiguous \
@@ -103,7 +109,7 @@ Infer ancestral sequences from the tree.
 
 Infer ancestral traits from the tree.
 
-  $ augur traits \
+  $ ../../../bin/augur traits \
   >  --tree "results/tree.nwk" \
   >  --weights "config/trait_weights.csv" \
   >  --metadata "results/metadata.tsv" \
@@ -123,7 +129,7 @@ See augur issue 541 (https://github.com/nextstrain/augur/issues/541) for more de
 
 Translate inferred ancestral and observed nucleotide sequences to amino acid mutations.
 
-  $ augur translate \
+  $ ../../../bin/augur translate \
   >  --tree "results/tree.nwk" \
   >  --ancestral-sequences "$TMP/out/nt_muts.json" \
   >  --reference-sequence "config/zika_outgroup.gb" \
@@ -133,7 +139,7 @@ Translate inferred ancestral and observed nucleotide sequences to amino acid mut
 
 Export JSON files as v1 auspice outputs.
 
-  $ augur export v1 \
+  $ ../../../bin/augur export v1 \
   >  --tree "results/tree.nwk" \
   >  --metadata "results/metadata.tsv" \
   >  --node-data "$TMP/out/branch_lengths.json" \
@@ -146,7 +152,7 @@ Export JSON files as v1 auspice outputs.
   >  --output-meta "$TMP/out/v1_zika_meta.json" \
   >  --output-sequence "$TMP/out/v1_zika_seq.json" > /dev/null
 
-  $ augur validate export-v1 "$TMP/out/v1_zika_meta.json" "$TMP/out/v1_zika_tree.json" > /dev/null
+  $ ../../../bin/augur validate export-v1 "$TMP/out/v1_zika_meta.json" "$TMP/out/v1_zika_tree.json" > /dev/null
 
 Compare auspice metadata files, but ignore the "updated" field since this changes with the date the export command is run.
 
@@ -154,7 +160,7 @@ Compare auspice metadata files, but ignore the "updated" field since this change
 
 Export JSON files as v2 auspice outputs.
 
-  $ augur export v2 \
+  $ ../../../bin/augur export v2 \
   >  --tree "results/tree.nwk" \
   >  --metadata "results/metadata.tsv" \
   >  --node-data "$TMP/out/branch_lengths.json" \
@@ -167,7 +173,7 @@ Export JSON files as v2 auspice outputs.
   >  --title 'Real-time tracking of Zika virus evolution -- v2 JSON' \
   >  --panels tree map entropy frequencies > /dev/null
 
-  $ augur validate export-v2 "$TMP/out/v2_zika.json" > /dev/null
+  $ ../../../bin/augur validate export-v2 "$TMP/out/v2_zika.json" > /dev/null
 
 Switch back to the original directory where testing started.
 


### PR DESCRIPTION
Removes all lines where tree builders remove log files during the clean up step
such that users can inspect logs after any run (successful or
unsuccessful). Updates functional test for the Zika build to confirm that the
log file exists as expected after running.

This commit also updates the functional tests for the Zika build such they
always run the local augur executable (i.e., the one relative to the test
directory). This change is most helpful when running tests on a local copy of
the repository where a global augur install might already exist.