### PR TITLE
Use builtin pandas functions to determine subsample groups

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -888,12 +888,12 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     group_by_strain = {}
     skipped_strains = []
 
-    if group_by:
-        groups = group_by
-        groups_set = set(groups)
-    else:
+    if not group_by or group_by == ('_dummy',):
         group_by_strain = {strain: ('_dummy',) for strain in strains}
         return group_by_strain, skipped_strains
+
+    groups = group_by
+    groups_set = set(groups)
 
     date_requested = ('year' in groups_set or 'month' in groups_set)
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -898,7 +898,7 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     date_requested = ('year' in groups_set or 'month' in groups_set)
 
     # If we could not find any requested categories, we cannot complete subsampling.
-    if 'date' not in metadata and date_requested and len(groups) == 1:
+    if 'date' not in metadata and (date_requested and len(groups) == 1) or groups_set == {'year', 'month'}:
         raise FilterException(f"The specified group-by categories ({groups}) were not found. No sequences-per-group sampling will be done. Note that using 'year' or 'year month' requires a column called 'date'.")
     if not groups_set & set(metadata.columns):
         raise FilterException(f"The specified group-by categories ({groups}) were not found. No sequences-per-group sampling will be done.")

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -911,14 +911,13 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
             df_dates = pd.DataFrame({'year': 'unknown', 'month': 'unknown'}, index=metadata.index)
             metadata = pd.concat([metadata, df_dates], axis=1)
         else:
-            if 'date' in metadata:
-                # replace date with year/month/day as nullable ints
-                date_cols = ['year', 'month', 'day']
-                df_dates = (metadata['date'].str.split('-', n=2, expand=True)
-                                                .set_axis(date_cols, axis=1))
-                for col in date_cols:
-                    df_dates[col] = pd.to_numeric(df_dates[col], errors='coerce').astype(pd.Int64Dtype())
-                metadata = pd.concat([metadata.drop('date', axis=1), df_dates], axis=1)
+            # replace date with year/month/day as nullable ints
+            date_cols = ['year', 'month', 'day']
+            df_dates = (metadata['date'].str.split('-', n=2, expand=True)
+                                            .set_axis(date_cols, axis=1))
+            for col in date_cols:
+                df_dates[col] = pd.to_numeric(df_dates[col], errors='coerce').astype(pd.Int64Dtype())
+            metadata = pd.concat([metadata.drop('date', axis=1), df_dates], axis=1)
             if 'year' in groups:
                 # skip ambiguous years
                 df_skip = metadata[metadata['year'].isnull()]

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -888,6 +888,9 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     group_by_strain = {}
     skipped_strains = []
 
+    if metadata.empty:
+        return group_by_strain, skipped_strains
+
     if not group_by or group_by == ('_dummy',):
         group_by_strain = {strain: ('_dummy',) for strain in strains}
         return group_by_strain, skipped_strains

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -885,13 +885,15 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
 
     """
     metadata = metadata.loc[strains]
+    group_by_strain = {}
+    skipped_strains = []
+
     if group_by:
         groups = group_by
     else:
-        groups = ("_dummy",)
+        group_by_strain = {strain: ('_dummy',) for strain in strains}
+        return group_by_strain, skipped_strains
 
-    group_by_strain = {}
-    skipped_strains = []
     # replace date with year/month/date
     if 'date' in metadata:
         date_cols = ['year', 'month', 'date']
@@ -919,7 +921,7 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
                 "filter": "skip_group_by_with_ambiguous_month",
                 "kwargs": "",
             })
-    # TODO: _dummy, unknown
+    # TODO: unknown
 
     group_by_strain = dict(zip(metadata.index, metadata[groups].apply(tuple, axis=1)))
     # If we could not find any requested categories, we cannot complete subsampling.

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -884,6 +884,7 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     [{'strain': 'strain1', 'filter': 'skip_group_by_with_ambiguous_month', 'kwargs': ''}]
 
     """
+    metadata = metadata.loc[strains]
     if group_by:
         groups = group_by
     else:
@@ -891,7 +892,6 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
 
     group_by_strain = {}
     skipped_strains = []
-    # TODO: strains
     # replace date with year/month/date
     if 'date' in metadata:
         date_cols = ['year', 'month', 'date']

--- a/tests/test_filter_groupby.py
+++ b/tests/test_filter_groupby.py
@@ -68,7 +68,6 @@ class TestFilterGroupBy:
         metadata.at["SEQ_2", "date"] = "XXXX-02-01"
         strains = metadata.index.tolist()
         group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata, group_by=groups)
