### PR TITLE
Add clarity to help message and output of probabilistic sampling

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1697,7 +1697,7 @@ def numeric_date(date):
         return treetime.utils.numeric_date(datetime.date(*map(int, date.split("-", 2))))
 
 
-def calculate_sequences_per_group(target_max_value, counts_per_group, probabilistic=True):
+def calculate_sequences_per_group(target_max_value, counts_per_group, allow_probabilistic=True):
     """Calculate the number of sequences per group for a given maximum number of
     sequences to be returned and the number of sequences in each requested
     group. Optionally, allow the result to be probabilistic such that the mean
@@ -1711,7 +1711,7 @@ def calculate_sequences_per_group(target_max_value, counts_per_group, probabilis
         number of sequences per group for the given counts per group.
     counts_per_group : list[int]
         A list with the number of sequences in each requested group.
-    probabilistic : bool
+    allow_probabilistic : bool
         Whether to allow probabilistic subsampling when the number of groups
         exceeds the requested maximum.
 
@@ -1719,7 +1719,7 @@ def calculate_sequences_per_group(target_max_value, counts_per_group, probabilis
     ------
     TooManyGroupsError :
         When there are more groups than sequences per group and probabilistic
-        subsampling is not enabled.
+        subsampling is not allowed.
 
     Returns
     -------
@@ -1737,7 +1737,7 @@ def calculate_sequences_per_group(target_max_value, counts_per_group, probabilis
             counts_per_group,
         )
     except TooManyGroupsError as error:
-        if probabilistic:
+        if allow_probabilistic:
             print(f"WARNING: {error}")
             sequences_per_group = _calculate_fractional_sequences_per_group(
                 target_max_value,

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1499,10 +1499,14 @@ def run(args):
                 records_per_group.values(),
                 args.probabilistic_sampling,
             )
-            print(f"Sampling probabilistically at {sequences_per_group:0.4f} sequences per group, meaning it is possible to have more than the requested maximum of {args.subsample_max_sequences} sequences after filtering.")
         except TooManyGroupsError as error:
             print(f"ERROR: {error}", file=sys.stderr)
             sys.exit(1)
+
+        if (args.probabilistic_sampling):
+            print(f"Sampling probabilistically at {sequences_per_group:0.4f} sequences per group, meaning it is possible to have more than the requested maximum of {args.subsample_max_sequences} sequences after filtering.")
+        else:
+            print(f"Sampling at {sequences_per_group} per group.")
 
         if queues_by_group is None:
             # We know all of the possible groups now from the first pass through

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1499,7 +1499,7 @@ def run(args):
                 records_per_group.values(),
                 args.probabilistic_sampling,
             )
-            print(f"Sampling at {sequences_per_group} per group.")
+            print(f"Sampling probabilistically at {sequences_per_group:0.4f} sequences per group, meaning it is possible to have more than the requested maximum of {args.subsample_max_sequences} sequences after filtering.")
         except TooManyGroupsError as error:
             print(f"ERROR: {error}", file=sys.stderr)
             sys.exit(1)
@@ -1748,6 +1748,7 @@ def calculate_sequences_per_group(target_max_value, counts_per_group, probabilis
         )
     except TooManyGroupsError as error:
         if probabilistic:
+            print(f"WARNING: {error}")
             sequences_per_group = _calculate_fractional_sequences_per_group(
                 target_max_value,
                 counts_per_group,

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1125,7 +1125,7 @@ def register_arguments(parser):
     subsample_limits_group.add_argument('--sequences-per-group', type=int, help="subsample to no more than this number of sequences per category")
     subsample_limits_group.add_argument('--subsample-max-sequences', type=int, help="subsample to no more than this number of sequences; can be used without the group_by argument")
     probabilistic_sampling_group = subsample_group.add_mutually_exclusive_group()
-    probabilistic_sampling_group.add_argument('--probabilistic-sampling', action='store_true', help="Enable probabilistic sampling during subsampling. This is useful when there are more groups than requested sequences. This option only applies when `--subsample-max-sequences` is provided.")
+    probabilistic_sampling_group.add_argument('--probabilistic-sampling', action='store_true', help="Allow probabilistic sampling during subsampling. This is useful when there are more groups than requested sequences. This option only applies when `--subsample-max-sequences` is provided.")
     probabilistic_sampling_group.add_argument('--no-probabilistic-sampling', action='store_false', dest='probabilistic_sampling')
     subsample_group.add_argument('--priority', type=str, help="""tab-delimited file with list of priority scores for strains (e.g., "<strain>\\t<priority>") and no header.
     When scores are provided, Augur converts scores to floating point values, sorts strains within each subsampling group from highest to lowest priority, and selects the top N strains per group where N is the calculated or requested number of strains per group.

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1476,7 +1476,7 @@ def run(args):
         # sequences requested, sequences per group will be a floating point
         # value and subsampling will be probabilistic.
         try:
