### PR TITLE
Update supported Python versions to drop 3.6, include 3.9 and 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     defaults:
       run:
         shell: bash -l {0}
@@ -26,7 +26,7 @@ jobs:
     - run: pytest -c pytest.python3.ini  --cov-report=xml --cov=augur
     - run: cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
     - run: bash tests/builds/runner.sh
-    - if: matrix.python-version == 3.8
+    - if: matrix.python-version == 3.10
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 ---
 version: 2
 python:
-  version: 3.6
+  version: 3.7
   install:
     - method: pip
       path: .

--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -27,7 +27,7 @@ Please see the [project board](https://github.com/orgs/nextstrain/projects/6) fo
 
 ## Contributing code
 
-We currently target compatibility with Python 3.6 and higher. As Python releases new versions,
+We currently target compatibility with Python 3.7 and higher. As Python releases new versions,
 the minimum target compatibility may be increased in the future.
 
 Versions for this project, Augur, from 3.0.0 onwards aim to follow the

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -40,7 +40,7 @@ mamba install -c conda-forge -c bioconda augur
 
 ## Using pip from PyPi
 
-Augur is written in Python 3 and requires at least Python 3.6.
+Augur is written in Python 3 and requires at least Python 3.7.
 It's published on [PyPi](https://pypi.org) as [nextstrain-augur](https://pypi.org/project/nextstrain-augur), so you can install it with `pip` like so:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,20 @@ from pathlib    import Path
 import setuptools
 import sys
 
-min_version = (3, 6)
+py_min_version = (3, 6)  # minimal supported python version
+since_augur_version = (7, 0)  # py_min_version is required since this augur version
 
-if sys.version_info < min_version:
+if sys.version_info < py_min_version:
     error = """
-Beginning with augur 7.0.0, Python {0} or above is required.
+Beginning with augur {0}, Python {1} or above is required.
+You are using Python {2}.
 
 This may be due to an out of date pip.
 
 Make sure you have pip >= 9.0.1.
-""".format('.'.join(str(n) for n in min_version)),
+""".format('.'.join(str(n) for n in since_augur_version),
+           '.'.join(str(n) for n in py_min_version),
+           '.'.join(str(n) for n in sys.version_info[:3]))
     sys.exit(error)
 
 base_dir = Path(__file__).parent.resolve()
@@ -45,7 +49,7 @@ setuptools.setup(
     },
     packages = setuptools.find_packages(),
     package_data = {'augur': ['data/*']},
-    python_requires = '>={}'.format('.'.join(str(n) for n in min_version)),
+    python_requires = '>={}'.format('.'.join(str(n) for n in py_min_version)),
     install_requires = [
         "bcbio-gff >=0.6.0",
         "biopython >=1.67, !=1.77, !=1.78",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 import sys
 
 py_min_version = (3, 7)  # minimal supported python version
-since_augur_version = (7, 0)  # py_min_version is required since this augur version
+since_augur_version = (14, 0)  # py_min_version is required since this augur version
 
 if sys.version_info < py_min_version:
     error = """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib    import Path
 import setuptools
 import sys
 
-py_min_version = (3, 6)  # minimal supported python version
+py_min_version = (3, 7)  # minimal supported python version
 since_augur_version = (7, 0)  # py_min_version is required since this augur version
 
 if sys.version_info < py_min_version:
@@ -91,9 +91,10 @@ setuptools.setup(
 
         # Python 3 only
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     # Install an "augur" program which calls augur.__main__.main()
     #   https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation


### PR DESCRIPTION
### Description of proposed changes    

This PR updates supported Python versions based on [current EOL status](https://devguide.python.org/#status-of-python-branches).

- Add variable for Augur version associated with min Python version: https://github.com/nextstrain/augur/commit/3f0974706b35f1ef3b886c1ab86fc1d3a487b77b
- Update CI matrix and minimum version references: https://github.com/nextstrain/augur/commit/65c736fdce7809385d2ffb5771b7490bc3059819
- Bump Augur version associated with min Python version to 14: https://github.com/nextstrain/augur/commit/6451394b0e594082a533de526f4f538573be773a

Note: I didn't update minimum version for biopython, since I'm not sure what we want to support. I'm thinking we bump from 1.67 to 1.73 like https://github.com/nextstrain/augur/commit/3dd51603b0856b9d5c7ee0220ee3a5bca13d42d4 (not in PR), would that be reasonable? We could also try a `matrix` based on [this discussion](https://github.com/nextstrain/augur/pull/796/files/e8fde5c0ef5e6fe0cef022dc87ca113346be8c83#r776533627).

### Related issue(s)
- #793