### PR TITLE
Document snakemake commands with required cores argument

### DIFF
--- a/docs/tutorials/tb_tutorial.md
+++ b/docs/tutorials/tb_tutorial.md
@@ -100,12 +100,12 @@ rule filter:
 
 Now run filter. If you are using the Snakefile included with the TB tutorial, you can run:
 ```bash
-snakemake filter
+snakemake --cores 1 filter
 ```
 
 If you have created your own Snakefile, you'll need to specify its name. For example, if it is called `TB_snakefile`, you would run:
 ```bash
-snakemake -s TB_snakefile filter
+snakemake --cores 1 -s TB_snakefile filter
 ```
 
 ### Mask the Sequences
@@ -450,7 +450,7 @@ rule all:
 
 This rule tells Snakemake what the final output of our entire run should look like.
 It will run all rules necessary to produce these files, so they should be the names of your final step.
-If you have an "all" rule, you can run your entire analysis just by running `snakemake` or `snakemake --snakefile Snakefile2` (if the name of your Snakefile is not 'Snakefile').
+If you have an "all" rule, you can run your entire analysis just by running `snakemake --cores 1` or `snakemake --cores 1 --snakefile Snakefile2` (if the name of your Snakefile is not 'Snakefile').
 
 We'll need to add a few remaining files to our list of files at the start of our Snakefile:
 ```bash

--- a/docs/tutorials/zika_tutorial.md
+++ b/docs/tutorials/zika_tutorial.md
@@ -79,7 +79,7 @@ This rule would produce `results/filtered.fasta` from the input files `data/sequ
 Note that we explicitly specify what is an input and what is an output file.
 To filter our data, we would now call snakemake as
 ```bash
-snakemake results/filtered.fasta
+snakemake --cores 1 results/filtered.fasta
 ```
 and snakemake will run the same command as specified above.
 
@@ -102,7 +102,7 @@ rule align:
 ```
 If you now want to generate the alignment, you can type
 ```bash
-snakemake results/aligned.fasta
+snakemake --cores 1 results/aligned.fasta
 ```
 and snakemake will
 

--- a/docs/usage/augur_snakemake.md
+++ b/docs/usage/augur_snakemake.md
@@ -29,7 +29,7 @@ This rule would produce `results/filtered.fasta` from the input files `data/sequ
 Note that we explicitly specify what is an input and what is an output file.
 To filter our data, we would now call snakemake as
 ```bash
-snakemake results/filtered.fasta
+snakemake --cores 1 results/filtered.fasta
 ```
 and snakemake will run the same command as specified above.
 
@@ -52,7 +52,7 @@ rule align:
 ```
 If you now want to generate the alignment, you can type
 ```bash
-snakemake results/aligned.fasta
+snakemake --cores 1 results/aligned.fasta
 ```
 and snakemake will
 

--- a/tests/builds/runner.sh
+++ b/tests/builds/runner.sh
@@ -19,8 +19,8 @@ mkdir auspice
 for snakefile in ./*/Snakefile; do
     echo -e "\nRunning ${snakefile} (quietly)\n"
     pushd $(dirname "${snakefile}") >/dev/null
-    snakemake --quiet clean 1>/dev/null
-    snakemake --quiet 1>/dev/null
+    snakemake --cores 1 --quiet clean 1>/dev/null
+    snakemake --cores 1 --quiet 1>/dev/null
     cp auspice/*.json ../auspice
     popd >/dev/null
 done


### PR DESCRIPTION
Adds the required `--cores 1` argument to all calls to snakemake in both scripts and documentation. This is the first step toward [removing Snakemake as an augur dependency](https://github.com/nextstrain/augur/pull/557).
