### PR TITLE
fix: accept "name" column for strain names in export

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -940,15 +940,22 @@ def parse_node_data_and_metadata(T, node_data, metadata):
     node_data_names = set()
     metadata_names = set()
 
+    # Determine if metadata file uses "strain" or "name" for strain name
+    try:
+        list(metadata.values())[0]["strain"]
+        strain_column = "strain"
+    except LookupError:
+        strain_column = "name"
+
     # assign everything to node_attrs, exclusions considered later
     node_attrs = {clade.name: {} for clade in T.root.find_clades()}
 
     # first pass: metadata
     for node in metadata.values():
-        if node["strain"] in node_attrs: # i.e. this node name is in the tree
+        if node[strain_column] in node_attrs: # i.e. this node name is in the tree
             for key, value in node.items():
                 corrected_key = update_deprecated_names(key)
-                node_attrs[node["strain"]][corrected_key] = value
+                node_attrs[node[strain_column]][corrected_key] = value
                 metadata_names.add(corrected_key)
 
     # second pass: node data JSONs (overwrites keys of same name found in metadata)


### PR DESCRIPTION
Metadata reader class accepts either "name" or "strain" as strain name columns.
However, export thus far doesn't accept "name".
This commit detects if "name" is used and uses it, thus getting rid of common error type.

### Related issue(s)
Fixes #905 

### Testing
I tested that metadata files with `name` instead of `strain` as the column name for strain names are now accepted - in line with what the metadata file class accepts. The reason we didn't emit useful error messages was that the metadata file class was happy with `name`. Yet export expected `strain` and wasn't happy with `name`.

Henceforth, this type of error shouldn't happen anymore: https://discussion.nextstrain.org/t/error-in-job-3-exporting-data-files-for-for-auspice/493

If you don't have either `strain` or `name` in metdata, you'll get a helpful error and all is good.

```
Traceback (most recent call last):
  File "/usr/local/Caskroom/mambaforge/base/envs/augur-dev/bin/augur", line 33, in <module>
    sys.exit(load_entry_point('nextstrain-augur', 'console_scripts', 'augur')())
  File "/Users/cr/code/augur/augur/__main__.py", line 10, in main
    return augur.run( argv[1:] )
  File "/Users/cr/code/augur/augur/__init__.py", line 75, in run
    return args.__command__.run(args)
  File "/Users/cr/code/augur/augur/export.py", line 22, in run
    return run_v2(args)
  File "/Users/cr/code/augur/augur/export_v2.py", line 1002, in run_v2
    metadata_file, _ = read_metadata(args.metadata)
  File "/Users/cr/code/augur/augur/utils.py", line 82, in read_metadata
    return MetadataFile(fname, query, as_data_frame).read()
  File "/Users/cr/code/augur/augur/util_support/metadata_file.py", line 19, in __init__
    self.key_type = self.find_key_type()
  File "/Users/cr/code/augur/augur/util_support/metadata_file.py", line 73, in find_key_type
    raise ValueError(
ValueError: Metadata file data/nextstrain_reinf.tsv does not contain `name` or `strain`
```