### PR TITLE
Replaces instances of seq.tomutable() with MutableSeq(seq)

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -8,6 +8,7 @@ import sys
 import time
 import uuid
 import Bio
+from Bio.Seq import MutableSeq
 from Bio import Phylo
 import numpy as np
 from treetime.vcf_utils import read_vcf
@@ -324,7 +325,7 @@ def mask_sites_in_multiple_sequence_alignment(alignment_file, excluded_sites_fil
     with open(masked_alignment_file, "w", encoding='utf-8') as oh:
         for record in alignment:
             # Convert to a mutable sequence to enable masking with Ns.
-            sequence = record.seq.tomutable()
+            sequence = MutableSeq(record.seq)
 
             # Replace all excluded sites with Ns.
             for site in excluded_sites:

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -10,6 +10,7 @@ from shlex import quote
 from Bio import SeqIO
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
+from Bio.Seq import MutableSeq
 from Bio.SeqRecord import SeqRecord
 
 from augur import align
@@ -366,7 +367,7 @@ class TestAlign:
     def test_postprocess_strip_non_reference(self, tmpdir, ref_seq, ref_file):
         """Postprocess should strip gaps in the reference sequence from other sequences, but not gaps in those sequences"""
         expected_length = len(ref_seq.seq) - ref_seq.seq.count("-")
-        gapped_seq = ref_seq.seq.tomutable()
+        gapped_seq = MutableSeq(ref_seq.seq)
         gapped_seq[1] = "-"
         gapped = SeqRecord(gapped_seq, "GAP")
         gap_file = write_strains(tmpdir, "gaps", [ref_seq, gapped])


### PR DESCRIPTION
Closes #787


Replaces instances of deprecated seq.tomutable() with MutableSeq(seq)
