### PR TITLE
Count insertion/deletion events once in pairwise distances

### DIFF
--- a/augur/distance.py
+++ b/augur/distance.py
@@ -135,6 +135,7 @@ import Bio
 import Bio.Phylo
 from collections import defaultdict
 import copy
+from itertools import chain
 import json
 import numpy as np
 import pandas as pd
@@ -300,6 +301,28 @@ def get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map,
     >>> get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
     2
 
+    If the default value is greater than any of the site-specific mismatches and
+    the specific mismatch does not have a weighted defined, use the default
+    weight.
+
+    >>> distance_map = {
+    ...     "default": 4,
+    ...     "map": {
+    ...         "gene": {
+    ...             1: {
+    ...                 ('C', 'G'): 1,
+    ...                 ('C', 'A'): 2
+    ...             },
+    ...             2: {
+    ...                 ('T', 'G'): 3,
+    ...                 ('T', 'A'): 2
+    ...             }
+    ...         }
+    ...     }
+    ... }
+    >>> get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
+    4
+
     Count mismatches adjacent to indel events.
 
     >>> node_a_sequences = {"gene": "ACTGTA"}
@@ -375,7 +398,10 @@ def get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map,
                         elif seq_ancestral == "-" or seq_derived == "-":
                             mismatch_distances.append(
                                 aggregate_function(
-                                    distance_map["map"][gene][site].values()
+                                    chain(
+                                        (distance_map["default"],),
+                                        distance_map["map"][gene][site].values()
+                                    )
                                 )
                             )
                         # Finally, use the default weight, if no

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -246,6 +246,68 @@ def get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
     >>> get_distance_between_nodes(node_b_sequences, node_a_sequences, distance_map)
     0.0
 
+    Treat a single indel as one event.
+
+    >>> node_a_sequences = {"gene": "ACTG"}
+    >>> node_b_sequences = {"gene": "A--G"}
+    >>> distance_map = {"default": 1, "map": {}}
+    >>> get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
+    1
+
+    Use the maximum weight of all sites affected by an indel with a site-specific distance map.
+
+    >>> distance_map = {"default": 0, "map": {"gene": {1: 1, 2: 2}}}
+    >>> get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
+    2
+
+    Use the maximum weight of all mutations at all sites affected by an indel with a mutation-specific distance map.
+
+    >>> distance_map = {
+    ...     "default": 0,
+    ...     "map": {
+    ...         "gene": {
+    ...             1: {
+    ...                 ('C', 'G'): 1,
+    ...                 ('C', 'A'): 2
+    ...             },
+    ...             2: {
+    ...                 ('T', 'G'): 3,
+    ...                 ('T', 'A'): 2
+    ...             }
+    ...         }
+    ...     }
+    ... }
+    >>> get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
+    3
+
+    Use the maximum weight of gaps at all sites affected by an indel with a mutation-specific distance map.
+
+    >>> distance_map = {
+    ...     "default": 0,
+    ...     "map": {
+    ...         "gene": {
+    ...             1: {
+    ...                 ('C', '-'): 1,
+    ...                 ('C', 'A'): 2
+    ...             },
+    ...             2: {
+    ...                 ('T', 'G'): 3,
+    ...                 ('T', '-'): 2
+    ...             }
+    ...         }
+    ...     }
+    ... }
+    >>> get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
+    2
+
+    Count mismatches adjacent to indel events.
+
+    >>> node_a_sequences = {"gene": "ACTGTA"}
+    >>> node_b_sequences = {"gene": "A--CCA"}
+    >>> distance_map = {"default": 1, "map": {}}
+    >>> get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
+    3
+
     Ignore specific characters defined in the distance map.
 
     >>> node_a_sequences = {"gene": "ACTGG"}
@@ -256,6 +318,7 @@ def get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
     >>> distance_map = {"default": 1, "ignored_characters":["-", "N"], "map": {}}
     >>> get_distance_between_nodes(node_a_sequences, node_b_sequences, distance_map)
     0
+
     """
     distance_type = type(distance_map["default"])
     distance = distance_type(0)


### PR DESCRIPTION
### Description of proposed changes    

Counts insertion/deletion (indel) events between sequences as single events instead of counting each gap character independently. Adds logic to support user-defined weights for gaps between specific characters, aggregating weights across all potential mismatches in a sequence-specific distance map, and aggregating weights across all sites in an indel event.

### Related issue(s)  

Fixes #692   

### Testing

Adds doctests for the new expected behavior.