### PR TITLE
Remove references to BioPython alphabet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* align: Remove references to BioPython's deprecated `Alphabet` attributes [#615][]
+* Pin BioPython dependency to a max supported version to prevent breaking changes to augur in the future [#615][]
+
+[#615]: https://github.com/nextstrain/augur/pull/615
 
 ## 10.0.1 (8 September 2020)
 

--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -152,6 +152,21 @@ We use [codecov](https://codecov.io/) to automatically produce test coverage for
 
 ### Releasing
 
+Before you create a new release, run all tests from a fresh conda environment to verify that nothing has broken since the last CI build on GitHub.
+The following commands will setup the equivalent conda environment to the Travis CI environment, run unit and integration tests, and deactivate the environment.
+
+```bash
+conda env create -f environment.yml
+conda activate augur
+python3 -m pip install -e .[dev]
+
+./run_tests.sh
+bash tests/builds/runner.sh
+
+conda deactivate
+conda env remove -n augur
+```
+
 New releases are tagged in git using an "annotated" tag.  If the git option
 `user.signingKey` is set, the tag will also be [signed][].  Signed tags are
 preferred, but it can be hard to setup GPG correctly.  The `release` branch
@@ -164,7 +179,7 @@ local repository.  It ends with instructions for you on how to push the release
 commit/tag/branch and how to upload the built distributions to PyPi.  You'll
 need [a PyPi account][] and [twine][] installed to do the latter.
 
-After you create a new release and before you push it to GitHub, run all tests with `./run_tests.sh` to confirm that nothing broke with the new release.
+After you create a new release and before you push it to GitHub, run all tests again as described above to confirm that nothing broke with the new release.
 If any tests fail, run the `./devel/rewind-release` script to undo the release, then fix the tests before trying again.
 
 [signed]: https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work

--- a/augur/align.py
+++ b/augur/align.py
@@ -384,7 +384,7 @@ def make_gaps_ambiguous(aln):
     for seq in aln:
         _seq = str(seq.seq)
         _seq = _seq.replace('-', 'N')
-        seq.seq = Seq.Seq(_seq, alphabet=seq.seq.alphabet)
+        seq.seq = Seq.Seq(_seq)
 
 
 def check_duplicates(*values):

--- a/pytest.python3.ini
+++ b/pytest.python3.ini
@@ -1,7 +1,4 @@
 [pytest]
-# ignore biopython's deprecation warnings about alphabet that are outside of our control
-filterwarnings = ignore::PendingDeprecationWarning:Bio.Alphabet
-
 addopts =
     # do not capture any output---necessary for interactive breakpoints
     -s

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),
     install_requires = [
         "bcbio-gff >=0.6.0, ==0.6.*",
-        "biopython >=1.67, ==1.*",
+        "biopython >=1.67, <=1.78",
         "jsonschema >=3.0.0, ==3.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",


### PR DESCRIPTION
Updates augur to work with [BioPython v1.78 (released on September 4)](https://github.com/biopython/biopython/blob/master/NEWS.rst#4-september-2020-biopython-178) by removing references to the deprecated `Alphabet` module. Since minor BioPython releases like this most recent one can include breaking changes, this PR also defensively pins the max supported version of BioPython for augur to avoid breaking augur in the future.

For Nextstrain maintainers, this PR also includes better instructions for running tests from your local development environment prior to a release to catch the kinds of [errors that happened with v10.0.1 in Travis CI](https://travis-ci.com/github/nextstrain/augur/jobs/382502588#L2810) and that I failed to detect in my own local test runs.