### PR TITLE
Sync and deduplicate installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.com/nextstrain/augur.svg?branch=master)](https://travis-ci.com/nextstrain/augur)
 [![PyPI version](https://badge.fury.io/py/nextstrain-augur.svg)](https://pypi.org/project/nextstrain-augur/)
-[![Documentation Status](https://readthedocs.org/projects/nextstrain-augur/badge/?version=latest)](https://nextstrain-augur.readthedocs.io/en/stable/?badge=latest)     
+[![Documentation Status](https://readthedocs.org/projects/nextstrain-augur/badge/?version=latest)](https://nextstrain-augur.readthedocs.io/en/stable/?badge=latest)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 ## About Nextstrain
@@ -12,6 +12,7 @@ Our goal is to aid epidemiological understanding and improve outbreak response.
 Resulting data and inferences are available live at the website [nextstrain.org](https://nextstrain.org).
 
 ## About Augur
+
 *Definition: One held to foretell events by omens.*
 
 Augur is the bioinformatics toolkit we use to track evolution from sequence and serological data.
@@ -19,52 +20,19 @@ It provides a collection of commands which are designed to be composable into la
 
 The output of augur is a series of JSONs that can be used to visualize your results using [Auspice](https://github.com/nextstrain/auspice).
 
-
 ## Documentation
-* [Overview of how Augur fits together with other Nextstrain tools](https://nextstrain.org/docs/getting-started/introduction#open-source-tools-for-the-community)  
-* [Overview of Augur usage](https://nextstrain.org/docs/bioinformatics/introduction-to-augur)  
-* [Technical documentation for Augur](https://nextstrain-augur.readthedocs.io/en/stable/installation/installation.html)  
-* [Contributor guide](https://github.com/nextstrain/.github/blob/master/CONTRIBUTING.md)  
-* [Project board with available issues](https://github.com/orgs/nextstrain/projects/6)   
-* [Developer docs for Augur](./DEV_DOCS.md)  
 
+* [Overview of how Augur fits together with other Nextstrain tools](https://nextstrain.org/docs/getting-started/introduction#open-source-tools-for-the-community)
+* [Overview of Augur usage](https://nextstrain.org/docs/bioinformatics/introduction-to-augur)
+* [Technical documentation for Augur](https://nextstrain-augur.readthedocs.io/en/stable/installation/installation.html)
+* [Contributor guide](https://github.com/nextstrain/.github/blob/master/CONTRIBUTING.md)
+* [Project board with available issues](https://github.com/orgs/nextstrain/projects/6)
+* [Developer docs for Augur](./DEV_DOCS.md)
 
+## Quickstart
 
-# Quickstart
-
-## Installation
-
-Augur is written in Python 3 and requires at least Python 3.6.
-
-To install, run:
-```bash
-    pip install nextstrain-augur[full]
-```
-
-Augur uses some common external bioinformatics programs which you'll need to install to have a fully functioning toolkit:
-
-* `augur align` requires [mafft](https://mafft.cbrc.jp/alignment/software/)
-
-* `augur tree` requires at least one of:
-   - [IQ-TREE](http://www.iqtree.org/) (used by default)
-   - [RAxML](https://sco.h-its.org/exelixis/web/software/raxml/) (optional alternative)
-   - [FastTree](http://www.microbesonline.org/fasttree/) (optional alternative)
-
-* Bacterial data (or any VCF usage) requires [vcftools](https://vcftools.github.io/)
-
-On macOS, you can install these external programs using Homebrew with:
-```bash
-brew tap brewsci/bio
-brew install mafft iqtree raxml fasttree vcftools
-```
-
-On Debian/Ubuntu, you can install them via:
-
-```bash
-sudo apt install mafft iqtree raxml fasttree vcftools
-```
-
-[For more extensive installation instructions, please see the technical docs](https://nextstrain-augur.readthedocs.io/en/stable/installation/installation.html)
+[Follow instructions to install augur](https://nextstrain-augur.readthedocs.io/en/stable/installation/installation.html).
+Try out an analysis of real virus data by [completing the Zika tutorial](https://nextstrain.org/docs/tutorials/zika).
 
 ## Basic Usage
 

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -29,6 +29,7 @@ Augur uses some common external bioinformatics programs which you'll need to ins
 
 On macOS, you can install these external programs using [Homebrew](https://brew.sh/) with:
 
+    brew tap brewsci/bio
     brew install mafft iqtree raxml fasttree vcftools
 
 On Debian/Ubuntu, you can install them via:


### PR DESCRIPTION
Replaces installation instructions from the README with a link to the full
installations instructions in the docs. Also, adds a link out to the Zika
tutorial to flesh out the "quickstart". Updates the full installation
instructions with a missing brew tap command that was adding to the README in an
earlier commit.

Resolves #519