### PR TITLE
Metadata delimiter autodetection

### DIFF
--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -310,7 +310,7 @@ def get_root_sequence(root_node, ref=None, translations=None):
 def add_core_args(parser):
     core = parser.add_argument_group("REQUIRED")
     core.add_argument('--tree','-t', required=True, help="tree to perform trait reconstruction on")
-    core.add_argument('--metadata', required=True, help="tsv file with sequence meta data")
+    core.add_argument('--metadata', required=True, metavar="FILE", help="sequence metadata, as CSV or TSV")
     core.add_argument('--node-data', required=True, nargs='+', help="JSON files with meta data for each node")
     core.add_argument('--output-tree', help="JSON file name that is passed on to auspice (e.g., zika_tree.json).")
     core.add_argument('--output-meta', help="JSON file name that is passed on to auspice (e.g., zika_meta.json).")

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -734,7 +734,7 @@ def register_arguments_v2(subparsers):
     optional_inputs = v2.add_argument_group(
         title="OPTIONAL INPUT FILES"
     )
-    optional_inputs.add_argument('--metadata', metavar="TSV", help="Additional metadata for strains in the tree")
+    optional_inputs.add_argument('--metadata', metavar="FILE", help="Additional metadata for strains in the tree, as CSV or TSV")
     optional_inputs.add_argument('--colors', metavar="TSV", help="Custom color definitions")
     optional_inputs.add_argument('--lat-longs', metavar="TSV", help="Latitudes and longitudes for geography traits (overrides built in mappings)")
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -88,7 +88,7 @@ def filter_by_query(sequences, metadata_file, query):
 
 def register_arguments(parser):
     parser.add_argument('--sequences', '-s', required=True, help="sequences in fasta or VCF format")
-    parser.add_argument('--metadata', required=True, help="metadata associated with sequences")
+    parser.add_argument('--metadata', required=True, metavar="FILE", help="sequence metadata, as CSV or TSV")
     parser.add_argument('--min-date', type=numeric_date, help="minimal cutoff for date; may be specified as an Augur-style numeric date (with the year as the integer part) or YYYY-MM-DD")
     parser.add_argument('--max-date', type=numeric_date, help="maximal cutoff for date; may be specified as an Augur-style numeric date (with the year as the integer part) or YYYY-MM-DD")
     parser.add_argument('--min-length', type=int, help="minimal length of the sequences")

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -16,8 +16,8 @@ def register_arguments(parser):
     # Shared arguments
     parser.add_argument('--method', choices=["diffusion", "kde"], required=True,
                         help="method by which frequencies should be estimated")
-    parser.add_argument('--metadata', type=str, required=True,
-                        help="tab-delimited metadata including dates for given samples")
+    parser.add_argument('--metadata', type=str, required=True, metavar="FILE",
+                        help="metadata including dates for given samples, as CSV or TSV")
     parser.add_argument('--regions', type=str, nargs='+', default=['global'],
                         help="region to subsample to")
     parser.add_argument("--pivot-interval", type=int, default=3,

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -90,7 +90,7 @@ def collect_node_data(T, attributes):
 def register_arguments(parser):
     parser.add_argument('--alignment', '-a', help="alignment in fasta or VCF format")
     parser.add_argument('--tree', '-t', required=True, help="prebuilt Newick")
-    parser.add_argument('--metadata', type=str, help="tsv/csv table with meta data for sequences")
+    parser.add_argument('--metadata', type=str, metavar="FILE", help="sequence metadata, as CSV or TSV")
     parser.add_argument('--output-tree', type=str, help='file name to write tree to')
     parser.add_argument('--output-node-data', type=str, help='file name to write branch lengths as node data')
     parser.add_argument('--timetree', action="store_true", help="produce timetree using treetime")

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -105,7 +105,7 @@ def register_arguments(parser):
         subcommand argument parser
     """
     parser.add_argument('--tree', '-t', required=True, help="tree to perform trait reconstruction on")
-    parser.add_argument('--metadata', required=True, help="tsv/csv table with meta data")
+    parser.add_argument('--metadata', required=True, metavar="FILE", help="table with metadata, as CSV or TSV")
     parser.add_argument('--weights', required=False, help="tsv/csv table with equilibrium probabilities of discrete states")
     parser.add_argument('--columns', required=True, nargs='+',
                         help='metadata fields to perform discrete reconstruction on')

--- a/augur/util_support/metadata_file.py
+++ b/augur/util_support/metadata_file.py
@@ -90,6 +90,7 @@ class MetadataFile:
     def parse_file(self):
         return pandas.read_csv(
             self.fname,
-            sep="\t" if self.fname.endswith("tsv") else ",",
+            sep=None,  # csv.Sniffer will automatically detect sep
+            engine="python",
             skipinitialspace=True,
         ).fillna("")

--- a/tests/util_support/test_metadata_file.py
+++ b/tests/util_support/test_metadata_file.py
@@ -9,7 +9,7 @@ import pytest
 def prepare_file(tmpdir):
     def _prepare_file(contents):
         with open(f"{tmpdir}/metadata.txt", "w") as file:
-            file.write(re.sub("^\s*", "", contents))
+            file.write(re.sub(r"^\s*", "", contents))
 
     return _prepare_file
 
@@ -113,15 +113,7 @@ class TestMetadataFile:
 
         records, columns = MetadataFile(f"{tmpdir}/metadata.txt").read()
         assert records == {
-            "strainA": {
-                "strain": "strainA",
-                "location": "colorado",
-                "quality": "good",
-            },
-            "strainB": {
-                "strain": "strainB",
-                "location": "nevada",
-                "quality": "good",
-            },
+            "strainA": {"strain": "strainA", "location": "colorado", "quality": "good"},
+            "strainB": {"strain": "strainB", "location": "nevada", "quality": "good"},
         }
         assert list(columns) == ["strain", "location", "quality"]

--- a/tests/util_support/test_metadata_file.py
+++ b/tests/util_support/test_metadata_file.py
@@ -1,3 +1,5 @@
+import re
+
 from augur.util_support.metadata_file import MetadataFile
 
 import pytest
@@ -7,7 +9,7 @@ import pytest
 def prepare_file(tmpdir):
     def _prepare_file(contents):
         with open(f"{tmpdir}/metadata.txt", "w") as file:
-            file.write(contents)
+            file.write(re.sub("^\s*", "", contents))
 
     return _prepare_file
 
@@ -99,3 +101,27 @@ class TestMetadataFile:
 
         with pytest.raises(ValueError, match="does not contain"):
             MetadataFile(f"{tmpdir}/metadata.txt", None).read()
+
+    def test_metadata_delimiter_autodetect(self, tmpdir, prepare_file):
+        prepare_file(
+            """
+            strain\tlocation\tquality
+            strainA\tcolorado\tgood
+            strainB\tnevada\tgood
+            """
+        )
+
+        records, columns = MetadataFile(f"{tmpdir}/metadata.txt").read()
+        assert records == {
+            "strainA": {
+                "strain": "strainA",
+                "location": "colorado",
+                "quality": "good",
+            },
+            "strainB": {
+                "strain": "strainB",
+                "location": "nevada",
+                "quality": "good",
+            },
+        }
+        assert list(columns) == ["strain", "location", "quality"]


### PR DESCRIPTION
### Description of proposed changes    
Automatically detect the delimiter in metadata files, using Pandas' built-in functionality (which relies on the Python parsing engine and `csv.Sniffer`).

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #574

### Testing
Try CSV and TSV metadata files. Unit tests included.