-        print(group_by_strain)
         assert group_by_strain == {
             'SEQ_1': ('A', 2020, (2020, 1)),
             'SEQ_3': ('B', 2020, (2020, 3)),

--- a/tests/test_filter_groupby.py
+++ b/tests/test_filter_groupby.py
@@ -147,3 +147,11 @@ class TestFilterGroupBy:
         captured = capsys.readouterr()
         assert captured.err == "WARNING: A 'date' column could not be found to group-by year or month.\nFiltering by group may behave differently than expected!\n"
         assert skipped_strains == []
+
+    def test_filter_groupby_no_strains(self, valid_metadata: pd.DataFrame):
+        groups = ['country', 'year', 'month']
+        metadata = valid_metadata.copy()
+        strains = []
+        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert group_by_strain == {}
+        assert skipped_strains == []

--- a/tests/test_filter_groupby.py
+++ b/tests/test_filter_groupby.py
@@ -108,23 +108,14 @@ class TestFilterGroupBy:
             get_groups_for_subsampling(strains, metadata, group_by=groups)
         assert str(e_info.value) == "The specified group-by categories (['month']) were not found. No sequences-per-group sampling will be done. Note that using 'year' or 'year month' requires a column called 'date'."
 
-    def test_filter_groupby_missing_date_warn_2(self, valid_metadata: pd.DataFrame, capsys):
+    def test_filter_groupby_missing_year_and_month_error(self, valid_metadata: pd.DataFrame):
         groups = ['year', 'month']
         metadata = valid_metadata.copy()
         metadata = metadata.drop('date', axis='columns')
         strains = metadata.index.tolist()
-        # maybe this should raise exception
-        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata, group_by=groups)
-        assert group_by_strain == {
-            'SEQ_1': ('unknown', 'unknown'),
-            'SEQ_2': ('unknown', 'unknown'),
-            'SEQ_3': ('unknown', 'unknown'),
-            'SEQ_4': ('unknown', 'unknown'),
-            'SEQ_5': ('unknown', 'unknown')
-        }
-        captured = capsys.readouterr()
-        assert captured.err == "WARNING: A 'date' column could not be found to group-by year or month.\nFiltering by group may behave differently than expected!\n"
-        assert skipped_strains == []
+        with pytest.raises(FilterException) as e_info:
+            get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert str(e_info.value) == "The specified group-by categories (['year', 'month']) were not found. No sequences-per-group sampling will be done. Note that using 'year' or 'year month' requires a column called 'date'."
 
     def test_filter_groupby_missing_date_warn(self, valid_metadata: pd.DataFrame, capsys):
         groups = ['country', 'year', 'month']

--- a/tests/test_filter_groupby.py
+++ b/tests/test_filter_groupby.py
@@ -90,6 +90,20 @@ class TestFilterGroupBy:
         }
         assert skipped_strains == [{'strain': 'SEQ_2', 'filter': 'skip_group_by_with_ambiguous_month', 'kwargs': ''}]
 
+    def test_filter_groupby_skip_month_2(self, valid_metadata: pd.DataFrame):
+        groups = ['country', 'year', 'month']
+        metadata = valid_metadata.copy()
+        metadata.at["SEQ_2", "date"] = "2020"
+        strains = metadata.index.tolist()
+        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert group_by_strain == {
+            'SEQ_1': ('A', 2020, (2020, 1)),
+            'SEQ_3': ('B', 2020, (2020, 3)),
+            'SEQ_4': ('B', 2020, (2020, 4)),
+            'SEQ_5': ('B', 2020, (2020, 5))
+        }
+        assert skipped_strains == [{'strain': 'SEQ_2', 'filter': 'skip_group_by_with_ambiguous_month', 'kwargs': ''}]
+
     def test_filter_groupby_missing_year_error(self, valid_metadata: pd.DataFrame):
         groups = ['year']
         metadata = valid_metadata.copy()

--- a/tests/test_filter_groupby.py
+++ b/tests/test_filter_groupby.py
@@ -76,7 +76,7 @@ class TestFilterGroupBy:
         }
         assert skipped_strains == [{'strain': 'SEQ_2', 'filter': 'skip_group_by_with_ambiguous_year', 'kwargs': ''}]
 
-    def test_filter_groupby_skip_month(self, valid_metadata: pd.DataFrame):
+    def test_filter_groupby_skip_ambiguous_month(self, valid_metadata: pd.DataFrame):
         groups = ['country', 'year', 'month']
         metadata = valid_metadata.copy()
         metadata.at["SEQ_2", "date"] = "2020-XX-01"
