### PR TITLE
Use pandas duplicated() to check for duplicate index values

### DIFF
--- a/augur/util_support/metadata_file.py
+++ b/augur/util_support/metadata_file.py
@@ -56,15 +56,9 @@ class MetadataFile:
         return metadata
 
     def check_metadata_duplicates(self):
-        duplicates = (
-            self.metadata[self.key_type]
-            .value_counts()
-            .reset_index()
-            .query(f"{self.key_type} > 1")["index"]
-            .values
-        )
-
-        if len(duplicates) > 0:
+        duplicate_rows = self.metadata[self.key_type].duplicated()
+        if any(duplicate_rows):
+            duplicates = self.metadata.loc[duplicate_rows, self.key_type].values
             raise ValueError(
                 f"Duplicated {self.key_type} in metadata: {', '.join(duplicates)}"
             )


### PR DESCRIPTION
### Description of proposed changes    
This PR uses the built-in [`pandas.Series.duplicated()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.duplicated.html) to check for duplicates, based on @huddlej's [original suggestion](https://github.com/nextstrain/augur/issues/825#issue-1094836051). Also cleans up the logic for optimal performance.

### Related issue(s)  
Fixes #825

### Testing
- Added test