### PR TITLE
fix: move custom extensions to meta in export v2

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -312,10 +312,6 @@
                     "items": {"$ref": "#/$defs/tree"}
                 }
             ]
-        },
-        "extensions": {
-            "description": "Data for use by applications other than auspice",
-            "$comment": "Any type is accepted"
         }
     },
     "$defs": {

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -108,6 +108,10 @@
                     "uniqueItems": true,
                     "minItems": 1
                 },
+                "extensions": {
+                    "description": "Data to be passed through to the the resulting dataset JSON",
+                    "$comment": "Any type is accepted"
+                },
                 "geo_resolutions": {
                     "description": "The available options for the geographic resolution dropdown, and their lat/long information",
                     "type": "array",

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -1037,7 +1037,7 @@ def run_v2(args):
 
     # pass through any extensions block in the auspice config JSON without any changes / checking
     if config.get("extensions"):
-        data_json["extensions"] = config["extensions"]
+        data_json["meta"]["extensions"] = config["extensions"]
 
     # Write outputs - the (unified) dataset JSON intended for auspice & perhaps the ref root-sequence JSON
     indent = {"indent": None} if args.minify_json else {}

--- a/tests/functional/export_v2/dataset2.json
+++ b/tests/functional/export_v2/dataset2.json
@@ -101,6 +101,9 @@
     "panels": [
       "tree"
     ],
+    "extensions": {
+      "some_key": "some_value"
+    },
     "title": "Minimal config with an extensions block",
     "updated": "2021-06-09"
   },
@@ -221,8 +224,5 @@
       }
     }
   },
-  "version": "v2",
-  "extensions": {
-    "some_key": "some_value"
-  }
+  "version": "v2"
 }


### PR DESCRIPTION
resolves #885

I misspecified where extensions should be placed by augur. I hadn’t made it clear that Nextclade has settled on `meta.extensions` and I didn’t notice it when reviewing the PR #865. So now Augur places extensions at top level - which Nextclade doesn’t accept.

This PR moves extensions to where Nextclade expects it.

Only a few code changes were required. The tests pass.