### PR TITLE
Document conda support

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -6,7 +6,8 @@ Thank you for helping us to improve Nextstrain! This document describes:
 - Contributing code
   - Running local code changes
   - Testing
-  - Creating a release
+  - Releasing
+  - Maintaining Bioconda package
   - Continuous integration
 - Contributing documentation
   - Formats (Markdown and reStructuredText)
@@ -169,6 +170,16 @@ If any tests fail, run the `./devel/rewind-release` script to undo the release, 
 [signed]: https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work
 [a PyPi account]: https://pypi.org/account/register/
 [twine]: https://pypi.org/project/twine
+
+### Maintaining Bioconda package
+
+Bioconda hosts [augur’s conda package](http://bioconda.github.io/recipes/augur/README.html) and defines augur’s dependencies in [a conda recipe YAML file](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/augur/meta.yaml).
+New releases on GitHub automatically trigger a new Bioconda release.
+
+To modify augur’s dependencies or other aspects of its conda environment, [follow Bioconda’s contributing guide](https://bioconda.github.io/contributor/index.html).
+You will need to update the existing recipe YAML locally and create a pull request on GitHub for testing and review.
+Add your GitHub username to the `recipe_maintainers` list, if this is your first time modifying the augur recipe.
+After a successful pull request review, Bioconda will automatically update the augur package that users download.
 
 ### Travis CI
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.com/nextstrain/augur.svg?branch=master)](https://travis-ci.com/nextstrain/augur)
 [![PyPI version](https://badge.fury.io/py/nextstrain-augur.svg)](https://pypi.org/project/nextstrain-augur/)
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/augur/README.html)
 [![Documentation Status](https://readthedocs.org/projects/nextstrain-augur/badge/?version=latest)](https://nextstrain-augur.readthedocs.io/en/stable/?badge=latest)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -1,11 +1,34 @@
 # Installation
 
+* [Using conda](#using-conda)
 * [Using pip from PyPi](#using-pip-from-pypi)
-* [Using Conda](#using-conda)
 * [Install from source](#install-from-source)
 * [Testing if it worked](#testing-if-it-worked)
 
 ---
+
+## Using conda
+
+Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
+Create a conda environment to install augur into and activate that environment.
+
+```bash
+conda create -n nextstrain
+conda activate nextstrain
+```
+
+Install augur and its dependencies into your environment.
+
+```bash
+conda install -c conda-forge -c bioconda augur
+```
+
+For a much faster installation process, use [mamba](https://github.com/TheSnakePit/mamba) as a drop-in replacement for conda.
+
+```bash
+conda install -c conda-forge mamba
+mamba install -c conda-forge -c bioconda augur
+```
 
 ## Using pip from PyPi
 
@@ -40,18 +63,6 @@ On Debian/Ubuntu, you can install them via:
 
 Other Linux distributions will likely have the same packages available, although the names may differ slightly.
 Follow [Snakemake's installation instructions](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html) for your operating system.
-
-## Using Conda
-
-Alternatively, augur itself and all of its dependencies can be installed into a [Conda](https://conda.io/miniconda.html) environment:
-
-    conda env create -f environment.yml
-
-> _By default this environment is named "augur" but you can change that by providing a name to the above command with `-n <your-env-name>`_
-
-When that finishes, the enviroment needs to be activated whenever you want to use augur:
-
-    conda activate augur
 
 ## Install from source
 


### PR DESCRIPTION
## Description of proposed changes

Document support for installing augur with conda through updated installation and developer documentation.

## Testing

The installation instructions here work from OS X with Miniconda, but I am especially curious whether they work for a range of user environments. The maintainer's instructions for the Bioconda recipe reflect [my own experiences updating that recipe](https://github.com/bioconda/bioconda-recipes/pull/23910).