### PR TITLE
Schemas for our sidecars

### DIFF
--- a/augur/data/schema-export-root-sequence.json
+++ b/augur/data/schema-export-root-sequence.json
@@ -5,6 +5,7 @@
   "description": "Typically produced by Augur and consumed by Auspice.  Applicable to the `--root-sequence` output of `augur export v2` as well as the `--output-sequence` option of `augur export v1`.",
   "oneOf": [
     {
+      "$comment": "This is sort of weird, but `augur export v1` can explicitly produce an empty object.",
       "description": "An empty object",
       "type": "object",
       "properties": {},

--- a/augur/data/schema-export-root-sequence.json
+++ b/augur/data/schema-export-root-sequence.json
@@ -17,14 +17,14 @@
       "required": ["nuc"],
       "properties": {
         "nuc": {
-          "description": "Nucleotide sequence of whole genome",
+          "description": "Nucleotide sequence of whole genome (from the output of `augur ancestral`)",
           "type": "string"
         }
       },
       "patternProperties": {
         "^[a-zA-Z0-9*_-]+$": {
           "$comment": "This pattern is the same pattern used in the corresponding parts of schema-export-v2.json.",
-          "description": "Amino acid sequence of genome annotation (e.g. gene) identified by this key",
+          "description": "Amino acid sequence of genome annotation (e.g. gene) identified by this key (from the output of `augur translate`)",
           "type": "string"
         }
       }

--- a/augur/data/schema-export-root-sequence.json
+++ b/augur/data/schema-export-root-sequence.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://nextstrain.org/schemas/dataset/root-sequence",
+  "title": "Nextstrain root-sequence sidecar for datasets",
+  "description": "Typically produced by Augur and consumed by Auspice.  Applicable to the `--root-sequence` output of `augur export v2` as well as the `--output-sequence` option of `augur export v1`.",
+  "oneOf": [
+    {
+      "description": "An empty object",
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    },
+    {
+      "description": "An object containing at least a \"nuc\" key and optionally additional keys for genome annotations (e.g. genes)",
+      "type": "object",
+      "required": ["nuc"],
+      "properties": {
+        "nuc": {
+          "description": "Nucleotide sequence of whole genome",
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^[a-zA-Z0-9*_-]+$": {
+          "$comment": "This pattern is the same pattern used in the corresponding parts of schema-export-v2.json.",
+          "description": "Amino acid sequence of genome annotation (e.g. gene) identified by this key",
+          "type": "string"
+        }
+      }
+    }
+  ]
+}

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -2,7 +2,8 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "https://nextstrain.org/schemas/dataset/v2",
     "type": "object",
-    "title": "Nextstrain metadata JSON schema proposal (meta + tree together)",
+    "title": "Nextstrain dataset v2",
+    "description": "Typically produced by Augur (`augur export v2`) and consumed by Auspice.  Combines dataset v1 meta and tree files together into one file, with additional changes.",
     "additionalProperties": false,
     "required": ["version", "meta", "tree"],
     "properties": {

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -8,9 +8,8 @@
     "required": ["version", "meta", "tree"],
     "properties": {
         "version" : {
-            "description": "JSON schema version",
-            "type" : "string",
-            "pattern": "^v[0-9]+$"
+            "description": "Major schema version",
+            "const": "v2"
         },
         "meta": {
             "type": "object",

--- a/augur/data/schema-frequencies.json
+++ b/augur/data/schema-frequencies.json
@@ -3,6 +3,7 @@
   "$id": "https://nextstrain.org/schemas/augur/frequencies",
   "title": "`augur frequencies` output",
   "description": "This schema describes the various forms of `augur frequencies` output when using the default `--output-format=auspice`.  The specific form used depends on the input parameters, as noted for each possible form below.  One of the forms is compatible with the Nextstrain tip-frequencies sidecar described by <https://nextstrain.org/schemas/tip-frequencies>.",
+  "$comment": "For historical context (some, not complete) on the development of this format, see <https://github.com/nextstrain/augur/pull/83> and <https://github.com/nextstrain/augur/issues/84>.",
   "oneOf": [
     {
       "description": "`augur frequencies` with an input `--tree` and `--method=diffusion`",

--- a/augur/data/schema-frequencies.json
+++ b/augur/data/schema-frequencies.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://nextstrain.org/schemas/augur/frequencies",
+  "title": "`augur frequencies` output",
+  "description": "This schema describes the various forms of `augur frequencies` output when using the default `--output-format=auspice`.  The specific form used depends on the input parameters, as noted for each possible form below.  One of the forms is compatible with the Nextstrain tip-frequencies sidecar described by <https://nextstrain.org/schemas/tip-frequencies>.",
+  "oneOf": [
+    {
+      "description": "`augur frequencies` with an input `--tree` and `--method=diffusion`",
+      "type": "object",
+      "required": ["pivots", "counts"],
+      "properties": {
+        "counts": {
+          "description": "Counts by region",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Counts for region identified by this key",
+            "type": "array",
+            "items": {"type": "integer"}
+          }
+        },
+        "pivots": {"$ref": "#/$defs/pivots"},
+        "generated_by": {"$ref": "#/$defs/generated_by"}
+      },
+      "additionalProperties": {
+        "description": "Estimated frequencies by region for tip (or node) identified by this key",
+        "type": "object",
+        "additionalProperties": {
+          "description": "Estimated frequencies for region identified by this key",
+          "type": "array",
+          "items": {"type": "number"}
+        }
+      }
+    },
+    {
+      "description": "`augur frequencies` with an input `--tree` and `--method=kde`, compatible with <https://nextstrain.org/schemas/tip-frequencies>",
+      "type": "object",
+      "required": ["pivots"],
+      "properties": {
+        "pivots": {"$ref": "#/$defs/pivots"},
+        "generated_by": {"$ref": "#/$defs/generated_by"}
+      },
+      "additionalProperties": {
+        "description": "Estimated frequencies for tip (or node) identified by this key",
+        "type": "object",
+        "properties": {
+          "frequencies": {
+            "type": "array",
+            "items": {"type": "number"}
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "description": "`augur frequencies` with input gene `--alignments` and `--method=diffusion`",
+      "type": "object",
+      "required": ["pivots"],
+      "properties": {
+        "pivots": {"$ref": "#/$defs/pivots"},
+        "generated_by": {"$ref": "#/$defs/generated_by"}
+      },
+      "patternProperties": {
+        "^(.+):counts$": {
+          "description": "Counts for gene alignment position+state identified by this key (<GENE>:counts)",
+          "type": "array",
+          "items": {"type": "integer"}
+        },
+        "^(.+):([0-9]+)(.+)$": {
+          "description": "Estimated frequencies for gene alignment position+state identified by this key (<GENE>:<POSITION><STATE>)",
+          "type": "array",
+          "items": {"type": "number"}
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "`augur frequencies` with input gene `--alignments` and `--method=kde`",
+      "type": "object",
+      "required": ["pivots"],
+      "properties": {
+        "pivots": {"$ref": "#/$defs/pivots"},
+        "generated_by": {"$ref": "#/$defs/generated_by"}
+      },
+      "patternProperties": {
+        "^(.+):([0-9]+)(.+)$": {
+          "description": "Estimated frequencies for gene alignment position+state identified by this key (<GENE>:<POSITION><STATE>)",
+          "type": "array",
+          "items": {"type": "number"}
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "$defs": {
+    "pivots": {
+      "description": "Pivot dates as floating point numbers (YYYY.nnnnnn)",
+      "type": "array",
+      "items": {"type": "number"},
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "generated_by": {
+      "description": "Information about the software which produced the file",
+      "type": "object",
+      "properties": {
+        "program": {"type": "string"},
+        "version": {"type": "string"}
+      }
+    }
+  }
+}

--- a/augur/data/schema-tip-frequencies.json
+++ b/augur/data/schema-tip-frequencies.json
@@ -1,0 +1,41 @@
+
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "https://nextstrain.org/schemas/dataset/tip-frequencies",
+  "title": "Nextstrain tip-frequencies sidecar for datasets",
+  "description": "Typically produced by Augur (with `augur frequencies --method kde --tree …`) and consumed by Auspice.  Note that the full range of output forms from `augur frequencies` is broader than this, see <https://nextstrain.org/schemas/augur/frequencies>.",
+  "type": "object",
+  "required": ["pivots"],
+  "properties": {
+    "pivots": {
+      "description": "Pivot dates as floating point numbers (YYYY.nnnnnn)",
+      "type": "array",
+      "items": {"type": "number"},
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "projection_pivot": {
+      "description": "Pivot at which estimates are projected into the future.  This property is understood by Auspice but only produced by custom generators; it is not produced by `augur frequencies`.",
+      "type": "number"
+    },
+    "generated_by": {
+      "description": "Information about the software which produced the file",
+      "type": "object",
+      "properties": {
+        "program": {"type": "string"},
+        "version": {"type": "string"}
+      }
+    }
+  },
+  "additionalProperties": {
+    "description": "Estimated frequencies for tip (or node) identified by this key",
+    "type": "object",
+    "properties": {
+      "frequencies": {
+        "type": "array",
+        "items": {"type": "number"}
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/augur/data/schema-tip-frequencies.json
+++ b/augur/data/schema-tip-frequencies.json
@@ -4,6 +4,7 @@
   "$id": "https://nextstrain.org/schemas/dataset/tip-frequencies",
   "title": "Nextstrain tip-frequencies sidecar for datasets",
   "description": "Typically produced by Augur (with `augur frequencies --method kde --tree …`) and consumed by Auspice.  Note that the full range of output forms from `augur frequencies` is broader than this, see <https://nextstrain.org/schemas/augur/frequencies>.",
+  "$comment": "For historical context (some, not complete) on the development of this format, see <https://github.com/nextstrain/augur/pull/83> and <https://github.com/nextstrain/augur/issues/84>.",
   "type": "object",
   "required": ["pivots"],
   "properties": {

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -754,39 +754,6 @@ def node_data_prop_is_normal_trait(name):
 
     return True
 
-def get_root_sequence(root_node, ref=None, translations=None):
-    '''
-    create a json structure that contains the sequence of the root, both as
-    nucleotide and as translations. This allows look-up of the sequence for
-    all states, including those that are not variable.
-
-    Parameters
-    ----------
-    root_node : dict
-    	data associated with the node
-    ref : str, optional
-        filename of the root sequence
-    translations : str, optional
-        file name of translations
-
-    Returns
-    -------
-    dict
-        dict of nucleotide sequence and translations
-    '''
-    root_sequence = {}
-    if ref and translations:
-        from Bio import SeqIO
-        refseq = SeqIO.read(ref, 'fasta')
-        root_sequence['nuc']=str(refseq.seq)
-        for gene in SeqIO.parse(translations, 'fasta'):
-            root_sequence[gene.id] = str(gene.seq)
-    else:
-        root_sequence["nuc"] = root_node["sequence"]
-        root_sequence.update(root_node["aa_sequences"])
-
-    return root_sequence
-
 
 def register_arguments_v2(subparsers):
     v2 = subparsers.add_parser("v2", help="Export version 2 JSON schema")

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -46,7 +46,7 @@ def load_json_schema(path):
     try:
         jsonschema.Draft6Validator.check_schema(schema)
     except jsonschema.exceptions.SchemaError as err:
-        raise ValidateError("Schema {} is not a valid JSON file. Error: {}".format(path, err))
+        raise ValidateError("Schema {} is not a valid JSON Schema (draft 6). Error: {}".format(path, err))
     return jsonschema.Draft6Validator(schema)
 
 def load_json(path):

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -43,11 +43,12 @@ def load_json_schema(path):
     except json.JSONDecodeError as err:
         raise ValidateError("Schema {} is not a valid JSON file. Error: {}".format(path, err))
     # check loaded schema is itself valid -- see http://python-jsonschema.readthedocs.io/en/latest/errors/
+    Validator = jsonschema.validators.validator_for(schema)
     try:
-        jsonschema.Draft6Validator.check_schema(schema)
+        Validator.check_schema(schema)
     except jsonschema.exceptions.SchemaError as err:
-        raise ValidateError("Schema {} is not a valid JSON Schema (draft 6). Error: {}".format(path, err))
-    return jsonschema.Draft6Validator(schema)
+        raise ValidateError(f"Schema {path} is not a valid JSON Schema ({Validator.META_SCHEMA['$schema']}). Error: {err}")
+    return Validator(schema)
 
 def load_json(path):
     with open(path, 'rb') as fh:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,14 @@
+import json
+import jsonschema.validators
+import pytest
+from pathlib import Path
+
+schemas = list(Path("augur/data/").glob("schema-*.json"))
+
+@pytest.mark.parametrize("schema_path", schemas, ids = lambda schema_path: str(schema_path))
+def test_schema_is_valid(schema_path):
+    with schema_path.open("rb") as schema_fh:
+        schema = json.load(schema_fh)
+
+    Validator = jsonschema.validators.validator_for(schema)
+    Validator.check_schema(schema)


### PR DESCRIPTION
I added JSON Schemas for our root-sequence and tip-frequencies sidecars and threw in a schema for other forms of `augur frequencies` output too. Cleaned up a few other things as I went along.

I think these are the best descriptions of the formats yet and can be used and extended in the future to generate documentation pages. They'll also be useful for file detection in `nextstrain remote upload` (see https://github.com/nextstrain/cli/pull/141).