### PR TITLE
Clean output from functional tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -23,6 +23,7 @@ python3 -m pytest -c pytest.python3.ini $coverage_arg "$@"
 if [ "$partial_test" = 0 ]; then
     echo "Running functional tests with cram"
     cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
+    git clean -f tests/
 else
     echo "Skipping functional tests when running a subset of unit tests"
 fi


### PR DESCRIPTION
### Description of proposed changes

Previously, running the tests would result in these untracked files:

```
tests/functional/tree/full_aligned-delim.fasta.contree
tests/functional/tree/full_aligned-delim.fasta.splits.nex
tests/functional/tree/full_aligned-delim.fasta.ufboot
tests/functional/tree/masked_aligned-delim.iqtree.log.xz
tests/functional/tree/masked_aligned.fasta.xz
```

The `git clean` command removes these after tests have been run.

### Related issue(s)
- Fixes #863

### Testing

_N/A_