### PR TITLE
Document augur's external dependency on Snakemake

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -18,6 +18,8 @@ python3 -m pip install nextstrain-augur
 
 Augur uses some common external bioinformatics programs which you'll need to install to have a fully functioning toolkit:
 
+* Nextstrain workflows and some tutorials require [Snakemake](https://snakemake.readthedocs.io)
+
 * `augur align` requires [mafft](https://mafft.cbrc.jp/alignment/software/)
 
 * `augur tree` requires at least one of:
@@ -27,7 +29,7 @@ Augur uses some common external bioinformatics programs which you'll need to ins
 
 * Bacterial data (or any VCF usage) requires [vcftools](https://vcftools.github.io/)
 
-On macOS, you can install these external programs using [Homebrew](https://brew.sh/) with:
+On macOS, you can install most of these external programs using [Homebrew](https://brew.sh/) with:
 
     brew tap brewsci/bio
     brew install mafft iqtree raxml fasttree vcftools
@@ -37,6 +39,7 @@ On Debian/Ubuntu, you can install them via:
     sudo apt install mafft iqtree raxml fasttree vcftools
 
 Other Linux distributions will likely have the same packages available, although the names may differ slightly.
+Follow [Snakemake's installation instructions](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html) for your operating system.
 
 ## Using Conda
 

--- a/docs/tutorials/tb_tutorial.md
+++ b/docs/tutorials/tb_tutorial.md
@@ -5,6 +5,10 @@ However, much of it will be applicable to any run where you are starting with [V
 
 As in the Zika fasta-input [tutorial](zika_tutorial), we'll build up a Snakefile step-by-step for each step of the analysis.
 
+## Setup
+
+To run this tutorial you'll need to [install augur](../installation/installation) and [install Snakemake](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html).
+
 ## Build steps
 Nextstrain builds typically require the following steps:
 

--- a/docs/tutorials/zika_tutorial.md
+++ b/docs/tutorials/zika_tutorial.md
@@ -5,6 +5,9 @@ Augur consists of a number of tools that allow the user to filter and align sequ
 The different tools are meant to be composable and the output of one tool will serve as the input of other tools.
 We will work off the tutorial for Zika virus on the [nextstrain web site](https://nextstrain.org/docs/getting-started/zika-tutorial) and the github repository [nextstrain/zika-tutorial](https://github.com/nextstrain/zika-tutorial).
 
+## Setup
+
+To run this tutorial you'll need to [install augur](../installation/installation) and [install Snakemake](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html).
 
 ## Augur commands
 


### PR DESCRIPTION
As part of the move to [remove Snakemake as a dependency from the augur Python package](https://github.com/nextstrain/augur/pull/557), this PR documents when Snakemake is required to complete a tutorial and also includes Snakemake in the list of external dependencies users must install separately.
