### PR TITLE
Support incomplete ambiguous dates

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -246,13 +246,7 @@ def run(args):
     # filter by date
     num_excluded_by_date = 0
     if (args.min_date or args.max_date) and 'date' in meta_columns:
-        if num_excluded_by_ambiguous_date:
-            date_meta_dict = {}
-            for seq_name in seq_keep:
-                date_meta_dict[seq_name]=meta_dict[seq_name]
-            dates = get_numerical_dates(date_meta_dict, fmt="%Y-%m-%d")
-        else:
-            dates = get_numerical_dates(meta_dict, fmt="%Y-%m-%d")
+        dates = get_numerical_dates(meta_dict, fmt="%Y-%m-%d")
         tmp = [s for s in seq_keep if dates[s] is not None]
         if args.min_date:
             tmp = [s for s in tmp if (np.isscalar(dates[s]) or all(dates[s])) and np.max(dates[s])>args.min_date]

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -106,7 +106,7 @@ def register_arguments(parser):
     parser.add_argument('--include-where', nargs='+',
                                 help="Include samples with these values. ex: host=rat. Multiple values are processed as OR (having any of those specified will be included), not AND. This rule is applied last and ensures any sequences matching these rules will be included.")
     parser.add_argument('--exclude-ambiguous-dates-by', choices=['all', 'day', 'month', 'year'],
-                                help='Exclude ambiguous dates Ex: days - excludes 2020-09-XX, months - excludes 2020-xx-19, all - excludes any ambiguous dates')
+                                help='Exclude ambiguous dates by day (e.g., 2020-09-XX), month (e.g., 2020-XX-XX), year (e.g., 200X-10-01), or all date fields')
     parser.add_argument('--query', help="Filter samples by attribute. Uses Pandas Dataframe querying, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query for syntax.")
     parser.add_argument('--output', '-o', help="output file", required=True)
 
@@ -238,8 +238,9 @@ def run(args):
     if args.exclude_ambiguous_dates_by and 'date' in meta_columns:
         seq_keep_by_date = []
         for seq_name in seq_keep:
-            if is_date_ambiguous(meta_dict[seq_name]['date'],args.exclude_ambiguous_dates_by) is False:
+            if not is_date_ambiguous(meta_dict[seq_name]['date'], args.exclude_ambiguous_dates_by):
                 seq_keep_by_date.append(seq_name)
+
         num_excluded_by_ambiguous_date = len(seq_keep) - len(seq_keep_by_date)
         seq_keep = seq_keep_by_date
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -105,8 +105,8 @@ def register_arguments(parser):
                                 help="Exclude samples matching these conditions. Ex: \"host=rat\" or \"host!=rat\". Multiple values are processed as OR (matching any of those specified will be excluded), not AND")
     parser.add_argument('--include-where', nargs='+',
                                 help="Include samples with these values. ex: host=rat. Multiple values are processed as OR (having any of those specified will be included), not AND. This rule is applied last and ensures any sequences matching these rules will be included.")
-    parser.add_argument('--exclude-ambiguous-dates-by', choices=['all', 'day', 'month', 'year'],
-                                help='Exclude ambiguous dates by day (e.g., 2020-09-XX), month (e.g., 2020-XX-XX), year (e.g., 200X-10-01), or all date fields')
+    parser.add_argument('--exclude-ambiguous-dates-by', choices=['any', 'day', 'month', 'year'],
+                                help='Exclude ambiguous dates by day (e.g., 2020-09-XX), month (e.g., 2020-XX-XX), year (e.g., 200X-10-01), or any date fields. An ambiguous year makes the corresponding month and day ambiguous, too, even if those fields have unambiguous values (e.g., "201X-10-01"). Similarly, an ambiguous month makes the corresponding day ambiguous (e.g., "2010-XX-01").')
     parser.add_argument('--query', help="Filter samples by attribute. Uses Pandas Dataframe querying, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query for syntax.")
     parser.add_argument('--output', '-o', help="output file", required=True)
 

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -92,7 +92,7 @@ def is_date_ambiguous(date, ambiguous_by="all"):
         year, month = date_components
         day = "XX"
     else:
