### PR TITLE
docs: Set "version" in Sphinx configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
+from augur.__version__ import __version__ as augur_version
 from datetime import date
 import subprocess
 
@@ -44,6 +45,8 @@ def prose_list(items):
         return ", ".join([*items[0:-1], "and " + items[-1]])
 
 project = 'Augur'
+version = augur_version
+release = version
 copyright = '2014–%d Trevor Bedford and Richard Neher' % (date.today().year)
 author = prose_list(git_authors())
 


### PR DESCRIPTION
This will allow us to display the specific version for "stable" on Read
the Docs (once <https://github.com/nextstrain/sphinx-theme/pull/16> is
merged).

Also sets "release" as the Sphinx documentation says¹:

    If you don’t need the separation provided between version and
    release, just set them both to the same value.

¹ https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-release

