### PR TITLE
Mask: Add --mask-invalid flag to mask invalid nucleotides from FASTA files

### DIFF
--- a/augur/mask.py
+++ b/augur/mask.py
@@ -108,7 +108,7 @@ def mask_fasta(mask_sites, in_file, out_file, mask_from_beginning=0, mask_from_e
                 beginning, end = sequence_length, 0
             seq = str(record.seq)[beginning:-end or None]
             if mask_invalid:
-                seq = str(nuc if nuc in VALID_NUCLEOTIDES else "N" for nuc in seq)
+                seq = "".join(nuc if nuc in VALID_NUCLEOTIDES else "N" for nuc in seq)
             sequence = MutableSeq("N" * beginning + seq + "N" * end)
             # Replace all excluded sites with Ns.
             for site in mask_sites:

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -122,6 +122,7 @@ def register_arguments(parser):
     parser.add_argument('--mask', dest="mask_file", required=False, help="locations to be masked in either BED file format, DRM format, or one 1-indexed site per line.")
     parser.add_argument('--mask-from-beginning', type=int, default=0, help="FASTA Only: Number of sites to mask from beginning")
     parser.add_argument('--mask-from-end', type=int, default=0, help="FASTA Only: Number of sites to mask from end")
+    parser.add_argument('--mask-invalid', action='store_true', help="FASTA Only: Mask invalid nucleotides")
     parser.add_argument("--mask-sites", nargs='+', type = int,  help="1-indexed list of sites to mask")
     parser.add_argument('--output', '-o', help="output file")
     parser.add_argument('--no-cleanup', dest="cleanup", action="store_false",
@@ -153,8 +154,8 @@ def run(args):
         if os.path.getsize(args.mask_file) == 0:
             print("ERROR: {} is an empty file.".format(args.mask_file))
             sys.exit(1)
-    if not any((args.mask_file, args.mask_from_beginning, args.mask_from_end, args.mask_sites)):
-        print("No masking sites provided. Must include one of --mask, --mask-from-beginning, --mask-from-end, or --mask-sites")
+    if not any((args.mask_file, args.mask_from_beginning, args.mask_from_end, args.mask_sites, args.mask_invalid)):
+        print("No masking sites provided. Must include one of --mask, --mask-from-beginning, --mask-from-end, --mask-invalid, or --mask-sites")
         sys.exit(1)
 
     mask_sites = set()
@@ -173,14 +174,15 @@ def run(args):
                                 "masked_" + os.path.basename(args.sequences))
 
     if is_vcf(args.sequences):
-        if args.mask_from_beginning or args.mask_from_end:
-            print("Cannot use --mask-from-beginning or --mask-from-end with VCF files!")
+        if args.mask_from_beginning or args.mask_from_end or args.mask_invalid:
+            print("Cannot use --mask-from-beginning, --mask-from-end, or --mask-invalid with VCF files!")
             sys.exit(1)
         mask_vcf(mask_sites, args.sequences, out_file, args.cleanup)
     else:
         mask_fasta(mask_sites, args.sequences, out_file, 
                    mask_from_beginning=args.mask_from_beginning,
-                   mask_from_end=args.mask_from_end)
+                   mask_from_end=args.mask_from_end,
+                   mask_invalid=args.mask_invalid)
 
     if args.output is None:
         copyfile(out_file, args.sequences)

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -779,3 +779,8 @@ def load_mask_sites(mask_file):
         mask_sites = read_mask_file(mask_file)
     print("%d masking sites read from %s" % (len(mask_sites), mask_file))
     return mask_sites
+
+VALID_NUCLEOTIDES = { # http://reverse-complement.com/ambiguity.html
+    "A", "G", "C", "T", "U", "N", "R", "Y", "S", "W", "K", "M", "B", "V", "D", "H", "-",
+    "a", "g", "c", "t", "u", "n", "r", "y", "s", "w", "k", "m", "b", "v", "d", "h", "-"
+}

