### PR TITLE
Use GitHub Actions in release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version X.X.X'
+        required: true
+        type: string
+      pypi_instance:
+        # PyPI has a separate instance which can be used for testing purposes.
+        description: 'PyPI instance for publishing'
+        required: true
+        default: 'PyPI'
+        type: choice
+        options:
+        - 'TestPyPI'
+        - 'PyPI'
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Fetch all branches and tags.
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - name: Set Nextstrain bot as git user
+        run: |
+          git config --global user.email "hello@nextstrain.org"
+          git config --global user.name "Nextstrain bot"
+      - run: python3 -m pip install --upgrade build twine
+      - run: devel/release ${{ github.event.inputs.version}}
+      - run: devel/test
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - run: git push origin master release tag ${{ github.event.inputs.version}}
+      - name: 'Publish to TestPyPI'
+        if: ${{ github.event.inputs.pypi_instance == 'TestPyPI' }}
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+      - name: 'Publish to PyPI'
+        if: ${{ github.event.inputs.pypi_instance == 'PyPI' }}
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/

--- a/devel/release
+++ b/devel/release
@@ -159,9 +159,8 @@ merge-to-release-branch() {
 }
 
 build-dist() {
-    rm -rfv dist augur.egg-info
-    python3 setup.py clean
-    python3 setup.py sdist bdist_wheel
+    rm -rfv build/ dist/ nextstrain_augur.egg-info
+    python3 -m build
 }
 
 remind-to-push() {

--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -30,9 +30,6 @@ Please see the [project board](https://github.com/orgs/nextstrain/projects/6) fo
 We currently target compatibility with Python 3.7 and higher. As Python releases new versions,
 the minimum target compatibility may be increased in the future.
 
-Versions for this project, Augur, from 3.0.0 onwards aim to follow the
-[Semantic Versioning rules](https://semver.org).
-
 ### Running local changes
 
 While you are making code changes, you will want to run augur to see it behavior with those changes.
@@ -158,27 +155,64 @@ We use [codecov](https://codecov.io/) to automatically produce test coverage for
 
 ### Releasing
 
-Before you create a new release, run all tests from a fresh conda environment to verify that nothing has broken since the last CI build on GitHub.
-The following commands will setup the equivalent conda environment to the GitHub Actions environment, run unit and integration tests, and deactivate the environment.
+Versions for this project, Augur, from 3.0.0 onwards aim to follow the
+[Semantic Versioning rules](https://semver.org).
 
-```bash
-# Update Conda.
-conda activate base
-conda update conda
+#### Steps
 
-# Create an Augur environment.
-conda create -n augur -c conda-forge -c bioconda augur
-conda activate augur
-python3 -m pip install -e .[dev]
+##### 1. Gather PRs and draft release notes
 
-# Run tests.
-./run_tests.sh
-bash tests/builds/runner.sh
+1. Compare changes to find PRs and direct commits since the previous tag (e.g. https://github.com/nextstrain/augur/compare/14.1.0...15.0.0, replacing `14.1.0` with previous tag and `15.0.0` with `master`)
+2. Add the PRs to the open GitHub milestone.
+3. Define a new version number `X.X.X` based on changes and Semantic Versioning rules.
+4. Rename the milestone as `<Major|Feature|Patch> release X.X.X`.
+5. Draft changes in the milestone description using Markdown. Keep headers and formatting consistent with [CHANGES.md](../../CHANGES.md).
 
-# Clean up.
-conda deactivate
-conda env remove -n augur
-```
+##### 2. Update change log
+
+In your local copy of `augur`:
+
+1. Run `git switch master`.
+2. Run `git pull`.
+3. In `CHANGES.md`, add milestone description under the `__NEXT__` header.
+4. Stage changes.
+5. Run `git commit -m 'Update change log for X.X.X'`.
+
+##### 3. Run build/test/release scripts
+
+In your local copy of `augur`:
+
+1. Run `devel/release X.X.X`.
+2. Run `devel/test`.
+    - Verify successful run.
+3. Run `git push origin master release tag X.X.X`.
+4. Run `twine upload dist/*`.
+
+##### 4. Update GitHub milestones
+
+1. Close current release milestone.
+2. Create new milestone named `Next release X.X.X`.
+
+##### 5. Update on Bioconda
+
+For versions without dependency changes:
+
+1. Wait for an auto-bump PR in [bioconda-recipes][].
+2. Add a comment `@BiocondaBot please add label`.
+3. Wait for a bioconda maintainer to approve and merge.
+
+For versions with dependency changes:
+
+1. Create a new PR in [bioconda-recipes][] following instructions at [nextstrain/bioconda-recipes/README.md](https://github.com/nextstrain/bioconda-recipes/blob/readme/README.md).
+    - [Example](https://github.com/bioconda/bioconda-recipes/pull/34344)
+2. Add a comment `@BiocondaBot please add label`.
+3. Wait for a bioconda maintainer to approve and merge.
+4. Wait for an auto-bump PR in [bioconda-recipes][].
+5. Add a comment in the auto-bump PR `Please close this in favor of #<your PR number>`.
+
+[bioconda-recipes]: https://github.com/bioconda/bioconda-recipes/pull/34509
+
+#### Notes
 
 New releases are tagged in git using an "annotated" tag.  If the git option
 `user.signingKey` is set, the tag will also be [signed][].  Signed tags are

--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -170,23 +170,23 @@ Versions for this project, Augur, from 3.0.0 onwards aim to follow the
 
 ##### 2. Update change log
 
-In your local copy of `augur`:
-
-1. Run `git switch master`.
-2. Run `git pull`.
-3. In `CHANGES.md`, add milestone description under the `__NEXT__` header.
-4. Stage changes.
-5. Run `git commit -m 'Update change log for X.X.X'`.
+1. Visit [this link](https://github.com/nextstrain/augur/edit/master/CHANGES.md) to open `CHANGES.md` for edit.
+2. Add the milestone description under the `__NEXT__` header.
+3. At the bottom of the page:
+    1. Title: `Update change log for X.X.X`
+    2. Description: leave empty
+    3. Select the option **Commit directly to the `master` branch.**
+4. Select **Commit changes**.
 
 ##### 3. Run build/test/release scripts
 
-In your local copy of `augur`:
-
-1. Run `devel/release X.X.X`.
-2. Run `devel/test`.
-    - Verify successful run.
-3. Run `git push origin master release tag X.X.X`.
-4. Run `twine upload dist/*`.
+1. Go to [this GitHub Actions workflow](https://github.com/nextstrain/augur/actions/workflows/release.yaml).
+2. Select **Run workflow**. In the new menu:
+    1. Ensure `master` branch is selected.
+    2. In **New version X.X.X**, provide the new version number.
+    3. Set **PyPI instance for publishing** as *PyPI* (default) or *TestPyPI*. [More info](https://packaging.python.org/en/latest/guides/using-testpypi)
+    4. Select **Run workflow**.
+3. Ensure workflow runs successfully.
 
 ##### 4. Update GitHub milestones
 


### PR DESCRIPTION
### Description of proposed changes

Similar to [the publish workflow for nextstrain-sphinx-theme](https://github.com/nextstrain/sphinx-theme/blob/main/.github/workflows/publish.yml).

Reduces but does not completely eliminate manual work in the release process. See [updated release steps](https://github.com/victorlin/augur/blob/master/docs/contribute/DEV_DOCS.md#releasing).

### Related issue(s)

_N/A_

### Testing

On my fork repo, I uploaded 15.0.1 to TestPyPI using these changes + a cherry-picked ed8ed92e0ba6d4bd1a5a217242d0529c00bd6fb5 ([see successful run](https://github.com/victorlin/augur/runs/6167733572)). I already released 15.0.1 to PyPI using current manual steps, but this can be used for the next release once merged.