### PR TITLE
Add missing kwargs attribute to TiterCollection

### DIFF
--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -176,6 +176,8 @@ class TiterCollection(object):
         **kwargs
             Description
         """
+        self.kwargs = kwargs
+
         # Assign titers and prepare list of strains.
         if (isinstance(titers, str) and os.path.isfile(titers))\
             or isinstance(titers, list):

--- a/tests/test_titer_models.py
+++ b/tests/test_titer_models.py
@@ -1,0 +1,11 @@
+import pytest
+
+from augur.titer_model import TiterCollection
+
+
+def test_titer_collection():
+    # Confirm that titers load from a file path.
+    titers = TiterCollection("tests/data/titer_model/h3n2_titers_subset.tsv")
+
+    # Confirm that all distinct test and reference strains have been counted.
+    assert len(titers.strains) == 13


### PR DESCRIPTION
When instantiating a TiterCollection from a filename, the `read_titers` method tries to access the `kwargs` attribute of the object, but this attribute never gets set. This commit fixes the bug and adds a minimal unit test to make sure the `TiterCollection` class works as expected.
