### PR TITLE
Improve validation of Auspice JSONs

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -445,9 +445,9 @@
                 },
                 "children": {
                     "description": "Child nodes. Recursive structure. Terminal nodes do not have this property.",
-                    "$comment": "Polytomies (more than 2 items) allowed.",
+                    "$comment": "Polytomies (more than 2 items) allowed, as are nodes with a single child.",
                     "type": "array",
-                    "minItems": 2,
+                    "minItems": 1,
                     "items": {"$ref": "#/properties/tree"}
                 }
             }

--- a/augur/validate_export.py
+++ b/augur/validate_export.py
@@ -7,6 +7,20 @@ and refactored over time.
 import sys
 from collections import defaultdict
 
+def ensure_no_duplicate_names(root, ValidateError):
+    """
+    Check that all node names are identical, which is required for auspice (v2) JSONs.
+    """
+    names = set()
+    def recurse(node):
+        if node["name"] in names:
+            raise ValidateError(f"Node {node['name']} appears multiple times in the tree.")
+        names.add(node["name"])
+        if "children" in node:
+            [recurse(child) for child in node["children"]]
+    recurse(root)
+
+
 def collectTreeAttrsV2(root, warn):
     """
     Collect all keys specified on `node["node_attrs"]` throughout the tree
@@ -81,6 +95,8 @@ def verifyMainJSONIsInternallyConsistent(data, ValidateError):
         print("\tWARNING: ", msg, file=sys.stderr)
 
     print("Validating that the JSON is internally consistent...")
+
+    ensure_no_duplicate_names(data["tree"], ValidateError)
 
     if "entropy" in data["meta"]["panels"] and "genome_annotations" not in data["meta"]:
         warn("The entropy panel has been specified but annotations don't exist.")

--- a/tests/test_validate_export.py
+++ b/tests/test_validate_export.py
@@ -1,0 +1,30 @@
+import Bio.Phylo
+from io import StringIO
+from pathlib import Path
+import pytest
+import sys
+
+# we assume (and assert) that this script is running from the tests/ directory
+sys.path.append(str(Path(__file__).parent.parent.parent))
+
+from augur.export_v2 import convert_tree_to_json_structure
+from augur.validate import ValidateError
+from augur.validate_export import ensure_no_duplicate_names
+
+
+class TestValidateExport():
+    def test_export_without_duplicate_names(self):
+        # Create a tree with unique tip names.
+        tree = Bio.Phylo.read(StringIO("root(A, internal(B, C))"), "newick")
+        metadata = {"A": {}, "B": {}, "C": {}, "root": {}, "internal": {}}
+        root = convert_tree_to_json_structure(tree.root, metadata)
+        ensure_no_duplicate_names(root, ValidateError)
+
+    def test_export_with_duplicate_names(self):
+        # Create a tree with duplicate tip names.
+        tree = Bio.Phylo.read(StringIO("root(A, internal(B, B))"), "newick")
+        metadata = {"A": {}, "B": {}, "root": {}, "internal": {}}
+        root = convert_tree_to_json_structure(tree.root, metadata)
+
+        with pytest.raises(ValidateError):
+            ensure_no_duplicate_names(root, ValidateError)


### PR DESCRIPTION
This improves `augur validate export-v2` in two important ways:

(1) Stops validation failing on trees with (internal) nodes with a single child. Such trees are allowed - in fact we use this ability for our nCoV trees to encode travel history!
(2) Trees with identical node names cause Auspice to crash, however they currently pass validation without any warnings. They now result in an error message such as:

```
$ augur validate export-v2 X.json
Validating schema of 'X.json'...
Validating that the JSON is internally consistent...
FATAL ERROR: Node T38080 appears multiple times in the tree.
```

cc @batson 

