### PR TITLE
Include LICENSE.txt in distribution artifacts with MANIFEST.in not data_files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setuptools.setup(
     },
     packages = setuptools.find_packages(),
     package_data = {'augur': ['data/*']},
-    data_files = [("", ["LICENSE.txt"])],
     python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),
     install_requires = [
         "bcbio-gff >=0.6.0, ==0.6.*",


### PR DESCRIPTION
data_files are installed immediately under the Python installation root
(sys.prefix), e.g. /usr/local or ~/.conda/envs/…/, which is just rude.
It's also causing permission issues that otherwise wouldn't happen on
the macOS CI I'm setting up for Nextstrain CLI.
