### PR TITLE
schemas: Add "$id" key so we have a way of referring to these schemas

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://nextstrain.org/schemas/auspice/config/v2",
     "type": "object",
     "title": "Auspice config file to be supplied to `augur export v2`",
     "$comment": "This schema includes deprecated-but-handled-by-augur-export-v1 properties, but their schema definitions are somewhat incomplete",

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -1,7 +1,6 @@
 {
-    "type" : "object",
-    "version": "v2",
     "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
     "title": "Auspice config file to be supplied to `augur export v2`",
     "$comment": "This schema includes deprecated-but-handled-by-augur-export-v1 properties, but their schema definitions are somewhat incomplete",
     "additionalProperties": false,

--- a/augur/data/schema-export-v1-meta.json
+++ b/augur/data/schema-export-v1-meta.json
@@ -1,7 +1,6 @@
 {
-    "type" : "object",
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "version": "0.1",
+    "type": "object",
     "title": "Nextstrain minimal metadata JSON schema",
     "description": "This is the validation schema for the augur produced metadata JSON, for consumption in Auspice. Note that every field is optional, but excluding fields may disable certain features in Auspice.",
     "additionalProperties": true,

--- a/augur/data/schema-export-v1-meta.json
+++ b/augur/data/schema-export-v1-meta.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://nextstrain.org/schemas/dataset/v1/meta",
     "type": "object",
     "title": "Nextstrain minimal metadata JSON schema",
     "description": "This is the validation schema for the augur produced metadata JSON, for consumption in Auspice. Note that every field is optional, but excluding fields may disable certain features in Auspice.",

--- a/augur/data/schema-export-v1-tree.json
+++ b/augur/data/schema-export-v1-tree.json
@@ -1,6 +1,6 @@
 {
-    "type" : "object",
     "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
     "title": "Nextstrain tree JSON schema",
     "additionalProperties": false,
     "required": ["attr", "strain"],

--- a/augur/data/schema-export-v1-tree.json
+++ b/augur/data/schema-export-v1-tree.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://nextstrain.org/schemas/dataset/v1/tree",
     "type": "object",
     "title": "Nextstrain tree JSON schema",
     "additionalProperties": false,

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://nextstrain.org/schemas/dataset/v2",
     "type": "object",
     "title": "Nextstrain metadata JSON schema proposal (meta + tree together)",
     "additionalProperties": false,

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -1,7 +1,6 @@
 {
-    "type" : "object",
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "version": "2.0",
+    "type": "object",
     "title": "Nextstrain metadata JSON schema proposal (meta + tree together)",
     "additionalProperties": false,
     "required": ["version", "meta", "tree"],


### PR DESCRIPTION
Useful to unambiguously reference in documentation or even in other
schemas.

While these URLs are not required to be fetchable, I do plan to make
them so by setting up redirects from nextstrain.org to the files on
GitHub.  The reason for this indirection is that nextstrain.org lets us
more easily move the files around (e.g. renaming or to S3) if we ever
need to while preserving old URLs.  This is important as ids should be
~permanent since they're consumed and used externally.  The indirection
will also let us present rendered, human-friendly versions of the
schemas to browsers/humans while still returning the JSON representation
to programmatic clients.

See also https://github.com/nextstrain/nextstrain.org/pull/442.