@@ -90,7 +90,7 @@ class TestFilterGroupBy:
         }
         assert skipped_strains == [{'strain': 'SEQ_2', 'filter': 'skip_group_by_with_ambiguous_month', 'kwargs': ''}]
 
-    def test_filter_groupby_skip_month_2(self, valid_metadata: pd.DataFrame):
+    def test_filter_groupby_skip_missing_month(self, valid_metadata: pd.DataFrame):
         groups = ['country', 'year', 'month']
         metadata = valid_metadata.copy()
         metadata.at["SEQ_2", "date"] = "2020"

--- a/tests/test_filter_groupby.py
+++ b/tests/test_filter_groupby.py
@@ -15,6 +15,17 @@ def valid_metadata() -> pd.DataFrame:
     return pd.DataFrame.from_records(data, columns=columns).set_index('strain')
 
 class TestFilterGroupBy:
+    def test_filter_groupby_strain_subset(self, valid_metadata: pd.DataFrame):
+        metadata = valid_metadata.copy()
+        strains = ['SEQ_1', 'SEQ_3', 'SEQ_5']
+        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata)
+        assert group_by_strain == {
+            'SEQ_1': ('_dummy',),
+            'SEQ_3': ('_dummy',),
+            'SEQ_5': ('_dummy',)
+        }
+        assert skipped_strains == []
+
     def test_filter_groupby_dummy(self, valid_metadata: pd.DataFrame):
         metadata = valid_metadata.copy()
         strains = metadata.index.tolist()

