### PR TITLE
CI: install pip=21 to prevent error on Python 3.6 job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
         channels: conda-forge,bioconda
         channel-priority: true
         activate-environment: test
-    - run: mamba install mafft raxml fasttree iqtree vcftools pip numpy
+    - run: mamba install mafft raxml fasttree iqtree vcftools pip=21 numpy
     - run: pip install biopython==1.67
     - run: pip install -e .[dev]
     - run: conda info

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,9 @@ jobs:
         channels: conda-forge,bioconda
         channel-priority: true
         activate-environment: test
-    - run: mamba install mafft raxml fasttree iqtree vcftools pip=21 numpy
+    - run: mamba install mafft raxml fasttree iqtree vcftools numpy
+    - if: matrix.python-version == 3.6
+      run: mamba install pip=21
     - run: pip install biopython==1.67
     - run: pip install -e .[dev]
     - run: conda info


### PR DESCRIPTION
Recent CI is [failing](https://github.com/nextstrain/augur/runs/5029998710?check_suite_focus=true) with the following message on the Python 3.6 job, where `dataclasses` does not exist:

> ModuleNotFoundError: No module named 'dataclasses'

This is due to the release of `pip=22` [a couple days ago](https://pypi.org/project/pip/22.0/) ([relevant StackOverflow post](https://stackoverflow.com/questions/70914876/get-pip-py-fails-with-modulenotfounderror-no-module-named-dataclasses)).

Downgrading to `pip=21` lets things run as previously, but is not a good long-term solution. Instead, dropping Python 3.6 support would be better (#793).