### PR TITLE
pass -nt AUTO -ntmax {nthreads} to IQ-Tree

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -160,11 +160,19 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
         "-me",    "0.05"
     ]
 
+    # specify "-nt AUTO" to tell IQ-TREE to automatically determine the 
+    # best number of cores given the current data,
+    # with an upper bound of "-ntmax nthreads", the number of cores specified by the user.
+    # This puts the onus on IQ-TREE to determine the number of threads to use
+    # within the limit specified by the user. The actual number of threads used
+    # by IQ-TREE may be lower than the value of nthreads, depending on the data. 
+    # This avoid a scenario where IQ-TREE crashes because the user has specified 
+    # more cores than IQ-TREE can use for a given dataset.
+    #   See: https://github.com/nextstrain/augur/issues/589
+    call = ["iqtree", *fast_opts, "-nt", "AUTO", "-ntmax", str(nthreads), "-s", shquote(tmp_aln_file)]
     if substitution_model.lower() != "none":
-        call = ["iqtree", *fast_opts, "-nt", str(nthreads), "-s", shquote(tmp_aln_file),
-                "-m", substitution_model, tree_builder_args, ">", log_file]
-    else:
-        call = ["iqtree", *fast_opts, "-nt", str(nthreads), "-s", shquote(tmp_aln_file), tree_builder_args, ">", shquote(log_file)]
+        call += ["-m", substitution_model]
+    call += [tree_builder_args, ">", shquote(log_file)]
 
     cmd = " ".join(call)
 


### PR DESCRIPTION
### Description of proposed changes    

specify `-nt AUTO` in IQ-TREE call to automatically determine the best number of cores given the current data, with an upper bound of `-ntmax nthreads`, the number of cores specified by the augur user. This puts the onus on IQ-TREE to determine the number of threads to use within the limit specified by the user. The actual number of threads usedby IQ-TREE may be lower than the value of `nthreads`, depending on the data. This avoid a scenario where IQ-TREE crashes because the user has specified more cores than IQ-TREE can use for a given dataset. See:

https://github.com/nextstrain/augur/issues/589
https://github.com/nextstrain/augur/pull/590

This also applies `shquote` to the `log_file` path in the event a substitution model is specified (previously it was only applied if no model was given).

### Related issue(s)  
Fixes #589
Related to #590 

### Testing
This can be tested via the input included as part of issue #589.