--- a/tests/functional/mask.t
+++ b/tests/functional/mask.t
@@ -6,7 +6,7 @@ Integration tests for augur mask.
 Try masking a VCF without any specified mask.
 
   $ ${AUGUR} mask --sequences mask/variants.vcf
-  No masking sites provided. Must include one of --mask, --mask-from-beginning, --mask-from-end, or --mask-sites
+  No masking sites provided. Must include one of --mask, --mask-from-beginning, --mask-from-end, --mask-invalid, or --mask-sites
   [1]
 
 Mask a VCF with a BED file and no specified output file.
@@ -32,7 +32,7 @@ Mask a VCF with a BED file and a specified output file.
 Try masking sequences without any specified mask.
 
   $ ${AUGUR} mask --sequences mask/sequences.fasta
-  No masking sites provided. Must include one of --mask, --mask-from-beginning, --mask-from-end, or --mask-sites
+  No masking sites provided. Must include one of --mask, --mask-from-beginning, --mask-from-end, --mask-invalid, or --mask-sites
   [1]
 
 Mask sequences with a BED file and no specified output file.
@@ -89,6 +89,19 @@ Mask a specific list of sites and also mask one base from the beginning and the 
   $ cat "$TMP/masked.fasta"
   >sequence_1
   NTNNTN
+  $ rm -f "$TMP/masked.fasta"
+
+Mask invalid nucleotides
+
+  $ ${AUGUR} mask \
+  >  --sequences mask/invalidnucleotide.fasta \
+  >  --mask-invalid \
+  >  --output "$TMP/masked.fasta"
+  Removing masked sites from FASTA file.
+
+  $ cat "$TMP/masked.fasta"
+  >sequence_1
+  ATCGNNNN
   $ rm -f "$TMP/masked.fasta"
 
   $ popd > /dev/null

--- a/tests/functional/mask/invalidnucleotide.fasta
+++ b/tests/functional/mask/invalidnucleotide.fasta
@@ -1,2 +1,2 @@
 >sequence_1
-ATCGNNNN
+ATCG1234

--- a/tests/functional/mask/invalidnucleotide.fasta
+++ b/tests/functional/mask/invalidnucleotide.fasta
@@ -1,0 +1,2 @@
+>sequence_1
+ATCGNNNN

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -342,7 +342,7 @@ class TestMask:
 
     def test_run_fasta_mask_from_beginning_or_end(self, fasta_file, out_file, argparser, mp_context):
         args = argparser("-s %s -o %s --mask-from-beginning 2 --mask-from-end 3" % (fasta_file, out_file))
-        def check_mask_from(*args, mask_from_beginning=0, mask_from_end=0):
+        def check_mask_from(*args, mask_from_beginning=0, mask_from_end=0, **kwargs):
             assert mask_from_beginning == 2
             assert mask_from_end == 3
         mp_context.setattr(mask, "mask_fasta", check_mask_from)
@@ -392,6 +392,15 @@ class TestMask:
                     assert site == "N"
                 else:
                     assert site == reference[idx]
+
+    def test_e2e_fasta_mask_invalid(self, fasta_file, out_file, sequences, argparser):
+        args = argparser("-s %s -o %s --mask-invalid" % (fasta_file, out_file))
+        mask.run(args)
+        output = SeqIO.parse(out_file, "fasta")
+        for record in output:
+            reference = str(sequences[record.id].seq)
+            for idx, site in enumerate(reference):
+                assert record.seq[idx] == site if site in VALID_NUCLEOTIDES else "N"
 
     def test_e2e_vcf_minimal(self, vcf_file, bed_file, argparser):
         args = argparser("-s %s --mask %s" % (vcf_file, bed_file))


### PR DESCRIPTION
### Description of proposed changes    
Add `--mask-invalid` flag to `augur mask`

Also adds a "VALID_NUCLEOTIDES" set to utils. I see valid nucleotide testing done in filter.py as well, but chose not to address that in this PR.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #72  

### Testing
Added new unit and e2e tests. Updated CRAM

### Thank you for contributing to Nextstrain!
You're welcome!