--- a/tests/test_filter_groupby.py
+++ b/tests/test_filter_groupby.py
@@ -1,0 +1,134 @@
+import pytest
+import pandas as pd
+from augur.filter import get_groups_for_subsampling, FilterException
+
+@pytest.fixture
+def valid_metadata() -> pd.DataFrame:
+    columns = ['strain', 'date', 'country']
+    data = [
+        ("SEQ_1","2020-01-XX","A"),
+        ("SEQ_2","2020-02-01","A"),
+        ("SEQ_3","2020-03-01","B"),
+        ("SEQ_4","2020-04-01","B"),
+        ("SEQ_5","2020-05-01","B")
+    ]
+    return pd.DataFrame.from_records(data, columns=columns).set_index('strain')
+
+class TestFilterGroupBy:
+    def test_filter_groupby_dummy(self, valid_metadata: pd.DataFrame):
+        metadata = valid_metadata.copy()
+        strains = metadata.index.tolist()
+        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata)
+        assert group_by_strain == {
+            'SEQ_1': ('_dummy',),
+            'SEQ_2': ('_dummy',),
+            'SEQ_3': ('_dummy',),
+            'SEQ_4': ('_dummy',),
+            'SEQ_5': ('_dummy',)
+        }
+        assert skipped_strains == []
+
+    def test_filter_groupby_invalid_error(self, valid_metadata: pd.DataFrame):
+        groups = ['invalid']
+        metadata = valid_metadata.copy()
+        strains = metadata.index.tolist()
+        with pytest.raises(FilterException) as e_info:
+            get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert str(e_info.value) == "The specified group-by categories (['invalid']) were not found. No sequences-per-group sampling will be done."
+
+    def test_filter_groupby_invalid_warn(self, valid_metadata: pd.DataFrame, capsys):
+        groups = ['country', 'year', 'month', 'invalid']
+        metadata = valid_metadata.copy()
+        strains = metadata.index.tolist()
+        group_by_strain, _ = get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert group_by_strain == {
+            'SEQ_1': ('A', 2020, (2020, 1), 'unknown'),
+            'SEQ_2': ('A', 2020, (2020, 2), 'unknown'),
+            'SEQ_3': ('B', 2020, (2020, 3), 'unknown'),
+            'SEQ_4': ('B', 2020, (2020, 4), 'unknown'),
+            'SEQ_5': ('B', 2020, (2020, 5), 'unknown')
+        }
+        captured = capsys.readouterr()
+        assert captured.err == "WARNING: Some of the specified group-by categories couldn't be found: invalid\nFiltering by group may behave differently than expected!\n"
+
+    def test_filter_groupby_skip_year(self, valid_metadata: pd.DataFrame):
+        groups = ['country', 'year', 'month']
+        metadata = valid_metadata.copy()
+        metadata.at["SEQ_2", "date"] = "XXXX-02-01"
+        strains = metadata.index.tolist()
+        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata, group_by=groups)
+        print(group_by_strain)
+        assert group_by_strain == {
+            'SEQ_1': ('A', 2020, (2020, 1)),
+            'SEQ_3': ('B', 2020, (2020, 3)),
+            'SEQ_4': ('B', 2020, (2020, 4)),
+            'SEQ_5': ('B', 2020, (2020, 5))
+        }
+        assert skipped_strains == [{'strain': 'SEQ_2', 'filter': 'skip_group_by_with_ambiguous_year', 'kwargs': ''}]
+
+    def test_filter_groupby_skip_month(self, valid_metadata: pd.DataFrame):
+        groups = ['country', 'year', 'month']
+        metadata = valid_metadata.copy()
+        metadata.at["SEQ_2", "date"] = "2020-XX-01"
+        strains = metadata.index.tolist()
+        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert group_by_strain == {
+            'SEQ_1': ('A', 2020, (2020, 1)),
+            'SEQ_3': ('B', 2020, (2020, 3)),
+            'SEQ_4': ('B', 2020, (2020, 4)),
+            'SEQ_5': ('B', 2020, (2020, 5))
+        }
+        assert skipped_strains == [{'strain': 'SEQ_2', 'filter': 'skip_group_by_with_ambiguous_month', 'kwargs': ''}]
+
+    def test_filter_groupby_missing_year_error(self, valid_metadata: pd.DataFrame):
+        groups = ['year']
+        metadata = valid_metadata.copy()
+        metadata = metadata.drop('date', axis='columns')
+        strains = metadata.index.tolist()
+        with pytest.raises(FilterException) as e_info:
+            get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert str(e_info.value) == "The specified group-by categories (['year']) were not found. No sequences-per-group sampling will be done. Note that using 'year' or 'year month' requires a column called 'date'."
+
+    def test_filter_groupby_missing_month_error(self, valid_metadata: pd.DataFrame):
+        groups = ['month']
+        metadata = valid_metadata.copy()
+        metadata = metadata.drop('date', axis='columns')
+        strains = metadata.index.tolist()
+        with pytest.raises(FilterException) as e_info:
+            get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert str(e_info.value) == "The specified group-by categories (['month']) were not found. No sequences-per-group sampling will be done. Note that using 'year' or 'year month' requires a column called 'date'."
+
+    def test_filter_groupby_missing_date_warn_2(self, valid_metadata: pd.DataFrame, capsys):
+        groups = ['year', 'month']
+        metadata = valid_metadata.copy()
+        metadata = metadata.drop('date', axis='columns')
+        strains = metadata.index.tolist()
+        # maybe this should raise exception
+        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert group_by_strain == {
+            'SEQ_1': ('unknown', 'unknown'),
+            'SEQ_2': ('unknown', 'unknown'),
+            'SEQ_3': ('unknown', 'unknown'),
+            'SEQ_4': ('unknown', 'unknown'),
+            'SEQ_5': ('unknown', 'unknown')
+        }
+        captured = capsys.readouterr()
+        assert captured.err == "WARNING: A 'date' column could not be found to group-by year or month.\nFiltering by group may behave differently than expected!\n"
+        assert skipped_strains == []
+
+    def test_filter_groupby_missing_date_warn(self, valid_metadata: pd.DataFrame, capsys):
+        groups = ['country', 'year', 'month']
+        metadata = valid_metadata.copy()
+        metadata = metadata.drop('date', axis='columns')
+        strains = metadata.index.tolist()
+        group_by_strain, skipped_strains = get_groups_for_subsampling(strains, metadata, group_by=groups)
+        assert group_by_strain == {
+            'SEQ_1': ('A', 'unknown', 'unknown'),
+            'SEQ_2': ('A', 'unknown', 'unknown'),
+            'SEQ_3': ('B', 'unknown', 'unknown'),
+            'SEQ_4': ('B', 'unknown', 'unknown'),
+            'SEQ_5': ('B', 'unknown', 'unknown')
+        }
+        captured = capsys.readouterr()
+        assert captured.err == "WARNING: A 'date' column could not be found to group-by year or month.\nFiltering by group may behave differently than expected!\n"
+        assert skipped_strains == []


### PR DESCRIPTION
Optimize `get_groups_for_subsampling` with builtin pandas functions instead of inefficiently iterating through each row.

- [x] add tests
- [x] update code to pass tests
- [x] change logic to raise `FilterException` when `--group-by year month` is used without a `date` column (#795)

### Related issue(s)  

- #789 
    Note: With groupby and probabilistic sampling, I don't think there's a way to avoid full processing of the metadata file. Hopefully code optimization will result in enough performance improvement.
- #795

### Testing

- Added tests for `get_groups_for_subsampling`