### PR TITLE
WIP: Include functional test results from cram in test coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       install:
         - pip install -e .[dev]
       script:
-        - (coverage run `which cram` --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
+        - (coverage run -m cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
         - (pytest -c pytest.python3.ini  --cov-report= --cov=augur --cov-append)
         - (bash tests/builds/runner.sh)
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       install:
         - pip install -e .[dev]
       script:
-        - (`which coverage` `which cram` --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
+        - (`which coverage` run `which cram` --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
         - (pytest -c pytest.python3.ini  --cov-report= --cov=augur)
         - (bash tests/builds/runner.sh)
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
         - pip install -e .[dev]
       script:
         - (`which coverage` run `which cram` --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
-        - (pytest -c pytest.python3.ini  --cov-report= --cov=augur)
+        - (pytest -c pytest.python3.ini  --cov-report= --cov=augur --cov-append)
         - (bash tests/builds/runner.sh)
       after_success:
         # upload to codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       install:
         - pip install -e .[dev]
       script:
-        - (`which coverage` run `which cram` --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
+        - (coverage run `which cram` --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
         - (pytest -c pytest.python3.ini  --cov-report= --cov=augur --cov-append)
         - (bash tests/builds/runner.sh)
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ jobs:
       install:
         - pip install -e .[dev]
       script:
+        - (`which coverage` `which cram` --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
         - (pytest -c pytest.python3.ini  --cov-report= --cov=augur)
-        - (cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
         - (bash tests/builds/runner.sh)
       after_success:
         # upload to codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       install:
         - pip install -e .[dev]
       script:
-        - (coverage run -m cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
+        - (cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t)
         - (pytest -c pytest.python3.ini  --cov-report= --cov=augur --cov-append)
         - (bash tests/builds/runner.sh)
       after_success:


### PR DESCRIPTION
### Description of proposed changes  (WIP)
> Coverage reports from pytest help us identify large gaps in our tests. Functional tests written in Cram aren't currently reflected in coverage reports, but they likely cover code that isn't covered by unit tests.

To resolve, `cram` is run with `coverage` enabled *before* pytest in CI.

### Related issue(s)  

Fixes #688  

### Testing (WIP)

#### ToDo
 * [ ] Verify coverage increases with the changeset