### PR TITLE
Refactor filters into separate functions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -142,7 +142,8 @@ disable=print-statement,
         multiple-imports,
         no-else-return,
         unscriptable-object,
-        relative-beyond-top-level
+        relative-beyond-top-level,
+        no-member
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/functional/filter.t
+++ b/tests/functional/filter.t
@@ -3,6 +3,19 @@ Integration tests for augur filter.
   $ pushd "$TESTDIR" > /dev/null
   $ export AUGUR="../../bin/augur"
 
+Filter with exclude query for two regions that comprise all but one strain.
+This filter should leave a single record from Oceania.
+Force include one South American record by country to get two total records.
+
+  $ ${AUGUR} filter \
+  >  --metadata filter/metadata.tsv \
+  >  --exclude-where "region=South America" "region=North America" \
+  >  --include-where "country=Ecuador" \
+  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  $ wc -l "$TMP/filtered_strains.txt"
+  \s*2 .* (re)
+  $ rm -f "$TMP/filtered_strains.txt"
+
 Filter with subsampling, requesting 1 sequence per group (for a group with 3 distinct values).
 
   $ ${AUGUR} filter \

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -165,18 +165,8 @@ class TestFilter:
                                           ("SEQ_2","colorado","bad"),
                                           ("SEQ_3","nevada","good")))
         metadata, columns = read_metadata(meta_fn, as_data_frame=True)
-        filtered = augur.filter.filter_by_query(set(sequences.keys()), metadata, 'quality=="good"')
+        filtered = augur.filter.filter_by_query(metadata, 'quality=="good"')
         assert sorted(filtered) == ["SEQ_1", "SEQ_3"]
-
-    def test_filter_on_query_subset(self, tmpdir):
-        """Test filtering on query works when given fewer strains than metadata"""
-        meta_fn = write_metadata(tmpdir, (("strain","location","quality"),
-                                          ("SEQ_1","colorado","good"),
-                                          ("SEQ_2","colorado","bad"),
-                                          ("SEQ_3","nevada","good")))
-        metadata, columns = read_metadata(meta_fn, as_data_frame=True)
-        filtered = augur.filter.filter_by_query({"SEQ_2"}, metadata, 'quality=="bad" & location=="colorado"')
-        assert sorted(filtered) == ["SEQ_2"]
 
     def test_filter_run_with_query(self, tmpdir, fasta_fn, argparser):
         """Test that filter --query works as expected"""


### PR DESCRIPTION
## Description of proposed changes

Refactors filter logic into separate function with the same signature of `func(metadata, **kwargs)` that returns a `set` of strain names that pass the filter. Although this work does not reduce the complexity of the code by itself, it sets up a pattern that will allow us to move all filters into a single loop through all user-requested filters. This change should simplify the main logic and also allow us to short-cut evaluation when filters remove all possible strains (e.g., `--exclude-all`), avoiding unnecessary checks.

This refactoring also includes new functions for sequence-based filters. As part of these sequence-based functions, we update the sequence index data frame to be indexed by strain name to be consistent with the metadata data frame.

One side-effect of this refactoring is the addition of a functional test for both `--include-where` and `--exclude-where` filters to make sure these are properly implemented and no regressions occur during refactoring. The lack of this test initially allowed the refactoring of `--exclude-where` logic to introduce a bug.

Finally, we also define a new function to include strains by a query. Note that this implementation relies on the same query parser used by the `--exclude-where` argument which allows the negation operator and also the code that lowercases the strings before comparison. This change is backward compatible, however, and only adds functionality that is consistent with the `--exclude-where` functionality.

## Related issue(s)

Builds on work in the `pandas-metadata` branch and PR #743 

## Testing

Adds doctests for all new filter functions. Test these functions locally by installing augur with dev dependencies (`python3 -m pip install .[dev]`) with `./run_tests -k filter_by`.