### PR TITLE
Fix 'Forbidden characters' typo

### DIFF
--- a/augur/parse.py
+++ b/augur/parse.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from .io import open_file, read_sequences, write_sequences
 
-forbidden_chactacters = str.maketrans(
+forbidden_characters = str.maketrans(
     {' ': None,
      '(': '_',
      ')': '_',
@@ -103,7 +103,7 @@ def parse_sequence(sequence, fields, strain_key="strain", separator="|", prettif
     sequence_fields = map(str.strip, sequence.description.split(separator))
     metadata = dict(zip(fields, sequence_fields))
 
-    tmp_name = metadata[strain_key].translate(forbidden_chactacters)
+    tmp_name = metadata[strain_key].translate(forbidden_characters)
     sequence.name = sequence.id = tmp_name
     sequence.description = ''
 


### PR DESCRIPTION
### Description of proposed changes    
Fixes a typo, correcting `forbidden_chactacters` ([here](https://github.com/nextstrain/augur/blob/master/augur/parse.py)) to `forbidden_characters`

Seems this was introduced 2 years ago - thankfully I hope hasn't caused issues since then. However, I actually use
```
from augur.parse import forbidden_characters
```
in a number of my scripts & builds (outside of SC2) - so found this bug when running them for the first time since Jan 2020.

