### PR TITLE
Support latest versions of BioPython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
     python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),
     install_requires = [
         "bcbio-gff >=0.6.0, ==0.6.*",
-        "biopython >=1.67, <=1.76",
+        "biopython >=1.67, !=1.77, !=1.78",
         "jsonschema >=3.0.0, ==3.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",


### PR DESCRIPTION
## Description of proposed changes

Support BioPython 1.79 and later by explicitly disallowing previous versions that did not work.

## Related issue(s)

Fixes #763

## Testing

Tested by CI.