### PR TITLE
ensure columns strain and name in metadata are parsed as string

### DIFF
--- a/augur/util_support/metadata_file.py
+++ b/augur/util_support/metadata_file.py
@@ -93,4 +93,5 @@ class MetadataFile:
             sep=None,  # csv.Sniffer will automatically detect sep
             engine="python",
             skipinitialspace=True,
+            dtype={"strain":"string", "name":"string"}
         ).fillna("")

--- a/tests/util_support/test_metadata_file.py
+++ b/tests/util_support/test_metadata_file.py
@@ -117,3 +117,15 @@ class TestMetadataFile:
             "strainB": {"strain": "strainB", "location": "nevada", "quality": "good"},
         }
         assert list(columns) == ["strain", "location", "quality"]
+
+    def test_metadata_strain_type(self, tmpdir, prepare_file):
+        prepare_file(
+            """
+            strain\tlocation
+            1\tWashington
+            2\tOregon
+            """
+        )
+
+        records, columns = MetadataFile(f"{tmpdir}/metadata.txt").read()
+        assert "1" in records


### PR DESCRIPTION
### Description of proposed changes    
ensure columns strain and name in metadata are parsed as string.

Fixes issue https://github.com/nextstrain/augur/issues/667

### Testing
we could add a test if deemed necessary.

### Thank you for contributing to Nextstrain!
