### PR TITLE
Git ignore log files created by run_tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ Thumbs.db
 
 # slurm logs
 builds/flu/slurm_log/*
+
+# run_tests logs
+tests/functional/tree/*.log


### PR DESCRIPTION
### Description of proposed changes    
git ignore *.log files created by `bash run_tests.sh`

### Related issue(s)  
Fixes #700


### Testing
Steps taken to test the proposed changes:

Execute `run_tests.sh`:
```
(nextstrain)  ddye@cornix  ~/Projects/nextstrain/augur   git_ignore_run_tests_logs  bash run_tests.sh
Running unit tests and doctests with pytest
================================================================================================= test session starts ==================================================================================================
platform darwin -- Python 3.9.2, pytest-5.4.3, py-1.10.0, pluggy-0.13.1 -- /usr/local/opt/python@3.9/bin/python3.9
cachedir: .pytest_cache
rootdir: /Users/ddye/Projects/nextstrain/augur, inifile: pytest.python3.ini, testpaths: augur/, tests/
plugins: mock-2.0.0, cov-2.8.1
collected 241 items

augur/align.py::augur.align.strip_non_reference PASSED
...
```

Verify the .log files no longer dirty git:
```
(nextstrain)  ✘ ddye@cornix  ~/Projects/nextstrain/augur   git_ignore_run_tests_logs  git status
On branch git_ignore_run_tests_logs
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	alignment.fasta.to_align.fasta

nothing added to commit but untracked files present (use "git add" to track)
```