### PR TITLE
Enable reading metadata as a pandas DataFrame

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -137,7 +137,12 @@ disable=print-statement,
         missing-docstring,
         bad-whitespace,
         line-too-long,
-        invalid-name
+        invalid-name,
+        wrong-import-order,
+        multiple-imports,
+        no-else-return,
+        unscriptable-object,
+        relative-beyond-top-level
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/augur/util_support/metadata_file.py
+++ b/augur/util_support/metadata_file.py
@@ -11,9 +11,10 @@ class MetadataFile:
     which is used to match metadata with samples.
     """
 
-    def __init__(self, fname, query=None):
+    def __init__(self, fname, query=None, as_data_frame=False):
         self.fname = fname
         self.query = query
+        self.as_data_frame = as_data_frame
 
         self.key_type = self.find_key_type()
 
@@ -26,8 +27,12 @@ class MetadataFile:
         # original "strain"/"name" remains in the output.
         self.metadata["_index"] = self.metadata[self.key_type]
 
-        metadata_dict = self.metadata.set_index("_index").to_dict("index")
-        return metadata_dict, self.columns
+        metadata = self.metadata.set_index("_index")
+
+        if self.as_data_frame:
+            return metadata, self.columns
+        else:
+            return metadata.to_dict("index"), self.columns
 
     @property
     @functools.lru_cache()

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -1,6 +1,7 @@
 import argparse
 import Bio
 import Bio.Phylo
+from datetime import datetime
 import gzip
 import os, json, sys
 import pandas as pd
@@ -59,8 +60,8 @@ def get_json_name(args, default=None):
 def ambiguous_date_to_date_range(uncertain_date, fmt, min_max_year=None):
     return DateDisambiguator(uncertain_date, fmt=fmt, min_max_year=min_max_year).range()
 
-def read_metadata(fname, query=None):
-    return MetadataFile(fname, query).read()
+def read_metadata(fname, query=None, as_data_frame=False):
+    return MetadataFile(fname, query, as_data_frame).read()
 
 def is_date_ambiguous(date, ambiguous_by="any"):
     """
@@ -93,28 +94,63 @@ def is_date_ambiguous(date, ambiguous_by="any"):
         "X" in day and ambiguous_by in ("any", "day")
     ))
 
+def get_numerical_date_from_value(value, fmt=None, min_max_year=None, raise_error=True):
+    if type(value)!=str:
+        if raise_error:
+            raise ValueError(value)
+        else:
+            numerical_date = None
+    elif 'XX' in value:
+        ambig_date = ambiguous_date_to_date_range(value, fmt, min_max_year)
+        if ambig_date is None or None in ambig_date:
+            numerical_date = [None, None] #don't send to numeric_date or will be set to today
+        else:
+            numerical_date = [numeric_date(d) for d in ambig_date]
+    else:
+        try:
+            numerical_date = numeric_date(datetime.strptime(value, fmt))
+        except:
+            numerical_date = None
+
+    return numerical_date
+
 def get_numerical_dates(meta_dict, name_col = None, date_col='date', fmt=None, min_max_year=None):
     if fmt:
-        from datetime import datetime
         numerical_dates = {}
-        for k,m in meta_dict.items():
-            v = m[date_col]
-            if type(v)!=str:
-                print("WARNING: %s has an invalid data string:"%k,v)
-                continue
-            elif 'XX' in v:
-                ambig_date = ambiguous_date_to_date_range(v, fmt, min_max_year)
-                if ambig_date is None or None in ambig_date:
-                    numerical_dates[k] = [None, None] #don't send to numeric_date or will be set to today
-                else:
-                    numerical_dates[k] = [numeric_date(d) for d in ambig_date]
-            else:
+
+        if isinstance(meta_dict, dict):
+            for k,m in meta_dict.items():
+                v = m[date_col]
                 try:
