### PR TITLE
chore: bump required treetime version to 0.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),
     install_requires = [
         "bcbio-gff >=0.6.0, ==0.6.*",
-        "biopython >=1.67, <=1.78",
+        "biopython >=1.67, <=1.76",
         "jsonschema >=3.0.0, ==3.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "jsonschema >=3.0.0, ==3.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",
-        "phylo-treetime >=0.7.4, ==0.7.*"
+        "phylo-treetime ==0.8.*"
     ],
     extras_require = {
         'full': [

--- a/tests/builds/zika.t
+++ b/tests/builds/zika.t
@@ -75,8 +75,6 @@ Build a time tree from the existing tree topology, the multiple sequence alignme
   >  --date-inference marginal \
   >  --clock-filter-iqd 4 \
   >  --seed 314159 > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
 Confirm that TreeTime trees match expected topology and branch lengths.
 
@@ -107,8 +105,6 @@ Infer ancestral sequences from the tree.
   >  --infer-ambiguous \
   >  --output-node-data "$TMP/out/nt_muts.json" \
   >  --inference joint > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
   $ diff -u --ignore-matching-lines version "results/nt_muts.json" "$TMP/out/nt_muts.json"
 

--- a/tests/functional/ancestral.t
+++ b/tests/functional/ancestral.t
@@ -11,8 +11,6 @@ The default is to infer ambiguous bases, so there should not be N bases in the i
   >  --alignment ancestral/aligned.fasta \
   >  --output-node-data "$TMP/ancestral_mutations.json" \
   >  --output-sequences "$TMP/ancestral_sequences.fasta" > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
   $ grep N "$TMP/ancestral_sequences.fasta"
   >NODE_0000000
@@ -26,8 +24,6 @@ There should not be N bases in the inferred output sequences.
   >  --infer-ambiguous \
   >  --output-node-data "$TMP/ancestral_mutations.json" \
   >  --output-sequences "$TMP/ancestral_sequences.fasta" > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
   $ grep N "$TMP/ancestral_sequences.fasta"
   >NODE_0000000
@@ -41,8 +37,6 @@ There be N bases in the inferred output sequences.
   >  --keep-ambiguous \
   >  --output-node-data "$TMP/ancestral_mutations.json" \
   >  --output-sequences "$TMP/ancestral_sequences.fasta" > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
   $ grep N "$TMP/ancestral_sequences.fasta"
   >NODE_0000000

--- a/tests/functional/refine.t
+++ b/tests/functional/refine.t
@@ -17,8 +17,6 @@ Try building a time tree.
   >  --date-inference marginal \
   >  --clock-filter-iqd 4 \
   >  --seed 314159 > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
 Confirm that TreeTime trees match expected topology and branch lengths.
 
@@ -40,8 +38,6 @@ Build a time tree with mutations as the reported divergence unit.
   >  --clock-filter-iqd 4 \
   >  --seed 314159 \
   >  --divergence-units mutations > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
 Confirm that TreeTime trees match expected topology and branch lengths.
 
@@ -62,8 +58,6 @@ This is one way to get named internal nodes for downstream analyses and does not
   >  --clock-filter-iqd 4 \
   >  --seed 314159 \
   >  --divergence-units mutations-per-site > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
 Confirm that trees match expected topology and branch lengths, given that the output should not be a time tree.
 
@@ -87,8 +81,6 @@ This approach only works when we provide an alignment FASTA.
   >  --clock-filter-iqd 4 \
   >  --seed 314159 \
   >  --divergence-units mutations > /dev/null
-  */treetime/aa_models.py:108: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray (glob)
-    [0.800038509951648, 1.20274751778601, 1.55207513886163, 1.46600946033173, 0.830022143283238, 1.5416250309563, 1.53255698189437, 1.41208067821187, 1.47469999960758, 0.351200119909572, 0.570542199221932, 1.21378822764856, 0.609532859331199, 0.692733248746636, 1.40887880416009, 1.02015839286433, 0.807404666228614, 1.268589159299, 0.933095433689795]
 
 Confirm that trees match expected topology and branch lengths, given that the output should not be a time tree.
 


### PR DESCRIPTION
### Description of proposed changes    
not much has changed in treetime but I dropped python 2.7. So new middle digit. 



### Thank you for contributing to Nextstrain!
