### PR TITLE
Exit when a tree cannot be read by the node data reader

### DIFF
--- a/augur/util_support/node_data_reader.py
+++ b/augur/util_support/node_data_reader.py
@@ -70,7 +70,6 @@ class NodeDataReader:
             print(
                 f"Failed to read tree from file {self.tree_file}: {e}", file=sys.stderr
             )
-            return
             sys.exit(2)
 
         return set([clade.name for clade in tree.find_clades()])

--- a/tests/util_support/test_node_data_reader.py
+++ b/tests/util_support/test_node_data_reader.py
@@ -113,3 +113,10 @@ class TestNodeDataFile:
 
         with pytest.raises(SystemExit):
             NodeDataReader([f"{tmpdir}/file1.json"], f"{tmpdir}/tree.newick").read()
+
+    def test_read_check_against_missing_tree(self, tmpdir):
+        with pytest.raises(SystemExit):
+            node_names_from_tree = NodeDataReader(
+                [f"{tmpdir}/file1.json"],
+                f"{tmpdir}/missing_file.txt"
+            ).node_names_from_tree_file


### PR DESCRIPTION
Instead of returning None when the tree cannot be read by the node data reader,
exit like the other methods in the class do. This commit adds a unit test to
represent this expected behavior.
