### PR TITLE
Send filter warnings to stderr

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -623,7 +623,7 @@ def construct_filters(args, sequence_index):
         is_vcf = filename_is_vcf(args.sequences)
 
         if is_vcf: #doesn't make sense for VCF, ignore.
-            print("WARNING: Cannot use min_length for VCF files. Ignoring...")
+            print("WARNING: Cannot use min_length for VCF files. Ignoring...", file=sys.stderr)
         else:
             exclude_by.append((
                 filter_by_sequence_length,
@@ -1744,7 +1744,7 @@ def calculate_sequences_per_group(target_max_value, counts_per_group, allow_prob
         )
     except TooManyGroupsError as error:
         if allow_probabilistic:
-            print(f"WARNING: {error}")
+            print(f"WARNING: {error}", file=sys.stderr)
             sequences_per_group = _calculate_fractional_sequences_per_group(
                 target_max_value,
                 counts_per_group,

--- a/tests/functional/filter.t
+++ b/tests/functional/filter.t
@@ -101,6 +101,7 @@ Explicitly use probabilistic subsampling to handle the case when there are more 
   >  --subsample-seed 314159 \
   >  --probabilistic-sampling \
   >  --output-strains "$TMP/filtered_strains_probabilistic.txt" > /dev/null
+  WARNING: Asked to provide at most 5 sequences, but there are 8 groups.
 
 Using the default probabilistic subsampling, should work the same as the previous case.
 
@@ -113,6 +114,7 @@ Using the default probabilistic subsampling, should work the same as the previou
   >  --subsample-max-sequences 5 \
   >  --subsample-seed 314159 \
   >  --output-strains "$TMP/filtered_strains_default.txt" > /dev/null
+  WARNING: Asked to provide at most 5 sequences, but there are 8 groups.
 
 By setting the subsample seed above, we should get the same results for both runs.
 
@@ -394,6 +396,7 @@ Strains with ambiguous years or months should be dropped and logged.
   >  --subsample-max-sequences 5 \
   >  --output-strains "$TMP/filtered_strains.txt" \
   >  --output-log "$TMP/filtered_log.tsv" > /dev/null
+  WARNING: Asked to provide at most 5 sequences, but there are 6 groups.
   $ grep "SG_018" "$TMP/filtered_log.tsv" | cut -f 1-2
   SG_018\tskip_group_by_with_ambiguous_month (esc)
   $ grep "COL/FLR_00024/2015" "$TMP/filtered_log.tsv" | cut -f 1-2


### PR DESCRIPTION
### Description of proposed changes

To be consistent with other warnings, for example:

- https://github.com/nextstrain/augur/blob/e4fdf59f75850bcd7172c405132444d51675395d/augur/filter.py#L913
- https://github.com/nextstrain/augur/blob/e4fdf59f75850bcd7172c405132444d51675395d/augur/filter.py#L954
- https://github.com/nextstrain/augur/blob/e4fdf59f75850bcd7172c405132444d51675395d/augur/filter.py#L1617-L1621

Caught the inconsistency while implementing [`9bcbccc6`](https://github.com/nextstrain/augur/pull/854/commits/9bcbccc63cdbdfe020db4a7a166dbb1854c189bb).

### Related issue(s)

None

### Testing

Updated tests accordingly.