-            sequences_per_group = calculate_sequences_per_group(
+            sequences_per_group, probabilistic_used = calculate_sequences_per_group(
                 args.subsample_max_sequences,
                 records_per_group.values(),
                 args.probabilistic_sampling,
@@ -1485,7 +1485,7 @@ def run(args):
             print(f"ERROR: {error}", file=sys.stderr)
             sys.exit(1)
 
-        if (args.probabilistic_sampling):
+        if (probabilistic_used):
             print(f"Sampling probabilistically at {sequences_per_group:0.4f} sequences per group, meaning it is possible to have more than the requested maximum of {args.subsample_max_sequences} sequences after filtering.")
         else:
             print(f"Sampling at {sequences_per_group} per group.")
@@ -1725,8 +1725,12 @@ def calculate_sequences_per_group(target_max_value, counts_per_group, probabilis
     -------
     int or float :
         Number of sequences per group.
+    bool :
+        Whether probabilistic subsampling was used.
 
     """
+    probabilistic_used = False
+
     try:
         sequences_per_group = _calculate_sequences_per_group(
             target_max_value,
@@ -1739,10 +1743,11 @@ def calculate_sequences_per_group(target_max_value, counts_per_group, probabilis
                 target_max_value,
                 counts_per_group,
             )
+            probabilistic_used = True
         else:
             raise error
 
-    return sequences_per_group
+    return sequences_per_group, probabilistic_used
 
 
 class TooManyGroupsError(ValueError):

--- a/tests/functional/filter.t
+++ b/tests/functional/filter.t
@@ -119,6 +119,39 @@ By setting the subsample seed above, we should get the same results for both run
   $ diff -u <(sort "$TMP/filtered_strains_probabilistic.txt") <(sort "$TMP/filtered_strains_default.txt")
   $ rm -f "$TMP/filtered_strains_probabilistic.txt" "$TMP/filtered_strains_default.txt"
 
+Check output of probabilistic sampling.
+
+  $ ${AUGUR} filter \
+  >  --metadata filter/metadata.tsv \
+  >  --group-by region year month \
+  >  --subsample-max-sequences 3 \
+  >  --probabilistic-sampling \
+  >  --subsample-seed 314159 \
+  >  --output-metadata "$TMP/filtered_metadata.tsv"
+  WARNING: Asked to provide at most 3 sequences, but there are 8 groups.
+  Sampling probabilistically at 0.3633 sequences per group, meaning it is possible to have more than the requested maximum of 3 sequences after filtering.
+  10 strains were dropped during filtering
+  \t1 were dropped during grouping due to ambiguous year information (esc)
+  \t1 were dropped during grouping due to ambiguous month information (esc)
+  \t8 of these were dropped because of subsampling criteria, using seed 314159 (esc)
+  2 strains passed all filters
+
+Ensure probabilistic sampling is not used when unnecessary.
+
+  $ ${AUGUR} filter \
+  >  --metadata filter/metadata.tsv \
+  >  --group-by region year month \
+  >  --subsample-max-sequences 10 \
+  >  --probabilistic-sampling \
+  >  --subsample-seed 314159 \
+  >  --output-metadata "$TMP/filtered_metadata.tsv"
+  Sampling at 10 per group.
+  2 strains were dropped during filtering
+  \t1 were dropped during grouping due to ambiguous year information (esc)
+  \t1 were dropped during grouping due to ambiguous month information (esc)
+  \t0 of these were dropped because of subsampling criteria, using seed 314159 (esc)
+  10 strains passed all filters
+
 Filter using only metadata without sequence input or output and save results as filtered metadata.
 
   $ ${AUGUR} filter \


### PR DESCRIPTION
With a low value of `--subsample-max-sequences` relative to the number of groups, it is possible to get more than the desired max number of sequences due to [probabilistic sampling](https://github.com/nextstrain/augur/blob/1146e74763b35d8f5c5447641bdd6242dec4b306/augur/filter.py#L1744-L1756). This PR:

1. Clarifies the behavior in console output.
2. Updates variable names and help strings to reflect whether probabilistic sampling is allowed by `--probabilistic-sampling`, and if it is actually used.

## 1

Example command:

```
augur filter \
    --sequences data/sequences.fasta \
    --sequence-index results/sequence_index.tsv \
    --metadata data/metadata.tsv \
    --exclude config/dropped_strains.txt \
    --output results/filtered.fasta \
    --group-by country year month \
    --subsample-max-sequences 3 \
    --min-date 2012
```

Current output:

```
Sampling at 0.12305646484374999 per group.
29 strains were dropped during filtering
	1 of these were dropped because they were in config/dropped_strains.txt
	28 of these were dropped because of subsampling criteria
5 strains passed all filters
```

New output:

```
WARNING: Asked to provide at most 3 sequences, but there are 24 groups.
Sampling probabilistically at 0.1231 sequences per group, meaning it is possible to have more than the requested maximum of 3 sequences after filtering.
29 strains were dropped during filtering
	1 of these were dropped because they were in config/dropped_strains.txt
	28 of these were dropped because of subsampling criteria
5 strains passed all filters
```

## 2

Command:

```
augur filter --help
```

Current output:

```
  --probabilistic-sampling
                        Enable probabilistic sampling during subsampling. This
                        is useful when there are more groups than requested
                        sequences. This option only applies when `--subsample-
                        max-sequences` is provided. (default: True)
```

New output:

```
  --probabilistic-sampling
                        Allow probabilistic sampling during subsampling. This
                        is useful when there are more groups than requested
                        sequences. This option only applies when `--subsample-
                        max-sequences` is provided. (default: True)
```