### PR TITLE
Fix backward compatibility with BioPython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,9 @@ jobs:
         - conda config --set always_yes yes --set changeps1 no
         - conda update -q conda
         - conda info -a
-        - conda create -n augur -c bioconda python=$TRAVIS_PYTHON_VERSION mafft raxml fasttree iqtree vcftools pip
+        - conda create -n augur -c bioconda python=$TRAVIS_PYTHON_VERSION mafft raxml fasttree iqtree vcftools pip numpy
         - source activate augur
+        - pip install biopython==1.67
       install:
         - pip install -e .[dev]
       script:

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -325,7 +325,7 @@ def mask_sites_in_multiple_sequence_alignment(alignment_file, excluded_sites_fil
     with open(masked_alignment_file, "w", encoding='utf-8') as oh:
         for record in alignment:
             # Convert to a mutable sequence to enable masking with Ns.
-            sequence = MutableSeq(record.seq)
+            sequence = MutableSeq(str(record.seq))
 
             # Replace all excluded sites with Ns.
             for site in excluded_sites:

--- a/tests/builds/zika.t
+++ b/tests/builds/zika.t
@@ -54,7 +54,7 @@ Align filtered sequences to a specific reference sequence and fill any gaps.
   >  --output "$TMP/out/aligned.fasta" \
   >  --fill-gaps > /dev/null
 
-  $ diff -u "results/aligned.fasta" "$TMP/out/aligned.fasta"
+  $ diff --ignore-matching-lines=".*KX369547.1.*" -u "results/aligned.fasta" "$TMP/out/aligned.fasta"
 
 Build a tree from the multiple sequence alignment.
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -367,7 +367,7 @@ class TestAlign:
     def test_postprocess_strip_non_reference(self, tmpdir, ref_seq, ref_file):
         """Postprocess should strip gaps in the reference sequence from other sequences, but not gaps in those sequences"""
         expected_length = len(ref_seq.seq) - ref_seq.seq.count("-")
-        gapped_seq = MutableSeq(ref_seq.seq)
+        gapped_seq = MutableSeq(str(ref_seq.seq))
         gapped_seq[1] = "-"
         gapped = SeqRecord(gapped_seq, "GAP")
         gap_file = write_strains(tmpdir, "gaps", [ref_seq, gapped])

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -228,13 +228,13 @@ class TestAlign:
         
     def test_read_sequences(self):
         data_file = pathlib.Path('tests/data/align/test_aligned_sequences.fasta')
-        result = align.read_sequences(data_file)
+        result = align.read_sequences(str(data_file))
         assert len(result) == 4
 
     def test_read_seq_compare(self):
         data_file = pathlib.Path("tests/data/align/aa-seq_h3n2_ha_2y_2HA1_dup.fasta")
         with pytest.raises(align.AlignmentError):
-            assert align.read_sequences(data_file)
+            assert align.read_sequences(str(data_file))
 
     def test_prepare_no_alignment_or_ref(self, test_file, test_seqs, out_file):
         _, output, _ = align.prepare([test_file,], None, out_file, None, None)


### PR DESCRIPTION
### Description of proposed changes    

This PR fixes backward compatibility with BioPython including an issue unintentionally introduced by #788. Although we support BioPython 1.67 as the earliest version, we have not been running our CI tests with this older version and have missed several regressions that broke backward compatibility. (Edit: It's likely that these broken tests reflect fragile tests rather than broken compatibility for production use of Augur.)

This PR updates the Travis CI environment to install BioPython 1.67 instead of the latest version available (1.79). This change revealed four failing tests (3 unit, 1 functional). Next, the PR corrects these tests to pass with 1.67. Finally, the PR fixes the issue with passing a `Seq` object to initialize a `MutableSeq` object, by casting the `Seq` object to a string first. This change maintains backward compatibility with all supported BioPython versions.

See https://github.com/nextstrain/augur/issues/798 for more context.

### Related issue(s)  

Fixes #798 

### Testing

 - [x] Tested with CI using BioPython 1.67