### PR TITLE
Move Uppercase after camelCase in parse.prettify

### DIFF
--- a/augur/parse.py
+++ b/augur/parse.py
@@ -47,15 +47,15 @@ def prettify(x, trim=0, camelCase=False, etal=None, removeComma=False):
     if 0 < trim < len(x):
         res = x[:trim] + "..."
 
-    if res in {'usvi', 'usa', 'uk'}:
-        res = res.upper()
-
     words = res.split('_')
 
     if camelCase:
         words = map(str.capitalize, words)
 
     res = ' '.join(words)
+
+    if res in {'usvi', 'usa', 'uk', 'Usvi', 'Usa', 'Uk'}:
+        res = res.upper()
 
     if removeComma:
         res = res.replace(',', '')


### PR DESCRIPTION
While trying to use [`parse.prettify()`](https://github.com/nextstrain/augur/blob/master/augur/parse.py#L45) with `camelCase=True` to fix some country names, I was struggling with entries like "usa" and "usvi".

This is because currently the script does the [correction to complete uppercase for such abbreviations first](https://github.com/nextstrain/augur/blob/master/augur/parse.py#L50), but [_then_ does the camelCase](https://github.com/nextstrain/augur/blob/master/augur/parse.py#L56) (if asked for) - returning them to being "Usa" "Uk" etc. 

This PR simply swaps the order so that it does camelCasing (if asked for) first, then checks for special cases (and includes capitalized verisons of "Uk", "Usa" etc).

Or, I might be misunderstanding how to use the original function!