-                    numerical_dates[k] = numeric_date(datetime.strptime(v, fmt))
-                except:
-                    numerical_dates[k] = None
+                    numerical_dates[k] = get_numerical_date_from_value(
+                        v,
+                        fmt,
+                        min_max_year
+                    )
+                except ValueError:
+                    print(
+                        "WARNING: %s has an invalid data string: %s"% (k, v),
+                        file=sys.stderr
+                    )
+                    continue
+        elif isinstance(meta_dict, pd.DataFrame):
+            strains = meta_dict.index.values
+            dates = meta_dict[date_col].apply(
+                lambda date: get_numerical_date_from_value(
+                    date,
+                    fmt,
+                    min_max_year,
+                    raise_error=False
+                )
+            ).values
+            numerical_dates = dict(zip(strains, dates))
     else:
-        numerical_dates = {k:float(v) for k,v in meta_dict.items()}
+        if isinstance(meta_dict, dict):
+            numerical_dates = {k:float(v) for k,v in meta_dict.items()}
+        elif isinstance(meta_dict, pd.DataFrame):
+            strains = meta_dict.index.values
+            dates = meta_dict[date_col].astype(float)
+            numerical_dates = dict(zip(strains, dates))
 
     return numerical_dates
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -9,6 +9,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
 import augur.filter
+from augur.utils import read_metadata
 
 @pytest.fixture
 def argparser():
@@ -163,8 +164,9 @@ class TestFilter:
                                           ("SEQ_1","colorado","good"),
                                           ("SEQ_2","colorado","bad"),
                                           ("SEQ_3","nevada","good")))
-        filtered = augur.filter.filter_by_query(sequences.keys(), meta_fn, 'quality=="good"')
-        assert filtered == ["SEQ_1", "SEQ_3"]
+        metadata, columns = read_metadata(meta_fn, as_data_frame=True)
+        filtered = augur.filter.filter_by_query(set(sequences.keys()), metadata, 'quality=="good"')
+        assert sorted(filtered) == ["SEQ_1", "SEQ_3"]
 
     def test_filter_on_query_subset(self, tmpdir):
         """Test filtering on query works when given fewer strains than metadata"""
@@ -172,8 +174,9 @@ class TestFilter:
                                           ("SEQ_1","colorado","good"),
                                           ("SEQ_2","colorado","bad"),
                                           ("SEQ_3","nevada","good")))
-        filtered = augur.filter.filter_by_query(["SEQ_2"], meta_fn, 'quality=="bad" & location=="colorado"')
-        assert filtered == ["SEQ_2"]
+        metadata, columns = read_metadata(meta_fn, as_data_frame=True)
+        filtered = augur.filter.filter_by_query({"SEQ_2"}, metadata, 'quality=="bad" & location=="colorado"')
+        assert sorted(filtered) == ["SEQ_2"]
 
     def test_filter_run_with_query(self, tmpdir, fasta_fn, argparser):
         """Test that filter --query works as expected"""


### PR DESCRIPTION
## Description of proposed changes

This PR modifies the current `read_metadata` function in `utils.py` and the associated `metadata_file.py` module to allow users to read metadata as a pandas DataFrame instead of as a Python dictionary. We have used pandas to read our metadata for a long time now, but we have converted the intermediate DataFrame into a dictionary for backwards compatibility across Augur. Since Python dictionaries use memory less efficiently than DataFrames for this type of data, we would like the option to return the intermediate DataFrame as the final representation of the metadata.

Most changes in this PR involve updating the `filter.py` module to use this new DataFrame interface for its downstream filtering logic. The most complicated change here involves a refactor of the `get_numerical_dates` utility function to support dates from a DataFrame. While we could rewrite this function to use less redundant logic, we can leave that work for a later PR.

Note that this PR is the first step toward a refactor of `filter.py` described in #699. By using pandas DataFrames in the filter logic now, we can later rely on the DataFrame chunking interface to avoid reading all metadata into memory and still benefit from pandas' `query`, indexing, and data type-related functionality.

## Related issue(s)

Related to #699

## Testing

- [x] Tested by CI