### PR TITLE
ci: Move docker rebuild step to release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,9 +49,3 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
-  deploy:
-    if: github.repository == 'nextstrain/augur' && github.ref == 'refs/heads/release'
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-    - run: gh workflow run ci.yml --repo nextstrain/docker-base

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,3 +52,8 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
           TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+  rebuild-docker-image:
+    needs: [run]
+    runs-on: ubuntu-latest
+    steps:
+    - run: gh workflow run ci.yml --repo nextstrain/docker-base


### PR DESCRIPTION
### Description of proposed changes

- Move docker rebuild step to release workflow, since it was already being conditioned upon release.
- Rename from `deploy` to `rebuild-docker-image` per discussion at https://github.com/nextstrain/auspice/pull/1505#discussion_r865244775

### Related issue(s)

_N/A_

### Testing

Will monitor during next release.