### PR TITLE
Use correct Python versions in CI environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
         - conda config --set always_yes yes --set changeps1 no
         - conda update -q conda
         - conda info -a
-        - conda env create -f environment.yml
+        - conda create -n augur -c bioconda python=$TRAVIS_PYTHON_VERSION mafft raxml fasttree iqtree vcftools pip
         - source activate augur
       install:
         - pip install -e .[dev]


### PR DESCRIPTION
Currently, Travis CI runs one build for three major Python versions except each environment installs and uses the same Python 3.6 version from a fixed conda environment file. This change follows the [recommendations from the conda documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html) to build each conda environment with the Travis Python version variable and the `conda create` command instead of the `conda env create` command. The cost of duplicating our dependencies here is small compared to the benefit of testing Augur with the appropriate Python versions.

Fixes #626