### PR TITLE
augur subsample command

### DIFF
--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -18,6 +18,7 @@ command_strings = [
     "parse",
     "index",
     "filter",
+    "subsample",
     "mask",
     "align",
     "tree",

--- a/augur/data/schema-subsampling.yaml
+++ b/augur/data/schema-subsampling.yaml
@@ -1,0 +1,42 @@
+type: object
+title: YAML Schema for subsampling configuration to be consumed by `augur subsample`
+patternProperties:
+    "^[a-zA-Z0-9*_-]+$":
+        type: object
+        title: description of a sample
+        additionalProperties: false
+        properties:
+            group-by:
+                type: array
+                minItems: 1
+                items:
+                    type: string
+            group_by:
+                description: ncov workflow syntax for group-by
+                type: string
+            sequences-per-group:
+                type: integer
+            seq_per_group:
+                description: ncov workflow syntax for sequences-per-group
+                type: integer
+            exclude-where:
+                type: array
+                minItems: 1
+                items:
+                    type: string
+            exclude:
+                description: ncov syntax for exclude-where uses this and starts with --exclude-where
+                type: string
+            query:
+                description: ncov workflow syntax starts with --query
+                type: string
+            sampling_scheme:
+                description: used by the ncov workflow to express extra arguments to augur filter
+                type: string
+            subsample-max-sequences:
+                type: integer
+            max_sequences:
+                description: ncov workflow syntax for subsample-max-sequences
+                type: integer
+            priorities:
+                type: object

--- a/augur/priorities.py
+++ b/augur/priorities.py
@@ -1,0 +1,238 @@
+import argparse
+from .io import read_sequences
+from random import shuffle
+from collections import defaultdict
+import numpy as np
+import pandas as pd
+from Bio.SeqIO.FastaIO import SimpleFastaParser
+from Bio.Seq import Seq
+from Bio import AlignIO, SeqIO
+from scipy import sparse
+import sys
+
+def compactify_sequences(sparse_matrix, sequence_names):
+    sequence_groups = defaultdict(list)
+    for s, snps in zip(sequence_names, sparse_matrix):
+        ind = snps.nonzero()
+        vals = np.array(snps[ind])
+        if len(ind[1]):
+            sequence_groups[tuple(zip(ind[1], vals[0]))].append(s)
+        else:
+            sequence_groups[tuple()].append(s)
+
+    return sequence_groups
+
+INITIALISATION_LENGTH = 1000000
+
+def sequence_to_int_array(s, fill_value=110, fill_gaps=True):
+    seq = np.frombuffer(str(s).lower().encode('utf-8'), dtype=np.int8).copy()
+    if fill_gaps:
+        seq[(seq!=97) & (seq!=99) & (seq!=103) & (seq!=116)] = fill_value
+    else:
+        seq[(seq!=97) & (seq!=99) & (seq!=103) & (seq!=116) & (seq!=45)] = fill_value
+    return seq
+
+# Function adapted from https://github.com/gtonkinhill/pairsnp-python
+def calculate_snp_matrix(fastafile, consensus=None, zipped=False, fill_value=110, chunk_size=0, ignore_seqs=None):
+    # This function generate a sparse matrix where differences to the consensus are coded as integers.
+    if ignore_seqs is None:
+        ignore_seqs = []
+
+    row = np.empty(INITIALISATION_LENGTH)
+    col = np.empty(INITIALISATION_LENGTH, dtype=np.int64)
+    val = np.empty(INITIALISATION_LENGTH, dtype=np.int8)
+
+    r = 0
+    n_snps = 0
+    nseqs = 0
+    seq_names = []
+    filled_positions = []
+    current_length = INITIALISATION_LENGTH
+
+    for record in fastafile:
+        h = record.name
+        s = str(record.seq)
+
+        if h in ignore_seqs:
+            continue
+        if consensus is None:
+            align_length = len(s)
+            # Take consensus as first sequence
+            consensus = sequence_to_int_array(s, fill_value=fill_value)
+        else:
+            align_length = len(consensus)
+
+        nseqs +=1
+        seq_names.append(h)
+
+        if(len(s)!=align_length):
+            raise ValueError('Fasta file appears to have sequences of different lengths!')
+
+        s = sequence_to_int_array(s, fill_value=fill_value)
+        snps = (consensus!=s) & (s!=fill_value)
+        right = n_snps + np.sum(snps)
+        filled_positions.append(np.where(s==fill_value)[0])
+
+        if right >= (current_length/2):
+            current_length = current_length + INITIALISATION_LENGTH
+            row.resize(current_length)
+            col.resize(current_length)
+            val.resize(current_length)
+
+        row[n_snps:right] = r
+        col[n_snps:right] = np.flatnonzero(snps)
+        val[n_snps:right] = s[snps]
+        r += 1
+        n_snps = right
+        if chunk_size and chunk_size==nseqs:
+            break
+
+    if nseqs==0:
+        return None
+
+    row = row[0:right]
+    col = col[0:right]
+    val = val[0:right]
+
+    sparse_snps = sparse.csc_matrix((val, (row, col)), shape=(nseqs, align_length))
+
+    return {'snps': sparse_snps, 'consensus': consensus, 'names': seq_names, 'filled_positions': filled_positions}
+
+# Function adapted from https://github.com/gtonkinhill/pairsnp-python
+def calculate_distance_matrix(sparse_matrix_A, sparse_matrix_B, consensus):
+
+    n_seqs_A = sparse_matrix_A.shape[0]
+    n_seqs_B = sparse_matrix_B.shape[0]
+
+    d = (1*(sparse_matrix_A==97)) * (sparse_matrix_B.transpose()==97)
+    d = d + (1*(sparse_matrix_A==99) * (sparse_matrix_B.transpose()==99))
+    d = d + (1*(sparse_matrix_A==103) * (sparse_matrix_B.transpose()==103))
+    d = d + (1*(sparse_matrix_A==116) * (sparse_matrix_B.transpose()==116))
+
+    d = d.todense()
+
+    n_comp = (1*(sparse_matrix_A==110) * ((sparse_matrix_B==110).transpose())).todense()
+    d = d + n_comp
+
+    temp_total = np.zeros((n_seqs_A, n_seqs_B))
+    temp_total[:] = (1*(sparse_matrix_A>0)).sum(1)
+    temp_total += (1*(sparse_matrix_B>0)).sum(1).transpose()
+
+    total_differences_shared = (1*(sparse_matrix_A>0)) * (sparse_matrix_B.transpose()>0)
+
+    n_total = np.zeros((n_seqs_A, n_seqs_B))
+    n_sum = (1*(sparse_matrix_A==110)).sum(1)
+    n_total[:] = n_sum
+    n_total += (1*(sparse_matrix_B==110)).sum(1).transpose()
+
+    diff_n = n_total - 2*n_comp
+    d = temp_total - total_differences_shared.todense() - d - diff_n
+
+    return d
+
+def get_distance_to_focal_set():
+    """
+    Calculate minimal distances between sequences in an alignment and a set of focal sequences
+    """
+    parser = argparse.ArgumentParser(
+        description="generate priorities files based on genetic proximity to focal sample",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--alignment", type=str, required=True, help="FASTA file of alignment")
+    parser.add_argument("--reference", type = str, required=True, help="reference sequence (FASTA)")
+    parser.add_argument("--ignore-seqs", type = str, nargs='+', help="sequences to ignore in distance calculation")
+    parser.add_argument("--focal-alignment", type = str, required=True, help="focal sample of sequences")
+    parser.add_argument("--chunk-size", type=int, default=10000, help="number of samples in the global alignment to process at once. Reduce this number to reduce memory usage at the cost of increased run-time.")
+    parser.add_argument("--output", type=str, required=True, help="FASTA file of output alignment")
+    args = parser.parse_args()
+
+    # load entire alignment and the alignment of focal sequences (upper case -- probably not necessary)
+    ref = sequence_to_int_array(SeqIO.read(args.reference, 'fasta').seq)
+    alignment_length = len(ref)
+
+    focal_seqs = read_sequences(args.focal_alignment)
+    focal_seqs_dict = calculate_snp_matrix(focal_seqs, consensus = ref, ignore_seqs=args.ignore_seqs)
+
+    if focal_seqs_dict is None:
+        print(
+            f"ERROR: There are no valid sequences in the focal alignment, '{args.focal_alignment}', to compare against the full alignment.",
+            "Check your subsampling settings for the focal alignment or consider disabling proximity-based subsampling.",
+            file=sys.stderr
+        )
+        sys.exit(1)
+
+    seqs = read_sequences(args.alignment)
+
+    # export priorities
+    fh_out = open(args.output, 'w')
+    fh_out.write('strain\tclosest strain\tdistance\n')
+
+    chunk_size=args.chunk_size
+    chunk_count = 0
+    while True:
+        context_seqs_dict = calculate_snp_matrix(seqs, consensus=ref, chunk_size=chunk_size)
+        if context_seqs_dict is None:
+            break
+
+        print("Reading the alignments.", chunk_count*chunk_size)
+
+        # calculate number of masked sites in either set
+        mask_count_focal = np.array([len(x) for x in focal_seqs_dict['filled_positions']])
+        mask_count_context = {s: len(x) for s,x in zip(context_seqs_dict['names'], context_seqs_dict['filled_positions'])}
+
+        # for each context sequence, calculate minimal distance to focal set, weigh with number of N/- to pick best sequence
+        d = np.array(calculate_distance_matrix(context_seqs_dict['snps'], focal_seqs_dict['snps'], consensus = context_seqs_dict['consensus']))
+        closest_match = np.argmin(d+mask_count_focal/alignment_length, axis=1)
+        print("Done finding closest matches.")
+
+        minimal_distance_to_focal_set = {}
+        for context_index, focal_index in enumerate(closest_match):
+            minimal_distance_to_focal_set[context_seqs_dict['names'][context_index]] = (d[context_index, focal_index], focal_seqs_dict["names"][focal_index])
+
+        for seqid in minimal_distance_to_focal_set:
+            fh_out.write(f"{seqid}\t{minimal_distance_to_focal_set[seqid][1]}\t{minimal_distance_to_focal_set[seqid][0]}\n")
+
+        chunk_count += 1
+
+    fh_out.close()
+
+
+
+
+def proximities():
+    """
+    calculate priorties from index and proximities
+    """
+    parser = argparse.ArgumentParser(
+        description="generate priorities files based on genetic proximity to focal sample",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--sequence-index", type=str, required=True, help="sequence index file")
+    parser.add_argument("--proximities", type = str, required=True, help="tsv file with proximities")
+    parser.add_argument("--Nweight", type = float, default=0.003, required=False, help="parameterizes de-prioritization of incomplete sequences")
+    parser.add_argument("--crowding-penalty", type = float, default=0.01, required=False, help="parameterizes how priorities decrease when there is many very similar sequences")
+    parser.add_argument("--output", type=str, required=True, help="tsv file with the priorities")
+    args = parser.parse_args()
+
+    proximities = pd.read_csv(args.proximities, sep='\t', index_col=0)
+    index = pd.read_csv(args.sequence_index, sep='\t', index_col=0)
+    combined = pd.concat([proximities, index], axis=1)
+
+    closest_matches = combined.groupby('closest strain')
+    candidates = {}
+    for focal_seq, seqs in closest_matches.groups.items():
+        tmp = combined.loc[seqs, ["distance", "N"]]
+        # penalize larger distances and more undetermined sites. 1/args.Nweight are 'as bad' as one extra mutation
+        tmp["priority"] = -tmp.distance - tmp.N*args.Nweight
+        name_prior = [(name, d.priority) for name, d in tmp.iterrows()]
+        shuffle(name_prior)
+        candidates[focal_seq] = sorted(name_prior, key=lambda x:x[1])
+
+    # export priorities
+    crowding = args.crowding_penalty
+    with open(args.output, 'w') as fh:
+        # loop over lists of sequences that are closest to particular focal sequences
+        for cs in candidates.values():
+            # these sets have been shuffled -- reduce priorities in this shuffled random order
+            for i, (name, pr) in enumerate(cs):
+                fh.write(f"{name}\t{pr-i*crowding:1.2f}\n")

--- a/augur/subsample.py
+++ b/augur/subsample.py
@@ -1,0 +1,355 @@
+"""
+Subsample an alignment
+"""
+from .utils import AugurException
+from .filter import run as augur_filter
+from .priorities import get_distance_to_focal_set, create_priorities
+from .index import index_sequences
+from .io import write_sequences, open_file, read_sequences, read_metadata
+import yaml
+from argparse import Namespace
+from os import path
+import pandas as pd
+from tempfile import NamedTemporaryFile
+import jsonschema
+from pkg_resources import resource_string
+import shlex
+
+def register_arguments(parser):
+    parser.add_argument('--scheme', required=True, metavar="YAML", help="subsampling scheme")
+    parser.add_argument('--output-dir', required=True, metavar="PATH", help="directory to save intermediate results")
+    parser.add_argument('--metadata', required=True, metavar="TSV", help="metadata")
+    parser.add_argument('--alignment', required=True, metavar="FASTA", help="alignment to subsample")
+    parser.add_argument('--alignment-index', required=False, metavar="INDEX", help="sequence index of alignment")
+    parser.add_argument('--reference', required=True, metavar="FASTA", help="reference (which was used for alignment)")
+    parser.add_argument('--include-strains-file', required=False, nargs="+", default=None, metavar="TXT", help="strains to force include")
+    parser.add_argument('--exclude-strains-file', required=False, nargs="+", default=None, metavar="TXT", help="strains to force exclude")
+    parser.add_argument('--output-fasta', required=True, metavar="FASTA", help="output subsampled sequences")
+    parser.add_argument('--output-metadata', required=True, metavar="TSV", help="output subsampled metadata")
+    parser.add_argument('--output-log', required=False, metavar="TSV", help="log file explaining why strains were excluded / included")
+
+def run(args):
+    
+    config = parse_scheme(args.scheme)
+
+    generate_sequence_index(args)
+
+    samples = [Sample(name, data, args) for name, data in config.items()]
+
+    graph = make_graph(samples)
+
+    traverse_graph(
+        graph,
+        lambda s: s.filter()
+    )
+
+    combine_samples(args, samples)
+
+def parse_scheme(filename):
+    with open(filename) as fh:
+        try:
+            data = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            print(exc)
+            raise AugurException(f"Error parsing subsampling scheme {filename}")
+    validate_scheme(data)
+    return data
+
+
+def validate_scheme(scheme):
+    try:
+        # with open(resource_string(__package__, path.join("data", "schema-subsampling.yaml"))) as fh:
+        schema = yaml.safe_load(resource_string(__package__, path.join("data", "schema-subsampling.yaml")))
+    except yaml.YAMLError as err:
+        raise AugurException("Subsampling schema definition is not valid YAML. Error: {}".format(err))
+    # check loaded schema is itself valid -- see http://python-jsonschema.readthedocs.io/en/latest/errors/
+    try:
+        jsonschema.Draft6Validator.check_schema(schema)
+    except jsonschema.exceptions.SchemaError as err:
+        raise AugurException("Subsampling schema definition is not valid. Error: {}".format(path, err))
+
+    try:
+        jsonschema.Draft6Validator(schema).validate(scheme)
+    except jsonschema.exceptions.ValidationError as err:
+        print(err)
+        raise AugurException("Subsampling scheme failed validation")
+
+
+class Sample():
+    """
+    A class to hold information about a sample. A subsampling scheme will consist of multiple
+    samples. Each sample may depend on the priorities based off another sample.
+    """
+    def __init__(self, name, config, cmd_args):
+        self.name = name
+        self.tmp_dir = cmd_args.output_dir
+        self.alignment = cmd_args.alignment
+        self.alignment_index = cmd_args.alignment_index
+        self.reference = cmd_args.reference
+        self.metadata = cmd_args.metadata
+        self.initialise_filter_args(config, cmd_args)
+        self.priorities = config.get("priorities", None) 
+        print("Constructor", self.name)
+    
+    def initialise_filter_args(self, config, subsample_args):
+        """
+        Currently this method is needed as we need to call `augur filter`'s `run()` with an
+        argparse instance. An improvement here would be to expose appropriate filtering
+        functions and call them as needed, with the output being `return`ed rather than
+        written to disk.
+        """
+        args = Namespace()
+        args.metadata = self.metadata
+        args.sequences = self.alignment
+        args.sequence_index = self.alignment_index
+        args.metadata_chunk_size = 100000
+        args.metadata_id_columns = ["strain", "name"]
+        args.min_date = None
+        args.max_date = None
+        args.exclude_ambiguous_dates_by = None
+        args.exclude = subsample_args.exclude_strains_file
+        args.exclude_all = None
+        args.include = subsample_args.include_strains_file
+        args.include_where = None
+        args.min_length = None
+        args.non_nucleotide = None
+        args.probabilistic_sampling = None
+        args.no_probabilistic_sampling = None
+        args.priority = None
+        args.subsample_seed = None
+        args.output          = path.join(self.tmp_dir, f"sample.{self.name}.fasta") # filtered sequences in FASTA forma
+        args.output_metadata = path.join(self.tmp_dir, f"sample.{self.name}.tsv")   # metadata for strains that passed filters
+        args.output_strains  = path.join(self.tmp_dir, f"sample.{self.name}.txt")   # list of strains that passed filters (no header)
+        args.output_log      = path.join(self.tmp_dir, f"sample.{self.name}.log.tsv")
+        # translate the subsampling config (YAML) into arguments for `augur filter`
+        # TODO - we should allow schemas to use a data structure identical to augur filter here, for instance
+        # `group-by: [year month]` rather than the current ncov structure which is `group_by: "year month"`
+        # right now we can use a bit of both, but this is not complete!
+        if "group-by" in config:
+            args.group_by = config['group-by']
+        elif "group_by" in config: # ncov syntax
+            args.group_by = shlex.split(config['group_by'])
+        else:
+            args.group_by = None
+        
+        if "sequences-per-group" in config:
+            args.sequences_per_group = config['sequences-per-group']
+        elif "seq_per_group" in config: # ncov syntax
+            args.sequences_per_group = config['seq_per_group']
+        else:
+            args.sequences_per_group = None
+
+        if "query" in config:
+            if config['query'].startswith("--query "):
+                args.query = config['query'].lstrip("--query ").strip('"').strip("'")
+            else:
+                args.query = config['query']
+        else:
+            args.query = None
+        
+        if "exclude-where" in config:
+            args.exclude_where = config['exclude-where'] # list
+        elif "exclude" in config and config['exclude'].startswith("--exclude-where"): # ncov syntax for exclude-where
+            args.exclude_where = shlex.split(config['exclude'])[1:]
+        else:
+            args.exclude_where = None
+        self.filter_args = args
+
+        if "subsample-max-sequences" in config:
+            args.subsample_max_sequences = config["subsample-max-sequences"]
+        elif "max_sequences" in config: # ncov syntax
+            args.subsample_max_sequences = config["max_sequences"]
+        else:
+            args.subsample_max_sequences = None
+
+        if "sampling_scheme" in config:
+            # ncov syntax for expressing additional filter arguments
+            if config["sampling_scheme"]=="--probabilistic-sampling":
+                args.probabilistic_sampling = True
+            elif config["sampling_scheme"]=="--no-probabilistic-sampling":
+                args.no_probabilistic_sampling = True
+
+        # ncov syntax options still to implement:
+        # include_argument = _get_specific_subsampling_setting("include", optional=True),
+        # exclude_ambiguous_dates_argument = _get_specific_subsampling_setting("exclude_ambiguous_dates_by", optional=True),
+        # min_date = _get_specific_subsampling_setting("min_date", optional=True),
+        # max_date = _get_specific_subsampling_setting("max_date", optional=True),
+
+    def calculate_required_priorities(self):
+        """
+        If computation of this sample requires priority information of another sample
+        (the "focus"), then this function will compute those priorities.
+        """
+        if not self.priorities:
+            return
+        focal_sample = self.priorities.get('sample', None)
+        if not focal_sample:
+            raise AugurException(f"Cannot calculate priorities needed for {self.name} as the {self.get_priority_focus_name()} sample wasn't linked")
+        print(f"Calculating priorities required by {self.name}")
+        focal_sample.calculate_priorities()
+
+    def calculate_priorities(self):
+        """
+        Calculate the priorities TSV file for the alignment in the context of this sample
+        """
+        print(f"Calculating proximity of {self.name}")
+        get_distance_to_focal_set(
+            self.alignment,
+            self.reference,
+            self.filter_args.output,
+            path.join(self.tmp_dir, f"proximity_{self.name}.tsv"),
+            ignore_seqs=["Wuhan/Hu-1/2019"]  # TODO - use the config to define this?
+        )
+        print(f"Calculating priorities of {self.name}")
+        create_priorities(
+            self.alignment_index,
+            path.join(self.tmp_dir, f"proximity_{self.name}.tsv"),
+            path.join(self.tmp_dir, f"priorities_{self.name}.tsv")
+        )
+
+    def get_priority_focus_name(self):
+        if not self.priorities:
+            return None
+        return self.priorities['focus']
+
+    def set_priority_sample(self, sample):
+        if not self.priorities:
+            raise AugurException(f"No priorities set for {self.name}")
+        self.priorities['sample'] = sample
+
+    def filter(self):
+        print("\n---------------------------------\nCONSTRUCTING SAMPLE FOR", self.name, "\n---------------------------------")
+        self.calculate_required_priorities()
+        augur_filter(self.filter_args)
+        # In the future, instead of `augur_filter` saving data to disk, it would return
+        # data to the calling process. In lieu of that, we read the data just written.
+        self.sampled_strains = set(pd.read_csv(self.filter_args.output_strains, header=None)[0])
+        self.filter_log = pd.read_csv(
+            self.filter_args.output_log,
+            header=0,
+            sep="\t",
+            index_col="strain"
+        )
+
+
+def make_graph(samples):
+    """"
+    Given a config file, construct a graph of samples to perform in an iterative fashion, such that
+    priorities 
+
+    This is a DAG, however an extremely simple one which we can construct outselves rather than relying on
+    extra libraries.
+
+    Constraints:
+    * Each sample can only use priorities of one other sample
+    * Acyclic
+
+    Structure:
+    tuple: (sample name, list of descendent samples) where a "descendant" sample requires the linked sample to be
+    created prior to it's creation. Each entry in the list has this tuple structure.
+    """
+
+    included = set() # set of samples added to graph
+    graph = (None, [])
+
+    # add all the samples which don't requre priorities to the graph
+    for sample in samples:
+        if not sample.get_priority_focus_name():
+            graph[1].append((sample, []))
+            included.add(sample.name)
+
+    def add_descendants(level):
+        parent_sample = level[0]
+        descendants = level[1]
+        for sample in samples:
+            if sample.name in included:
+                continue
+            if sample.get_priority_focus_name() == parent_sample.name:
+                sample.set_priority_sample(parent_sample)
+                descendants.append((sample, []))
+                included.add(sample.name)
+        for inner_level in descendants:
+            add_descendants(inner_level)
+
+    for level in graph[1]:
+        add_descendants(level)
+
+    # from pprint import pprint
+    # print("\ngraph"); pprint(graph);print("\n")
+
+    if len(samples)!=len(included):
+        AugurException("Incomplete graph construction")
+
+    return graph
+
+def traverse_graph(level, callback):
+    this_sample, descendents = level
+    # print("LEVEL", this_sample, len(descendents))
+    if this_sample:
+        callback(this_sample)
+    for child in descendents:
+        traverse_graph(child, callback)
+
+def generate_sequence_index(args):
+    if args.alignment_index:
+        print("Skipping sequence index creation as an index was provided")
+        return    
+    print("Creating ephemeral sequence index file")
+    with NamedTemporaryFile(delete=False) as sequence_index_file:
+        sequence_index_path = sequence_index_file.name
+        index_sequences(args.alignment, sequence_index_path)
+        args.alignment_index = sequence_index_path
+
+
+def combine_samples(args, samples):
+    """Collect the union of strains which are included in each sample and write them to disk.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed arguments from argparse
+    samples : list[Sample]
+        list of samples
+
+    """
+    print("\n\n")
+    ### Form a union of each sample set, which is the subsampled strains list
+    sampled_strains = set()
+    for sample in samples:
+        print(f"Sample \"{sample.name}\" included {len(sample.sampled_strains)} strains")
+        sampled_strains.update(sample.sampled_strains)
+    print(f"In total, {len(sampled_strains)} strains are included in the resulting subsampled dataset")
+
+    ## Iterate through the input sequences, streaming a subsampled version to disk.
+    sequences = read_sequences(args.alignment)
+    sequences_written_to_disk = 0
+    with open_file(args.output_fasta, "wt") as output_handle:
+        for sequence in sequences:
+            if sequence.id in sampled_strains:
+                sequences_written_to_disk += 1
+                write_sequences(sequence, output_handle, 'fasta')
+    print(f"Writing {sequences_written_to_disk} sequences to {args.output_fasta}")
+
+    ## Iterate through the metadata in chunks, writing out those entries which are in the subsample
+    metadata_reader = read_metadata(
+        args.metadata,
+        id_columns=["strain", "name"], # TODO - this should be an argument
+        chunk_size=10000 # TODO - argument
+    )
+    metadata_header = True
+    metadata_mode = "w"
+    metadata_written_to_disk = "???" # TODO
+    for metadata in metadata_reader:
+        metadata.loc[sampled_strains].to_csv(
+            args.output_metadata,
+            sep="\t",
+            header=metadata_header,
+            mode=metadata_mode,
+        )
+        metadata_header = False
+        metadata_mode = "a"
+    print(f"Writing {metadata_written_to_disk} metadata entries sequences to {args.output_metadata}")
+
+    ## Combine the log files (from augur filter) for each sample into a larger log file
+    ## Format TBD
+    ## TODO


### PR DESCRIPTION
This implements a new augur command `augur subsample`. The code quality is not ready for merge - there are a number of todos, incomplete testing & comments, and some functionality has not yet been implemented. I’m putting it up here to allow discussion about the direction.

A brief description of **the subsampling scheme as implemented in the Snakemake workflow** in the ncov repo:
	1. A build specifies a yaml-formatted subsampling scheme, with template strings which are filled in with build-specific info
	2. A scheme consists of a number of sample definitions
	3. Each sample definition specifies parameters which are translated into arguments to `augur filter`
	4. Each sample definition may define a “priorities” sample, such that the current sample is focused on sequences included in the focal sample

The **current implementation** of `augur subsample` essentially follows this approach:
	1. A subsampling scheme is provided, parsed, validated, and turned into a simple graph to indicate which samples rely on other samples having been computed (i.e. which are needed for priorities)
	2. Each sample is computed by calling the `run` function of  `augur filter`
	3. If priorities need to be calculated for a sample to be computed, this is achieved by calling functions from (a new) `augur/priorities.py` module before step 2. The code here has been taken directly from the nextstrain/ncov repo.
	4. The set of sequences to include in each sample is combined, and outputs written.

The **YAML subsampling scheme** provided to `augur subsample` can take two forms. We can use syntax which mostly maps one-to-one onto arguments used with `augur filter`, such as

```yaml
focal:
  group-by: [year, month]
  sequences-per-group: 5

related:
  group-by: [country, year]
  sequences-per-group: 20
  exclude-where: ["division=Washington"]
  priorities:
    type: "proximity"
    focus: "focal"
```

Or we can use syntax more familiar to our ncov workflows:

```yaml
focal:
  group_by: year month
  seq_per_group: 5

related:
  group_by: country year
  seq_per_group: 20
  exclude: "--exclude-where 'division= Washington'"
  priorities:
    type: "proximity"
    focus: "focal"
```


There’s an **extensive todo list** here, including the following points, however I wanted to discuss with others first.
	* Currently a limited selection of subsampling parameters are allowed in schema definitions 
	* Instead of using `augur filter`’s `run()` function, we could refactor that function slightly to have a function which returns a strain list for inclusion, as well as logging data etc. Currently the `run()` function writes data to disk which we immediately read in.
	* Similarly, the functions in `priority.py` are directly taken from scripts in the ncov repo. These functions can be refactored to return data rather than writing to disk.
	* Decide whether include / exclude files are defined by arguments to `augur subsample` or are set within the scheme definition, which would allow per-sample differences.
	* Write tests!
	* Allow a log file to be written explaining why strains were not included (or why they were!)
	* Expand priorities schema definition so that sample definitions define the `ignore_seqs` etc
	* VCF support
	* For samples which can be computed in parallel (e.g. those which don’t need priorities), in principle we could refactor the code in `augur filter` to allow independent sets of (sets of) filters to be applied each time we iterate over a chunk of metadata. This should speed things up quite a bit, but would come at increased code complexity. I don’t think this is immediately necessary.
	* See code for more!
	* (ncov workflow) allow default / “all” subsampling schemes
	* instead of allowing `augur subsample` to interpret ncov-specific subsampling syntax, we could (should) expand the  `rule extract_subsampling_scheme` to transform the scheme into more canonical, augur-filter style syntax (see above).

**Testing**
The [`subsample` branch of ncov](https://github.com/nextstrain/ncov/tree/subsample) is working for two profiles (and probably broken for all others!):

```
snakemake --cores 4 --profile my_profiles/subsample/ -pf auspice/ncov_test.json
```

```
snakemake --cores 4 --profile nextstrain_profiles/nextstrain-ci -pf all
```

