### PR TITLE
Recommend an alternate action when skyline optimization fails

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -222,7 +222,11 @@ def run(args):
                 node_data['skyline'] = [[float(x) for x in skyline.x], [float(y) for y in conf[0]],
                                         [float(y) for y in skyline.y], [float(y) for y in conf[1]]]
             except:
-                print("ERROR: skyline optimization by TreeTime has failed.", file=sys.stderr)
+                print(
+                    "ERROR: skyline optimization by TreeTime has failed.",
+                    "To avoid this error, try running without coalescent optimization or with `--coalescent opt` instead of `--coalescent skyline`.",
+                    file=sys.stderr
+                )
                 return 1
 
         attributes.extend(['numdate', 'clock_length', 'mutation_length', 'raw_date', 'date'])


### PR DESCRIPTION
### Description of proposed changes

The refine command can fail when skyline optimization in TreeTime fails.
These failures are most likely data-dependent, but this commit updates
the error message for this edge case to let the user know they should
try another approach.

### Related issue(s)

Related to #709

### Testing

This is difficult to test unless we have data that fails skyline optimization, but I tested this by raising an exception in the preceding `try` block and confirming that the new error was printed as expected.