### PR TITLE
[export] order keys in dataset for easier reading

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -4,7 +4,7 @@ Export JSON files suitable for visualization with auspice.
 from pathlib import Path
 import os, sys
 import time
-from collections import defaultdict, deque
+from collections import defaultdict, deque, OrderedDict
 import warnings
 import numbers
 import re
@@ -44,6 +44,67 @@ def configure_warnings():
 
 class InvalidOption(Exception):
     pass
+
+class CustomOrderedDict(OrderedDict):
+    """
+    Similar to OrderedDict but will convert dictionaries (and dictionaries of dictionaries)
+    into (nested) CustomOrderedDicts.
+    Encountered lists of dicts will be converted to lists of CustomOrderedDict but we will not
+    recursively explore nested lists.
+    Tuples and other iterators are not explored.
+    """
+    def __init__(self, *args):
+        super().__init__(*args)
+        for key in self:
+            if isinstance(self[key], dict) and not isinstance(self[key], OrderedDict):
+                self[key] = CustomOrderedDict(self[key])
+            elif isinstance(self[key], list):
+                self[key] = [
+                    (CustomOrderedDict(el) if (isinstance(el, dict) and not isinstance(el, OrderedDict)) else el)
+                    for el in self[key]
+                ]
+    def set_order(self, *order):
+        """
+        changes the order of keys to match those specified in `order` as much
+        as possible. Missing keys are ignored. Extra keys will come after those
+        specified in `order`.
+        """
+        for key in reversed(order):
+            self.move_to_end_if_present(key, last=False)
+    def move_to_end_if_present(self, key, **kwargs):
+        try:
+            self.move_to_end(key, **kwargs)
+        except KeyError:
+            pass
+
+
+def orderKeys(data):
+    """
+    converts the data dict (where keys are inherently unordered) into an
+    OrderedDict where keys are nicely ordered for human eyes to scan the
+    data when written to JSON. The ordering (mostly) mirrors the schema.
+    """
+    od = CustomOrderedDict(data)
+    od.set_order("version", "meta", "tree")
+    if "meta" in od:
+        od["meta"].set_order("title", "updated", "build_url", "data_provenance", "maintainers")
+        for coloring in od['meta'].get('colorings', []):
+            coloring.set_order("key", "title", "type", "scale", "legend")
+    def order_nodes(node):
+        """recursive function to order nodes in a (sub)tree"""
+        node.set_order("name", "node_attrs", "branch_attrs")
+        # children often a _large_ object and it improves readability if this comes last in the node
+        node.move_to_end_if_present("children")
+        if "node_attrs" in node:
+            node["node_attrs"].set_order("div", "num_date")
+        for child in node.get("children", []):
+            order_nodes(child)
+    if isinstance(od.get("tree"), list):
+        for subtree in od['tree']:
+            order_nodes(subtree)
+    elif isinstance(od.get("tree"), dict):
+        order_nodes(od['tree'])
+    return od
 
 def convert_tree_to_json_structure(node, metadata, div=0):
     """
@@ -974,7 +1035,7 @@ def run_v2(args):
 
     # Write outputs - the (unified) dataset JSON intended for auspice & perhaps the ref root-sequence JSON
     indent = {"indent": None} if args.minify_json else {}
-    write_json(data=data_json, file_name=args.output, include_version=False, **indent)
+    write_json(data=orderKeys(data_json), file_name=args.output, include_version=False, **indent)
 
     if args.include_root_sequence:
         if 'reference' in node_data:

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -10,7 +10,7 @@ import subprocess
 import shlex
 from contextlib import contextmanager
 from treetime.utils import numeric_date
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from pkg_resources import resource_stream
 from io import TextIOWrapper
 from .__version__ import __version__
@@ -256,9 +256,9 @@ def write_json(data, file_name, indent=(None if os.environ.get("AUGUR_MINIFY_JSO
 
     if include_version:
         data["generated_by"] = {"program": "augur", "version": get_augur_version()}
-
     with open(file_name, 'w', encoding='utf-8') as handle:
-        json.dump(data, handle, indent=indent, sort_keys=True)
+        sort_keys = False if isinstance(data, OrderedDict) else True
+        json.dump(data, handle, indent=indent, sort_keys=sort_keys)
 
 
 def load_features(reference, feature_names=None):


### PR DESCRIPTION
When scanning through dataset JSONs it's much nicer to have certain
keys come first in each dict. For instance, the title of the dataset,
or the name of each tree node etc. It's especially handy to encode the
data for each node before the array of children nodes (and this becomes worse
the deeper the nesting!). This has been a personal wish of mine for a
long time.

This commit changes the `write_json` util function to sort keys (the
previous default) unless the data is an OrderedDict (or subclass of).
A search through the augur code indicates that we don't use OrderedDicts
explicitly, however we may be using them implicitly.

All tests pass.

