### PR TITLE
Cast strains to list when subsetting metadata

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -884,7 +884,7 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     [{'strain': 'strain1', 'filter': 'skip_group_by_with_ambiguous_month', 'kwargs': ''}]
 
     """
-    metadata = metadata.loc[strains]
+    metadata = metadata.loc[list(strains)]
     group_by_strain = {}
     skipped_strains = []
 
@@ -1455,7 +1455,7 @@ def run(args):
 
         if args.output_metadata:
             # TODO: wrap logic to write metadata into its own function
-            metadata.loc[strains_to_write].to_csv(
+            metadata.loc[list(strains_to_write)].to_csv(
                 args.output_metadata,
                 sep="\t",
                 header=metadata_header,


### PR DESCRIPTION
This is to prevent `pandas>=1.4.0` from emitting a `FutureWarning` deprecation message. From [change log](https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.4.0.html#other-deprecations):

> Deprecated passing set or dict as indexer ...

Noticed due to [failing `cram` tests](https://github.com/nextstrain/augur/actions/runs/1752857291).