### PR TITLE
export v2: Allow periods (.) in accession numbers

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -400,7 +400,7 @@
                             "description": "Sequence accession number",
                             "$comment": "terminal nodes only",
                             "type": "string",
-                            "pattern": "^[0-9A-Za-z-_]+$"
+                            "pattern": "^[0-9A-Za-z-_.]+$"
                         }
                     },
                     "patternProperties": {


### PR DESCRIPTION
Periods are used to separate the unversioned accession number from the
accession's revision.

I'm not sure we should be restricting this at all instead of merely
treating accessions as opaque database-specific ids, but that's a larger
change which maybe warrants more discussion first.

Moves the hyphen (-) to the end of the character class so it's
unambiguously a literal hyphen and not a character range.

Resolves #831.