### PR TITLE
Do not attempt to close a SeqIO iterator

### DIFF
--- a/augur/index.py
+++ b/augur/index.py
@@ -156,8 +156,6 @@ def index_sequences(sequences_path, sequence_index_path):
             tot_length += row[1]
             num_of_seqs += 1
 
-    seqs.close()
-
     return num_of_seqs, tot_length
 
 


### PR DESCRIPTION
BioPython versions >=1.77 do not support closing SeqIO iterators. If users have installed Augur through the Bioconda package, they may have a later version of BioPython and will experience an exception when running the index command.