### PR TITLE
Request BioPython 1.79 or newer in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
     python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),
     install_requires = [
         "bcbio-gff >=0.6.0, ==0.6.*",
-        "biopython >=1.67, !=1.77, !=1.78",
+        "biopython >=1.79",
         "jsonschema >=3.0.0, ==3.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",


### PR DESCRIPTION
This PR is to address issue #798. From discussion in the previous BioPython version bump PR #763, it sounds like @rneher fixed TreeTime to work with BioPython 1.79:

https://github.com/nextstrain/augur/issues/763#issuecomment-905492429

cc @huddlej @tsibley 