### PR TITLE
Add --pivot-interval-units option and allow YYYY-MM-DD dates in frequencies

### DIFF
--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -22,6 +22,8 @@ def register_arguments(parser):
                         help="region to subsample to")
     parser.add_argument("--pivot-interval", type=int, default=3,
                         help="number of months between pivots")
+    parser.add_argument("--pivot-interval-units", type=str, default="months", choices=['months', 'weeks'],
+                        help="space pivots by months (default) or by weeks")
     parser.add_argument('--min-date', type=float,
                         help="minimal pivot value")
     parser.add_argument('--max-date', type=float,
@@ -104,7 +106,7 @@ def run(args):
 
         if args.method == "diffusion":
             # estimate tree frequencies
-            pivots = get_pivots(tps, args.pivot_interval, args.min_date, args.max_date)
+            pivots = get_pivots(tps, args.pivot_interval, args.min_date, args.max_date, args.pivot_interval_units)
             frequency_dict = {"pivots":format_frequencies(pivots)}
             frequency_dict["counts"] = {}
 
@@ -157,6 +159,7 @@ def run(args):
                 pivot_frequency=args.pivot_interval,
                 start_date=args.min_date,
                 end_date=args.max_date,
+                pivot_interval_units=args.pivot_interval_units,
                 weights=weights,
                 weights_attribute=weights_attribute,
                 include_internal_nodes=args.include_internal_nodes,
@@ -190,7 +193,7 @@ def run(args):
             tps = np.array([np.mean(dates[seq.name]) for seq in aln])
 
             if frequencies is None:
-                pivots = get_pivots(tps, args.pivot_interval, args.min_date, args.max_date)
+                pivots = get_pivots(tps, args.pivot_interval, args.min_date, args.max_date, args.pivot_interval_units)
                 frequencies = {"pivots":format_frequencies(pivots)}
 
             if args.method == "kde":
@@ -201,6 +204,7 @@ def run(args):
                     pivot_frequency=args.pivot_interval,
                     start_date=args.min_date,
                     end_date=args.max_date,
+                    pivot_interval_units=args.pivot_interval_units,
                     weights=weights,
                     weights_attribute=weights_attribute,
                     include_internal_nodes=args.include_internal_nodes,

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -23,7 +23,7 @@ def register_arguments(parser):
     parser.add_argument('--regions', type=str, nargs='+', default=['global'],
                         help="region to subsample to")
     parser.add_argument("--pivot-interval", type=int, default=3,
-                        help="number of months between pivots")
+                        help="number of units between pivots")
     parser.add_argument("--pivot-interval-units", type=str, default="months", choices=['months', 'weeks'],
                         help="space pivots by months (default) or by weeks")
     parser.add_argument('--min-date', type=numeric_date,

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -2,10 +2,12 @@
 infer frequencies of mutations or clades
 """
 import json, os, sys
+import datetime
 import numpy as np
 from collections import defaultdict
 from Bio import Phylo, AlignIO
 from Bio.Align import MultipleSeqAlignment
+import treetime.utils
 
 from .frequency_estimators import get_pivots, alignment_frequencies, tree_frequencies
 from .frequency_estimators import AlignmentKdeFrequencies, TreeKdeFrequencies, TreeKdeFrequenciesError
@@ -24,10 +26,10 @@ def register_arguments(parser):
                         help="number of months between pivots")
     parser.add_argument("--pivot-interval-units", type=str, default="months", choices=['months', 'weeks'],
                         help="space pivots by months (default) or by weeks")
-    parser.add_argument('--min-date', type=float,
-                        help="minimal pivot value")
-    parser.add_argument('--max-date', type=float,
-                        help="maximal pivot value")
+    parser.add_argument('--min-date', type=numeric_date,
+                        help="date to begin frequencies calculations; may be specified as an Augur-style numeric date (with the year as the integer part) or YYYY-MM-DD")
+    parser.add_argument('--max-date', type=numeric_date,
+                        help="date to end frequencies calculations; may be specified as an Augur-style numeric date (with the year as the integer part) or YYYY-MM-DD")
 
     # Tree-specific arguments
     parser.add_argument('--tree', '-t', type=str,
@@ -228,3 +230,19 @@ def run(args):
 
         write_json(frequencies, args.output)
         print("mutation frequencies written to", args.output, file=sys.stdout)
+
+
+def numeric_date(date):
+    """
+    Converts the given *date* string to a :py:class:`float`.
+    *date* may be given as a number (a float) with year as the integer part, or
+    in the YYYY-MM-DD (ISO 8601) syntax.
+    >>> numeric_date("2020.42")
+    2020.42
+    >>> numeric_date("2020-06-04")
+    2020.42486...
+    """
+    try:
+        return float(date)
+    except ValueError:
+        return treetime.utils.numeric_date(datetime.date(*map(int, date.split("-", 2))))

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -53,9 +53,12 @@ def get_pivots(observations, pivot_interval, start_date=None, end_date=None, piv
     pivot_start = start_date if start_date else np.floor(np.min(observations) / pivot_frequency) * pivot_frequency
     pivot_end = end_date if end_date else np.ceil(np.max(observations) / pivot_frequency) * pivot_frequency
 
-    offset = "%sMS" % pivot_interval
-    if pivot_interval_units == "weeks":
+    if pivot_interval_units == "months":
+        offset = "%sMS" % pivot_interval
+    elif pivot_interval_units == "weeks":
         offset = "%sW" % pivot_interval
+    else:
+        raise ValueError(f"The given interval unit '{pivot_interval_units}' is not supported.")
 
     datetime_pivots = pd.date_range(
         float_to_datestring(pivot_start),

--- a/tests/test_frequencies.py
+++ b/tests/test_frequencies.py
@@ -82,6 +82,26 @@ def test_get_pivots_from_start_and_end_date():
     assert pivots[-1] == 2018.5
     assert pivots[-1] >= end_date - pivot_frequency
 
+def test_get_pivots_by_months():
+    """Get pivots where intervals are defined by months.
+    """
+    pivots = get_pivots(observations=[], pivot_interval=1, start_date=2015.0, end_date=2016.0, pivot_interval_units="months")
+    # Pivots should include all 12 months of the year plus the month represented
+    # by the end date, since the pandas month interval uses "month starts". See
+    # pandas date offsets documentation for more details:
+    # https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+    assert len(pivots) == 13
+
+def test_get_pivots_by_weeks():
+    """Get pivots where intervals are defined as weeks instead of months.
+    """
+    pivots = get_pivots(observations=[], pivot_interval=1, start_date=2015.0, end_date=2016.0, pivot_interval_units="weeks")
+    assert len(pivots) == 52
+
+def test_get_pivots_by_invalid_unit():
+    with pytest.raises(ValueError, match=r".*invalid_unit.*is not supported.*"):
+        pivots = get_pivots(observations=[], pivot_interval=1, start_date=2015.0, end_date=2016.0, pivot_interval_units="invalid_unit")
+
 #
 # Test KDE frequency estimation for trees
 #

--- a/tests/test_frequencies.py
+++ b/tests/test_frequencies.py
@@ -66,17 +66,20 @@ def test_get_pivots_from_tree_only(tree):
 
 def test_get_pivots_from_start_and_end_date():
     """
-    Test pivot calculation from a given start and end date instead of a given tree.
+    Test pivot calculation from a given start and end date instead of a given tree
+    First pivot is the first day of the month immediately following start_date
+    Last pivot is the first day of the month immediately preceding end_date
+    Current logic converts numeric date 2015.5 to 2015-07-02, hence using 2015.49
     """
-    pivot_frequency = 3
-    start_date = 2015.5
+    pivot_frequency = 1
+    start_date = 2015.49
     end_date = 2018.5
     observations = []
     pivots = get_pivots(observations, pivot_frequency, start_date=start_date, end_date=end_date)
     assert isinstance(pivots, np.ndarray)
-    assert pivots[1] - pivots[0] == pivot_frequency / 12.0
-    assert pivots[0] == start_date
-    assert pivots[-1] == end_date
+    assert np.round( 12 * (pivots[1] - pivots[0]) ) == pivot_frequency
+    assert pivots[0] == 2015.5
+    assert pivots[-1] == 2018.5
     assert pivots[-1] >= end_date - pivot_frequency
 
 #
@@ -110,7 +113,7 @@ class TestTreeKdeFrequencies(object):
         )
         frequencies = kde_frequencies.estimate(tree)
         assert hasattr(kde_frequencies, "pivots")
-        assert kde_frequencies.pivots[0] == start_date
+        assert kde_frequencies.pivots[0] == 2015.5833
         assert hasattr(kde_frequencies, "frequencies")
         assert list(frequencies.values())[0].shape == kde_frequencies.pivots.shape
 


### PR DESCRIPTION
### Description of proposed changes    

Previously, `--pivot-intervals` specified only months and only allowed integers as options. This creates wide intervals relative to SARS-CoV-2 timeseries and has a particularly problematic edge condition where a `max-date` of Jan 2 will create a pivot at Feb 1 and project frequency estimate forward 30 days.

Commit 4fd41669bc3251b9fb0631d386d28c6eeb023aa7  allows `--pivot-interval-units` to specify `weeks` rather than `months` and thus allow more finely spaced pivots.

The seriousness of this issue can be seen here:

<img width="1126" alt="uk-monthly" src="https://user-images.githubusercontent.com/1176109/104081085-47dba300-51e1-11eb-95b9-5501101f9d8c.png">

https://nextstrain.org/ncov/global?f_country=United%20Kingdom&f_region=Europe, where frequency of 501Y.V2 is estimated to be 100% in the UK at the latest timepoint!

Switching to `--pivot-interval-units weeks` gives much nicer edge behavior:

<img width="1138" alt="uk-weekly" src="https://user-images.githubusercontent.com/1176109/104081100-604bbd80-51e1-11eb-959d-649277a28dec.png">

and curves look nicer to boot.

BTW I considering moving `--pivot-interval` to a float which could then be `0.5` for half-months. I'd be happy with this implementation instead. However, this seemed to have arbitrariness where we want pivots to fall along natural time units (weeks, months, etc...) and what do we do if `--pivot-interval 0.8` is chosen? This would need coercing to work with `pd.date_range` in `get_pivots`.

--------------------------------------------

Additionally, commit 6a129feca4567908400faf0c3055a49b90f39f5b allows `--min-date` and `--max-date` to take ISO 8601 YYYY-MM-DD values. This is significantly more convenient and would allow snakemake rules that pass through today's date without having to go through a numeric date conversion.

In doing this work I noticed significant shadowing between functions that convert between numeric and calendar dates in Augur. `frequency_estimators.py` uses its own `float_to_datestring`. And it also has its own `timestamp_to_float` to distinct from filter's `numeric_date`. I would aim to refactor this in a separate PR that pushes these two key functions into augur `utils`. These two functions in `utils` may just borrow directly from TreeTime, but I think better to have Augur commands like filter and frequencies use Augur's utils rather than reaching into TreeTime (when possible).

