### PR TITLE
Set default filter priority to negative infinity

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -62,9 +62,12 @@ def write_vcf(input_filename, output_filename, dropped_samps):
         pass
 
 def read_priority_scores(fname):
+    def constant_factory(value):
+        return lambda: value
+
     try:
         with open(fname, encoding='utf-8') as pfile:
-            return defaultdict(float, {
+            return defaultdict(constant_factory(-np.inf), {
                 elems[0]: float(elems[1])
                 for elems in (line.strip().split('\t') if '\t' in line else line.strip().split() for line in pfile.readlines())
             })

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,4 +1,5 @@
 import argparse
+import numpy as np
 import random
 import shlex
 
@@ -89,7 +90,7 @@ class TestFilter:
 
         assert priorities == {"strain1": 5, "strain2": 6, "strain3": 8}
         assert priorities["strain1"] == 5
-        assert priorities["strain42"] == 0, "Default priority is 0 for unlisted sequences"
+        assert priorities["strain42"] == -np.inf, "Default priority is negative infinity for unlisted sequences"
 
     def test_read_priority_scores_malformed(self, mock_priorities_file_malformed):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Description of proposed changes

Given that user-provided priorities to augur filter can be all negative values of which some rank higher than others (as in the ncov workflow's proximity-based prioritization), we cannot use a default priority value of 0 or we will always prioritize strains that do not have a defined priority.

This PR changes the expected default for priorities to negative infinity (as reflected in the changed unit test) and updates [the defaultdict factory](https://docs.python.org/3/library/collections.html#defaultdict-examples) in `read_priority_scores` to return negative infinity for missing strains. This change means we will always prefer strains with defined priorities over those without until there are no other options left.

## Testing

 - [x] Tested by CI with relevant unit test
 - [x] Tested with real data provided by @cassiawag where the issue was originally identified