### PR TITLE
CI: test earliest supported Biopython versions in matrix, remove redundant installs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,13 +5,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        versions:
-          # test earliest biopython version supporting each python version
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+        biopython-version:
+          # list of Biopython versions with support for a new Python version
           # from https://github.com/biopython/biopython/blob/master/NEWS.rst
-          - {python: '3.7', biopython: '1.73'}
-          - {python: '3.8', biopython: '1.76'}
-          - {python: '3.9', biopython: '1.79'}
-          - {python: '3.10', biopython: ''} # empty string = latest supported
+          - '1.73' # first to support Python 3.7
+          - '1.76' # first to support Python 3.8
+          - '1.79' # first to support Python 3.9
+          - ''     # latest
+        exclude:
+          # some older Biopython versions are incompatible with later Python versions
+          - { biopython-version: '1.73', python-version: '3.8' }
+          - { biopython-version: '1.73', python-version: '3.9' }
+          - { biopython-version: '1.73', python-version: '3.10' }
+          - { biopython-version: '1.76', python-version: '3.9' }
+          - { biopython-version: '1.76', python-version: '3.10' }
     defaults:
       run:
         shell: bash -l {0}
@@ -19,13 +31,13 @@ jobs:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: ${{ matrix.versions.python }}
+        python-version: ${{ matrix.python-version }}
         mamba-version: "*"
         channels: conda-forge,bioconda
         channel-priority: true
         activate-environment: test
     - run: mamba install mafft raxml fasttree iqtree vcftools
-    - run: mamba install biopython=${{ matrix.versions.biopython }}
+    - run: mamba install biopython=${{ matrix.biopython-version }}
     - run: pip install -e .[dev]
     - run: conda info
     - run: conda list

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     - run: pytest -c pytest.python3.ini  --cov-report=xml --cov=augur
     - run: cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
     - run: bash tests/builds/runner.sh
-    - if: github.repository == 'nextstrain/augur' && matrix.python-version == 3.10
+    - if: github.repository == 'nextstrain/augur' && matrix.python-version == '3.10' && matrix.biopython-version == ''
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        biopython-version:
-          - '1.73' # earliest version supporting Python 3.7 https://github.com/biopython/biopython/blob/master/NEWS.rst#18-december-2018-biopython-173
-          - '' # latest
+        versions:
+          # test earliest biopython version supporting each python version
+          # from https://github.com/biopython/biopython/blob/master/NEWS.rst
+          - {python: '3.7', biopython: '1.73'}
+          - {python: '3.8', biopython: '1.76'}
+          - {python: '3.9', biopython: '1.79'}
+          - {python: '3.10', biopython: ''}
     defaults:
       run:
         shell: bash -l {0}
@@ -16,20 +19,20 @@ jobs:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.versions.python }}
         mamba-version: "*"
         channels: conda-forge,bioconda
         channel-priority: true
         activate-environment: test
     - run: mamba install mafft raxml fasttree iqtree vcftools pip
-    - run: mamba install biopython=${{ matrix.biopython-version }}
+    - run: mamba install biopython=${{ matrix.versions.biopython }}
     - run: pip install -e .[dev]
     - run: conda info
     - run: conda list
     - run: pytest -c pytest.python3.ini  --cov-report=xml --cov=augur
     - run: cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
     - run: bash tests/builds/runner.sh
-    - if: github.repository == 'nextstrain/augur' && matrix.python-version == 3.10
+    - if: github.repository == 'nextstrain/augur' && matrix.versions.python == 3.10
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
           - {python: '3.7', biopython: '1.73'}
           - {python: '3.8', biopython: '1.76'}
           - {python: '3.9', biopython: '1.79'}
-          - {python: '3.10', biopython: ''}
+          - {python: '3.10', biopython: ''} # empty string = latest supported
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         channels: conda-forge,bioconda
         channel-priority: true
         activate-environment: test
-    - run: mamba install mafft raxml fasttree iqtree vcftools pip
+    - run: mamba install mafft raxml fasttree iqtree vcftools
     - run: mamba install biopython=${{ matrix.versions.biopython }}
     - run: pip install -e .[dev]
     - run: conda info

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
+        biopython-version:
+          - '1.73' # earliest version supporting Python 3.7 https://github.com/biopython/biopython/blob/master/NEWS.rst#18-december-2018-biopython-173
+          - '' # latest
     defaults:
       run:
         shell: bash -l {0}
@@ -18,8 +21,8 @@ jobs:
         channels: conda-forge,bioconda
         channel-priority: true
         activate-environment: test
-    - run: mamba install mafft raxml fasttree iqtree vcftools pip numpy
-    - run: pip install biopython==1.67
+    - run: mamba install mafft raxml fasttree iqtree vcftools pip
+    - run: mamba install biopython=${{ matrix.biopython-version }}
     - run: pip install -e .[dev]
     - run: conda info
     - run: conda list

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     - run: pytest -c pytest.python3.ini  --cov-report=xml --cov=augur
     - run: cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
     - run: bash tests/builds/runner.sh
-    - if: github.repository == 'nextstrain/augur' && matrix.versions.python == 3.10
+    - if: github.repository == 'nextstrain/augur' && matrix.python-version == 3.10
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   test:
+    name: test (python=${{ matrix.python-version }} biopython=${{ matrix.biopython-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   test:
-    name: test (python=${{ matrix.python-version }} biopython=${{ matrix.biopython-version }})
+    name: test (python=${{ matrix.python-version }} biopython=${{ matrix.biopython-version || 'latest' }})
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Description of proposed changes    

This PR uses `mamba` to install earliest Biopython versions in the CI matrix.

Additionally, remove explicit install of `pip` and `numpy` as they are already downstream dependencies.

### Detail

First, I tried using a separate matrix configuration for Biopython versions, which [failed](https://github.com/victorlin/augur/runs/5057158583?check_suite_focus=true) due to incompatibility of 1.73 with newer python versions. So I opted for a single matrix that pairs the Python version with earliest supported Biopython version.

Then, I opened this PR with a paired matrix approach.

Then, addressing review comments, I switched back to a separate matrix configuration with `exclude` to skip incompatible combinations.

### Related issue(s)  

- Motivated by https://github.com/nextstrain/augur/issues/798#issuecomment-993044873
- #793
