### PR TITLE
Update call and expected returns from pandas's parse_time_string

### DIFF
--- a/augur/parse.py
+++ b/augur/parse.py
@@ -25,7 +25,13 @@ def fix_dates(d, dayfirst=True):
     On failure to parse the date, the function will return the input.
     '''
     try:
-        dto, _, res = pd.core.tools.datetimes.parse_time_string(d, dayfirst=dayfirst)
+        from pandas.core.tools.datetimes import parsing
+        results = parsing.parse_time_string(d, dayfirst=dayfirst)
+        if len(results) == 2:
+            dto, res = results
+        else:
+            dto, _, res = results
+
         if res == 'year':
             return "%d-XX-XX"%dto.year
         elif res == 'month':


### PR DESCRIPTION
### Description of proposed changes

The API for `parse_time_string` [changed recently to only return two values instead of three](https://github.com/pandas-dev/pandas/pull/31065) and the function is no longer importable from the pandas core tools datetimes module as of version 1.1.0. Instead, we have to import the `parsing` module that exposes the `parse_time_string` function. This commit supports both the previous and new API's return values.

This bug should affect anyone trying to run augur with pandas 1.1.0 but not users running earlier versions of pandas.

We might consider not using this pandas function if it is truly part of pandas' internal API.

### Testing

To test this, I setup the same environment as the CI and confirmed that the test failed. After applying the patch from this PR, the test passes.

```
# Setup the environment
conda env create -f environment.yml
conda activate augur
pip install -e .[dev]

# Run the affected test
python3 -m pytest -c pytest.python3.ini -k test_fix_dates
```