### PR TITLE
Include functional tests in code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,9 +44,9 @@ jobs:
     - run: conda list
     - run: pytest -c pytest.python3.ini --cov=augur
     - run: cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
+    - run: coverage xml
     - run: bash tests/builds/runner.sh
     - if: github.repository == 'nextstrain/augur' && matrix.python-version == '3.10' && matrix.biopython-version == ''
-      run: coverage xml
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,10 @@ jobs:
     - run: conda list
     - run: pytest -c pytest.python3.ini --cov=augur
     - run: cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
+      env:
+        AUGUR: coverage run -a ${{ github.workspace }}/bin/augur
+        COVERAGE_FILE: ${{ github.workspace }}/.coverage
+        COVERAGE_RCFILE: ${{ github.workspace }}/.coveragerc
     - run: coverage xml
     - run: bash tests/builds/runner.sh
     - if: github.repository == 'nextstrain/augur' && matrix.python-version == '3.10' && matrix.biopython-version == ''

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,11 @@ jobs:
     - run: pip install -e .[dev]
     - run: conda info
     - run: conda list
-    - run: pytest -c pytest.python3.ini  --cov-report=xml --cov=augur
+    - run: pytest -c pytest.python3.ini --cov=augur
     - run: cram --shell=/bin/bash tests/functional/*.t tests/builds/*.t
     - run: bash tests/builds/runner.sh
     - if: github.repository == 'nextstrain/augur' && matrix.python-version == '3.10' && matrix.biopython-version == ''
+      run: coverage xml
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true

--- a/tests/builds/zika.t
+++ b/tests/builds/zika.t
@@ -7,7 +7,8 @@ Running from the test data directory allows us to use relative paths that won't 
   $ TEST_DATA_DIR="$TESTDIR/zika"
   $ mkdir -p "$TMP/out"
   $ pushd "$TEST_DATA_DIR" > /dev/null
-  $ export AUGUR="../../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../../bin/augur"
 
 Parse a FASTA whose defline contains metadata into separate sequence and metadata files.
 

--- a/tests/builds/zika.t
+++ b/tests/builds/zika.t
@@ -7,8 +7,7 @@ Running from the test data directory allows us to use relative paths that won't 
   $ TEST_DATA_DIR="$TESTDIR/zika"
   $ mkdir -p "$TMP/out"
   $ pushd "$TEST_DATA_DIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../../bin/augur}"
 
 Parse a FASTA whose defline contains metadata into separate sequence and metadata files.
 

--- a/tests/builds/zika_compressed.t
+++ b/tests/builds/zika_compressed.t
@@ -7,7 +7,8 @@ Running from the test data directory allows us to use relative paths that won't 
   $ TEST_DATA_DIR="$TESTDIR/zika"
   $ mkdir -p "$TMP/out"
   $ pushd "$TEST_DATA_DIR" > /dev/null
-  $ export AUGUR="../../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../../bin/augur"
 
 Parse a FASTA whose defline contains metadata into separate sequence and metadata files.
 

--- a/tests/builds/zika_compressed.t
+++ b/tests/builds/zika_compressed.t
@@ -7,8 +7,7 @@ Running from the test data directory allows us to use relative paths that won't 
   $ TEST_DATA_DIR="$TESTDIR/zika"
   $ mkdir -p "$TMP/out"
   $ pushd "$TEST_DATA_DIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../../bin/augur}"
 
 Parse a FASTA whose defline contains metadata into separate sequence and metadata files.
 

--- a/tests/functional/ancestral.t
+++ b/tests/functional/ancestral.t
@@ -1,8 +1,7 @@
 Integration tests for augur ancestral.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Infer ancestral sequences for the given tree and alignment.
 The default is to infer ambiguous bases, so there should not be N bases in the inferred output sequences.

--- a/tests/functional/ancestral.t
+++ b/tests/functional/ancestral.t
@@ -1,7 +1,8 @@
 Integration tests for augur ancestral.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Infer ancestral sequences for the given tree and alignment.
 The default is to infer ambiguous bases, so there should not be N bases in the inferred output sequences.

--- a/tests/functional/clades.t
+++ b/tests/functional/clades.t
@@ -1,7 +1,8 @@
 Integration tests for augur clades.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Test augur clades with simple Zika input files and hierarchical clades.
 

--- a/tests/functional/clades.t
+++ b/tests/functional/clades.t
@@ -1,8 +1,7 @@
 Integration tests for augur clades.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Test augur clades with simple Zika input files and hierarchical clades.
 

--- a/tests/functional/export_v2.t
+++ b/tests/functional/export_v2.t
@@ -1,7 +1,8 @@
 Integration tests for augur export v2.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Minimal export
 

--- a/tests/functional/export_v2.t
+++ b/tests/functional/export_v2.t
@@ -1,8 +1,7 @@
 Integration tests for augur export v2.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Minimal export
 

--- a/tests/functional/filter.t
+++ b/tests/functional/filter.t
@@ -1,8 +1,7 @@
 Integration tests for augur filter.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Filter with exclude query for two regions that comprise all but one strain.
 This filter should leave a single record from Oceania.

--- a/tests/functional/filter.t
+++ b/tests/functional/filter.t
@@ -1,7 +1,8 @@
 Integration tests for augur filter.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Filter with exclude query for two regions that comprise all but one strain.
 This filter should leave a single record from Oceania.

--- a/tests/functional/frequencies.t
+++ b/tests/functional/frequencies.t
@@ -1,7 +1,8 @@
 Integration tests for augur frequencies.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Calculate KDE-based tip frequencies from a refined tree.
 Timepoints used to estimate frequencies (i.e., "pivots") get calculated from the range of dates in the given metadata.

--- a/tests/functional/frequencies.t
+++ b/tests/functional/frequencies.t
@@ -1,8 +1,7 @@
 Integration tests for augur frequencies.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Calculate KDE-based tip frequencies from a refined tree.
 Timepoints used to estimate frequencies (i.e., "pivots") get calculated from the range of dates in the given metadata.

--- a/tests/functional/mask.t
+++ b/tests/functional/mask.t
@@ -1,7 +1,8 @@
 Integration tests for augur mask.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Try masking a VCF without any specified mask.
 

--- a/tests/functional/mask.t
+++ b/tests/functional/mask.t
@@ -1,8 +1,7 @@
 Integration tests for augur mask.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Try masking a VCF without any specified mask.
 

--- a/tests/functional/parse.t
+++ b/tests/functional/parse.t
@@ -1,7 +1,8 @@
 Integration tests for augur parse.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Parse Zika sequences into sequences and metadata.
 

--- a/tests/functional/parse.t
+++ b/tests/functional/parse.t
@@ -1,8 +1,7 @@
 Integration tests for augur parse.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Parse Zika sequences into sequences and metadata.
 

--- a/tests/functional/refine.t
+++ b/tests/functional/refine.t
@@ -1,7 +1,8 @@
 Integration tests for augur refine.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Try building a time tree.
 

--- a/tests/functional/refine.t
+++ b/tests/functional/refine.t
@@ -1,8 +1,7 @@
 Integration tests for augur refine.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Try building a time tree.
 

--- a/tests/functional/traits.t
+++ b/tests/functional/traits.t
@@ -1,8 +1,7 @@
 Integration tests for augur traits.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Infer the ancestral region for a given tree and metadata.
 

--- a/tests/functional/traits.t
+++ b/tests/functional/traits.t
@@ -1,7 +1,8 @@
 Integration tests for augur traits.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Infer the ancestral region for a given tree and metadata.
 

--- a/tests/functional/tree.t
+++ b/tests/functional/tree.t
@@ -1,7 +1,8 @@
 Integration tests for augur tree.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="../../bin/augur"
+  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
+  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
 
 Try building a tree with IQ-TREE.
 

--- a/tests/functional/tree.t
+++ b/tests/functional/tree.t
@@ -1,8 +1,7 @@
 Integration tests for augur tree.
 
   $ pushd "$TESTDIR" > /dev/null
-  $ export COVERAGE_FILE="$TESTDIR/../../.coverage"
-  $ export AUGUR="coverage run -a --rcfile=$TESTDIR/../../.coveragerc ../../bin/augur"
+  $ export AUGUR="${AUGUR:-../../bin/augur}"
 
 Try building a tree with IQ-TREE.
 


### PR DESCRIPTION
## Description of proposed changes

Use the default coverage report file `.coverage` for unit and functional
tests, running Augur in functional tests through an alias that runs
coverage in append mode. Then, use the coverage xml command to generate
the XML report needed by the codecov tool.

## Related issues

Fixes #688