### PR TITLE
Use io.read_metadata during export

### DIFF
--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -9,7 +9,9 @@ import warnings
 import numbers
 import re
 from Bio import Phylo
-from .utils import read_metadata, read_node_data, write_json, read_config, read_lat_longs, read_colors
+
+from .io import read_metadata
+from .utils import read_node_data, write_json, read_config, read_lat_longs, read_colors
 from .validate import export_v2 as validate_v2, auspice_config_v2 as validate_auspice_config_v2, ValidateError
 
 # Set up warnings & exceptions
@@ -992,7 +994,10 @@ def run_v2(args):
 
     if args.metadata is not None:
         try:
-            metadata_file, _ = read_metadata(args.metadata)
+            metadata_file = read_metadata(args.metadata).to_dict(orient="index")
+            for strain in metadata_file.keys():
+                if "strain" not in metadata_file[strain]:
+                    metadata_file[strain]["strain"] = strain
         except FileNotFoundError:
             print(f"ERROR: meta data file ({args.metadata}) does not exist")
             sys.exit(2)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -999,8 +999,11 @@ def run_v2(args):
                 if "strain" not in metadata_file[strain]:
                     metadata_file[strain]["strain"] = strain
         except FileNotFoundError:
-            print(f"ERROR: meta data file ({args.metadata}) does not exist")
+            print(f"ERROR: meta data file ({args.metadata}) does not exist", file=sys.stderr)
             sys.exit(2)
+        except Exception as error:
+            print(f"ERROR: {error}", file=sys.stderr)
+            sys.exit(1)
     else:
         metadata_file = {}
 

--- a/augur/io.py
+++ b/augur/io.py
@@ -91,11 +91,13 @@ def read_metadata(metadata_file, id_columns=("strain", "name"), chunk_size=None)
         kwargs["chunksize"] = chunk_size
 
     # Inspect the first chunk of the metadata, to find any valid index columns.
