### PR TITLE
export v2: Fix syntax warning

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -215,7 +215,7 @@ def set_colorings(data_json, config, command_line_colorings, metadata_names, nod
         ## consider various sources to find any user-provided scale information
         key = coloring["key"]
         scale_type = coloring["type"]
-        if scale_type is "continuous":
+        if scale_type == "continuous":
             ## continuous scale information can only come from an auspice config JSON
             if config.get(key, {}).get("scale"):
                 # enforce numeric values (we can't use the schema for this)


### PR DESCRIPTION
## Description of proposed changes

Use equality operator instead of an identity operator for `scale_type`, fixing a syntax warning.

## Testing

 - [x] Tested by CI