### PR TITLE
fix parsing of priorities tsv file to allow spaces in sequence IDs

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -60,7 +60,7 @@ def read_priority_scores(fname):
         with open(fname, encoding='utf-8') as pfile:
             return defaultdict(float, {
                 elems[0]: float(elems[1])
-                for elems in (line.strip().split('\t') for line in pfile.readlines())
+                for elems in (line.strip().split() if '\t' not in line else line.strip().split('\t') for line in pfile.readlines())
             })
     except Exception as e:
         print(f"ERROR: missing or malformed priority scores file {fname}", file=sys.stderr)

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -60,7 +60,7 @@ def read_priority_scores(fname):
         with open(fname, encoding='utf-8') as pfile:
             return defaultdict(float, {
                 elems[0]: float(elems[1])
-                for elems in (line.strip().split() for line in pfile.readlines())
+                for elems in (line.strip().split('\t') for line in pfile.readlines())
             })
     except Exception as e:
         print(f"ERROR: missing or malformed priority scores file {fname}", file=sys.stderr)

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -60,7 +60,7 @@ def read_priority_scores(fname):
         with open(fname, encoding='utf-8') as pfile:
             return defaultdict(float, {
                 elems[0]: float(elems[1])
-                for elems in (line.strip().split() if '\t' not in line else line.strip().split('\t') for line in pfile.readlines())
+                for elems in (line.strip().split('\t') if '\t' in line else line.strip().split() for line in pfile.readlines())
             })
     except Exception as e:
         print(f"ERROR: missing or malformed priority scores file {fname}", file=sys.stderr)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -57,6 +57,12 @@ def mock_run_shell_command(mocker):
     mocker.patch("augur.filter.run_shell_command")
 
 
+@pytest.fixture
+def mock_priorities_file_valid_with_spaces_and_tabs(mocker):
+    mocker.patch(
+        "builtins.open", mocker.mock_open(read_data="strain 1\t5\nstrain 2\t6\nstrain 3\t8\n")
+    )
+
 class TestFilter:
     def test_read_vcf_compressed(self):
         seq_keep, all_seq = augur.filter.read_vcf(
@@ -88,6 +94,14 @@ class TestFilter:
         with pytest.raises(ValueError):
             # builtins.open is stubbed, but we need a valid file to satisfy the existence check
             augur.filter.read_priority_scores("tests/builds/tb/data/lee_2015.vcf")
+
+    def test_read_priority_scores_valid_with_spaces_and_tabs(self, mock_priorities_file_valid_with_spaces_and_tabs):
+        # builtins.open is stubbed, but we need a valid file to satisfy the existence check
+        priorities = augur.filter.read_priority_scores(
+            "tests/builds/tb/data/lee_2015.vcf"
+        )
+
+        assert priorities == {"strain 1": 5, "strain 2": 6, "strain 3": 8}
 
     def test_read_priority_scores_does_not_exist(self):
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
### Description of proposed changes    

When parsing priority tsv files, an error could be encountered if a sequence name contain spaces, as `.split()` breaks not only on the tabs delimiting the file, but any whitespace characters. This replaces `.split()` with `.split('\t')` to address this and preserve sequence names containing spaces.

### Related issue(s)  
Flagged by @dpark01 as a problem. 

A priorities tsv file of the following form:
```
NC_045512.2 Wuhan seafood market pneumonia virus isolate Wuhan-Hu-1, complete genome	-0.20
Algeria/G0638_2264/2020	-235.60
Algeria/G0640_2265/2020	-140.70
```
Leads to the following failure:
```
Traceback (most recent call last):
  File "/usr/bin/augur", line 11, in <module>
    load_entry_point('nextstrain-augur', 'console_scripts', 'augur')()
  File "/nextstrain/augur/augur/__main__.py", line 10, in main
    return augur.run( argv[1:] )
  File "/nextstrain/augur/augur/__init__.py", line 74, in run
    return args.__command__.run(args)
  File "/nextstrain/augur/augur/filter.py", line 326, in run
    priorities = read_priority_scores(args.priority)
  File "/nextstrain/augur/augur/filter.py", line 67, in read_priority_scores
    raise e
  File "/nextstrain/augur/augur/filter.py", line 63, in read_priority_scores
    for elems in (line.strip().split() for line in pfile.readlines())
  File "/nextstrain/augur/augur/filter.py", line 63, in <dictcomp>
    for elems in (line.strip().split() for line in pfile.readlines())
ValueError: could not convert string to float: 'Wuhan'
```

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

No changes made to the tests (so far).