### PR TITLE
Skip codecov and deploy on CI workflows in fork repos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,12 +26,12 @@ jobs:
     - run: pytest -c pytest.python3.ini  --cov-report=xml --cov=augur
     - run: cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
     - run: bash tests/builds/runner.sh
-    - if: matrix.python-version == 3.8
+    - if: github.repository == 'nextstrain/augur' && matrix.python-version == 3.8
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
   deploy:
-    if: ${{ github.ref == 'refs/heads/release' }}
+    if: github.repository == 'nextstrain/augur' && github.ref == 'refs/heads/release'
     needs: [test]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With #796, our CI workflow can now be run on forks of the repo. I'm currently doing development in a fork [victorlin/augur](https://github.com/victorlin/augur), including for this PR, and CI workflows have been failing due to covtest upload failure albeit passing tests.

This PR adds an extra condition on running the codecov upload and `deploy` step, only under the context of the main GitHub repository.