### PR TITLE
Minimize codecov feedback on branches and PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+comment:
+  # Only post a codecov comment if coverage changes.
+  require_changes: true
+
+coverage:
+  status:
+    # Disable GitHub checks for code coverage that make otherwise valid builds fail.
+    project: off
+    patch: off
+
+github_checks:
+  # Disable inline annotations of code coverage in pull requests.
+  annotations: false


### PR DESCRIPTION
Limit codecov feedback to comments on PRs when the coverage has actually changed.

 - Do not invalidate branches and PRs because code coverage decreases.
 - Do not annotate each line of a PR that does not have code coverage.

These reminders are more annoying than they are helpful.

This PR adds a codecov YAML that validates with the following command:

```
curl --data-binary @codecov.yml https://codecov.io/validate
```