-        year = date_components
+        year = date_components[0]
         month = "XX"
         day = "XX"
 

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -93,7 +93,6 @@ def is_date_ambiguous(date, ambiguous_by="all"):
     )
 
 def get_numerical_dates(meta_dict, name_col = None, date_col='date', fmt=None, min_max_year=None):
-    num_excluded_recs = 0
     if fmt:
         from datetime import datetime
         numerical_dates = {}
@@ -115,8 +114,7 @@ def get_numerical_dates(meta_dict, name_col = None, date_col='date', fmt=None, m
                     numerical_dates[k] = None
     else:
         numerical_dates = {k:float(v) for k,v in meta_dict.items()}
-    if num_excluded_recs:
-        print("%s records were excluded due to ambiguous date"%num_excluded_recs)
+
     return numerical_dates
 
 

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -84,9 +84,20 @@ def is_date_ambiguous(date, ambiguous_by="all"):
     ambiguous_by : str
         Field of the date string to test for ambiguity ("day", "month", "year", "all")
     """
-    year, month, day = date.split('-')
+    date_components = date.split('-', 2)
+
+    if len(date_components) == 3:
+        year, month, day = date_components
+    elif len(date_components) == 2:
+        year, month = date_components
+        day = "XX"
+    else:
+        year = date_components
+        month = "XX"
+        day = "XX"
+
     return (
-            (ambiguous_by == 'all' and 'X' in date) or
+            (ambiguous_by == 'all' and ('X' in year or 'X' in month or 'X' in day)) or
             (ambiguous_by == 'day' and 'X' in day) or
             (ambiguous_by == 'month' and 'X' in month) or
             (ambiguous_by == 'year' and 'X' in year)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,7 +91,7 @@ class TestUtils:
             fh.write("\n".join(bed_lines))
         with pytest.raises(Exception):
             utils.read_bed_file(bed_file)
-    
+
     def test_read_mask_file_drm_file(self, tmpdir):
         """read_mask_file should handle drm files as well"""
         drm_file = str(tmpdir / "temp.drm")
@@ -110,7 +110,7 @@ class TestUtils:
 
     def test_not_is_date_ambiguous(self):
         """ is_date_ambiguous should return false for valid dates"""
-        assert utils.is_date_ambiguous("2019-09-03", "all") is False
-        assert utils.is_date_ambiguous("2019-03-XX", "month") is False
-        assert utils.is_date_ambiguous("2019-XX-01", "day") is False
-        assert utils.is_date_ambiguous("2019-XX-XX", "year") is False
+        assert not utils.is_date_ambiguous("2019-09-03", "all")
+        assert not utils.is_date_ambiguous("2019-03-XX", "month")
+        assert not utils.is_date_ambiguous("2019-XX-01", "day")
+        assert not utils.is_date_ambiguous("2019-XX-XX", "year")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,18 +102,25 @@ class TestUtils:
         assert utils.read_mask_file(drm_file) == expected_sites
 
     def test_is_date_ambiguous(self):
-        """ is_date_ambiguous should return true for ambiguous dates"""
+        """is_date_ambiguous should return true for ambiguous dates and false for valid dates."""
+        # Test complete date strings with ambiguous values.
         assert utils.is_date_ambiguous("2019-0X-0X", "all")
         assert utils.is_date_ambiguous("2019-XX-09", "month")
         assert utils.is_date_ambiguous("2019-03-XX", "day")
         assert utils.is_date_ambiguous("201X-03-09", "year")
+
+        # Test incomplete date strings with ambiguous values.
         assert utils.is_date_ambiguous("2019", "all")
+        assert utils.is_date_ambiguous("201X", "year")
+        assert utils.is_date_ambiguous("2019-XX", "month")
         assert utils.is_date_ambiguous("2019-10", "day")
 
-    def test_not_is_date_ambiguous(self):
-        """ is_date_ambiguous should return false for valid dates"""
+        # Test complete date strings without ambiguous dates for the requested field.
         assert not utils.is_date_ambiguous("2019-09-03", "all")
         assert not utils.is_date_ambiguous("2019-03-XX", "month")
-        assert not utils.is_date_ambiguous("2019-XX-01", "day")
+        assert not utils.is_date_ambiguous("2019-09-03", "day")
         assert not utils.is_date_ambiguous("2019-XX-XX", "year")
+
+        # Test incomplete date strings without ambiguous dates for the requested fields.
         assert not utils.is_date_ambiguous("2019", "year")
+        assert not utils.is_date_ambiguous("2019-10", "month")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,19 +104,24 @@ class TestUtils:
     def test_is_date_ambiguous(self):
         """is_date_ambiguous should return true for ambiguous dates and false for valid dates."""
         # Test complete date strings with ambiguous values.
-        assert utils.is_date_ambiguous("2019-0X-0X", "all")
+        assert utils.is_date_ambiguous("2019-0X-0X", "any")
         assert utils.is_date_ambiguous("2019-XX-09", "month")
         assert utils.is_date_ambiguous("2019-03-XX", "day")
         assert utils.is_date_ambiguous("201X-03-09", "year")
+        assert utils.is_date_ambiguous("20XX-01-09", "month")
+        assert utils.is_date_ambiguous("2019-XX-03", "day")
+        assert utils.is_date_ambiguous("20XX-01-03", "day")
 
         # Test incomplete date strings with ambiguous values.
-        assert utils.is_date_ambiguous("2019", "all")
+        assert utils.is_date_ambiguous("2019", "any")
         assert utils.is_date_ambiguous("201X", "year")
         assert utils.is_date_ambiguous("2019-XX", "month")
         assert utils.is_date_ambiguous("2019-10", "day")
+        assert utils.is_date_ambiguous("2019-XX", "any")
+        assert utils.is_date_ambiguous("2019-XX", "day")
 
         # Test complete date strings without ambiguous dates for the requested field.
-        assert not utils.is_date_ambiguous("2019-09-03", "all")
+        assert not utils.is_date_ambiguous("2019-09-03", "any")
         assert not utils.is_date_ambiguous("2019-03-XX", "month")
         assert not utils.is_date_ambiguous("2019-09-03", "day")
         assert not utils.is_date_ambiguous("2019-XX-XX", "year")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,6 +107,8 @@ class TestUtils:
         assert utils.is_date_ambiguous("2019-XX-09", "month")
         assert utils.is_date_ambiguous("2019-03-XX", "day")
         assert utils.is_date_ambiguous("201X-03-09", "year")
+        assert utils.is_date_ambiguous("2019", "all")
+        assert utils.is_date_ambiguous("2019-10", "day")
 
     def test_not_is_date_ambiguous(self):
         """ is_date_ambiguous should return false for valid dates"""
@@ -114,3 +116,4 @@ class TestUtils:
         assert not utils.is_date_ambiguous("2019-03-XX", "month")
         assert not utils.is_date_ambiguous("2019-XX-01", "day")
         assert not utils.is_date_ambiguous("2019-XX-XX", "year")
+        assert not utils.is_date_ambiguous("2019", "year")


### PR DESCRIPTION
### Description of proposed changes    

This PR continues work from #623 by adding support for incomplete ambiguous date strings like those matching the formats of "YYYY" and "YYYY-MM".

### Related issue(s)  

Related to #602.

### Testing

Adds new unit tests for the case of incomplete ambiguous date strings.

### Prior to merge

This PR should be rebased onto master after #623 is merged to avoid a messy git history.