### PR TITLE
Call new GitHub Actions workflow to rebuild images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,23 +54,4 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - env:
-          TRAVIS_AUTH_TOKEN: ${{ secrets.TRAVIS_AUTH_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          echo "Pinging Travis CI to rebuild Docker image"
-
-          body='{
-            "request": {
-              "branch": "master",
-              "message": "Build triggered from augur"
-            }
-          }'
-
-          curl -X POST https://api.travis-ci.com/repo/nextstrain%2Fdocker-base/requests \
-            -H "Content-Type: application/json" \
-            -H "Accept: application/json" \
-            -H "Travis-API-Version: 3" \
-            -H "Authorization: token $TRAVIS_AUTH_TOKEN" \
-            -d "$body"
+    - run: gh workflow run ci.yml --repo nextstrain/docker-base


### PR DESCRIPTION
### Description of proposed changes

See https://github.com/nextstrain/docker-base/pull/41

### Related issue(s)

_N/A_

### Testing

Unable to test until nextstrain/docker-base#41 is merged and a new Augur version is released.

### Post-merge

- [ ] Remove `TRAVIS_AUTH_TOKEN` from [org Actions secrets](https://github.com/organizations/nextstrain/settings/secrets/actions) if this is the last repo that's using it (see [query](https://github.com/search?q=TRAVIS_AUTH_TOKEN+org%3Anextstrain&type=code))