-    chunk = pd.read_csv(
+    metadata = pd.read_csv(
         metadata_file,
         iterator=True,
         **kwargs,
-    ).read(nrows=1)
+    )
+    chunk = metadata.read(nrows=1)
+    metadata.close()
 
     id_columns_present = [
         id_column

--- a/tests/functional/export_v2.t
+++ b/tests/functional/export_v2.t
@@ -65,3 +65,36 @@ Export with auspice config JSON with an extensions block
   $ python3 "$TESTDIR/../../scripts/diff_jsons.py"  export_v2/dataset2.json "$TMP/dataset3.json" \
   >   --exclude-paths "root['meta']['updated']"
   {}
+
+Run export with metadata using the default id column of "strain".
+
+  $ ${AUGUR} export v2 \
+  >  --tree export_v2/tree.nwk \
+  >  --metadata export_v2/dataset1_metadata_with_strain.tsv \
+  >  --node-data export_v2/div_node-data.json export_v2/location_node-data.json \
+  >  --auspice-config export_v2/auspice_config1.json \
+  >  --maintainers "Nextstrain Team" \
+  >  --output "$TMP/dataset1.json" > /dev/null
+
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" export_v2/dataset1.json "$TMP/dataset1.json" \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+  $ rm -f "$TMP/dataset1.json"
+
+Run export with metadata that uses a different id column other than "strain".
+In this case, the column is "name" (one of the default columns expected by Augur's `io.read_metadata` function).
+
+  $ ${AUGUR} export v2 \
+  >  --tree export_v2/tree.nwk \
+  >  --metadata export_v2/dataset1_metadata_with_name.tsv \
+  >  --node-data export_v2/div_node-data.json export_v2/location_node-data.json \
+  >  --auspice-config export_v2/auspice_config1.json \
+  >  --maintainers "Nextstrain Team" \
+  >  --output "$TMP/dataset1.json" > /dev/null
+
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" export_v2/dataset1.json "$TMP/dataset1.json" \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+  $ rm -f "$TMP/dataset1.json"
+
+  $ popd > /dev/null

--- a/tests/functional/export_v2.t
+++ b/tests/functional/export_v2.t
@@ -97,4 +97,17 @@ In this case, the column is "name" (one of the default columns expected by Augur
   {}
   $ rm -f "$TMP/dataset1.json"
 
+Run export with metadata that uses an invalid id column.
+This should fail with a helpful error message.
+
+  $ ${AUGUR} export v2 \
+  >  --tree export_v2/tree.nwk \
+  >  --metadata export_v2/dataset1_metadata_without_valid_id.tsv \
+  >  --node-data export_v2/div_node-data.json export_v2/location_node-data.json \
+  >  --auspice-config export_v2/auspice_config1.json \
+  >  --maintainers "Nextstrain Team" \
+  >  --output "$TMP/dataset1.json" > /dev/null
+  ERROR: None of the possible id columns (('strain', 'name')) were found in the metadata's columns ('invalid_id', 'div', 'mutation_length')
+  [1]
+
   $ popd > /dev/null

--- a/tests/functional/export_v2/dataset1_metadata_with_name.tsv
+++ b/tests/functional/export_v2/dataset1_metadata_with_name.tsv
@@ -1,0 +1,7 @@
+name	div	mutation_length
+tipA	1	1
+tipB	3	1
+tipC	3	1
+tipD	8	3
+tipE	9	4
+tipF	6	1

--- a/tests/functional/export_v2/dataset1_metadata_with_strain.tsv
+++ b/tests/functional/export_v2/dataset1_metadata_with_strain.tsv
@@ -1,0 +1,7 @@
+strain	div	mutation_length
+tipA	1	1
+tipB	3	1
+tipC	3	1
+tipD	8	3
+tipE	9	4
+tipF	6	1

--- a/tests/functional/export_v2/dataset1_metadata_without_valid_id.tsv
+++ b/tests/functional/export_v2/dataset1_metadata_without_valid_id.tsv
@@ -1,0 +1,7 @@
+invalid_id	div	mutation_length
+tipA	1	1
+tipB	3	1
+tipC	3	1
+tipD	8	3
+tipE	9	4
+tipF	6	1


### PR DESCRIPTION
## Description of proposed changes
Replaces a call to the older `utils.read_metadata` function with the newer `io.read_metadata` function while processing metadata for export to an Auspice JSON. This new function returns a pandas DataFrame indexed by the first viable strain name column found in the metadata file (removing this column from the data itself), while the original function returns a dictionary indexed by strain name (keeping the original named column like `strain` or `name` in the data).

To avoid changing the downstream code that consumes the metadata, this commit converts the pandas DataFrame to a dictionary that matches the output of the original function. The main advantage here is that the calling code does not need to know what the id column is named, since `io.read_metadata` handles this and indexed the data frame by that column.

Importantly, the `io.read_metadata` function defines a list of accepted id columns to look for and will raise an exception with a helpful error message when the input metadata has no valid id columns. Commit 45df6bd adds a check for this exception in the augur export v2 command such that the user will get a helpful error message on the command line instead of an uncaught exception. An example from a new functional test demonstrates this behavior:

```bash
$ augur export v2 \
  --tree tree.nwk \
  --metadata dataset1_metadata_without_valid_id.tsv \
  --node-data div_node-data.json location_node-data.json \
  --auspice-config auspice_config1.json \
  --maintainers "Nextstrain Team" \
  --output test.json
ERROR: None of the possible id columns (('strain', 'name')) were found in the metadata's columns ('invalid_id', 'div', 'mutation_length')
$ echo $?
1
```

I preferred this implementation over the check for valid id columns in https://github.com/nextstrain/augur/pull/906 because: 

1. it replaces an unmaintained `read_metadata` function with a maintained version, 
2. it does not duplicate information about valid id columns in the export module (this information is left to `read_metadata`),
3. and it provides the user with a helpful error message when there are no valid id columns.

### Related issue(s)

Fixes #905

### Testing

 - [x] Adds functional tests for the expected behavior of export v2 with metadata inputs.
 - [x] Tested by CI