### PR TITLE
Handle `FileNotFoundError` and unexpected exceptions gracefully

### DIFF
--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -7,6 +7,8 @@ import re
 import os
 import sys
 import importlib
+import traceback
+from textwrap import dedent
 from types import SimpleNamespace
 
 from .io import print_err
@@ -80,6 +82,15 @@ def run(argv):
         sys.exit(2)
     except RecursionError:
         print_err("FATAL: Maximum recursion depth reached. You can set the env variable AUGUR_RECURSION_LIMIT to adjust this (current limit: {})".format(sys.getrecursionlimit()))
+        sys.exit(2)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        print_err("\n")
+        print_err(dedent("""\
+            An error occurred (see above) that has not been properly handled by Augur.
+            To report this, please open a new issue including the original command and the error above:
+                <https://github.com/nextstrain/augur/issues/new/choose>
+            """))
         sys.exit(2)
 
 

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -83,6 +83,9 @@ def run(argv):
     except RecursionError:
         print_err("FATAL: Maximum recursion depth reached. You can set the env variable AUGUR_RECURSION_LIMIT to adjust this (current limit: {})".format(sys.getrecursionlimit()))
         sys.exit(2)
+    except FileNotFoundError as e:
+        print_err(f"ERROR: {e.strerror}: '{e.filename}'")
+        sys.exit(2)
     except Exception:
         traceback.print_exc(file=sys.stderr)
         print_err("\n")

--- a/tests/functional/filter.t
+++ b/tests/functional/filter.t
@@ -449,3 +449,23 @@ Error on duplicates in metadata in separate chunks.
   $ cat $TMP/metadata-filtered.tsv
   cat: .*: No such file or directory (re)
   [1]
+
+Try to filter on an metadata file that does not exist.
+
+  $ ${AUGUR} filter \
+  >  --metadata file-does-not-exist.tsv \
+  >  --group-by year month \
+  >  --sequences-per-group 1 \
+  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  ERROR: No such file or directory: 'file-does-not-exist.tsv'
+  [2]
+
+Try to output to a directory that does not exist.
+
+  $ ${AUGUR} filter \
+  >  --metadata filter/metadata.tsv \
+  >  --group-by year month \
+  >  --sequences-per-group 1 \
+  >  --output-strains "directory-does-not-exist/filtered_strains.txt" > /dev/null
+  ERROR: No such file or directory: 'directory-does-not-exist/filtered_strains.txt'
+  [2]


### PR DESCRIPTION
### Description of proposed changes

This is similar to the global exception handler for Nextstrain CLI: https://github.com/nextstrain/cli/commit/c046fb248eca56f22419ba54e1d72b7dd5c2fc5e

Any uncaught exception from augur subcommands is unexpected and should be opened as a GitHub issue for triage to determine if:

1. It is an expected exception and we should handle it with a specific message
2. It is a bug that needs fixing

As an example of (1), this PR also addresses unhandled `FileNotFoundError`s.

### Related issue(s)

- Fixes #903
- Fixes the `FileNotFoundError` example in #642

### Testing

Tested locally, borrowing example from https://github.com/nextstrain/augur/issues/871#issuecomment-1071771710 :

```sh
echo -e 'strain\tdate\tyear
SEQ1\t2021-01-01\todd
SEQ2\t2021-01-02\todd
SEQ3\t2022-01-01\teven
SEQ4\t2022-01-02\teven
SEQ5\t2022-02-02\teven
' > metadata.tsv

augur filter \
  --metadata metadata.tsv \
  --group-by year month \
  --sequences-per-group 1 \
  --output-metadata filtered.tsv
```

Output:

```
Traceback (most recent call last):
  File "/Users/vlin/Dropbox/repos/nextstrain/augur/augur/__init__.py", line 77, in run
    return args.__command__.run(args)
  File "/Users/vlin/Dropbox/repos/nextstrain/augur/augur/filter.py", line 1418, in run
    group_by,
  File "/Users/vlin/Dropbox/repos/nextstrain/augur/augur/filter.py", line 945, in get_groups_for_subsampling
    df_skip = metadata[metadata['year'].isnull()]
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/frame.py", line 3445, in __getitem__
    return self.where(key)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/util/_decorators.py", line 311, in wrapper
    return func(*args, **kwargs)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/frame.py", line 10736, in where
    return super().where(cond, other, inplace, axis, level, errors, try_cast)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/generic.py", line 9032, in where
    return self._where(cond, other, inplace, axis, level, errors=errors)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/generic.py", line 8794, in _where
    cond = cond.reindex(self._info_axis, axis=self._info_axis_number, copy=False)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/util/_decorators.py", line 324, in wrapper
    return func(*args, **kwargs)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/frame.py", line 4772, in reindex
    return super().reindex(**kwargs)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/generic.py", line 4819, in reindex
    axes, level, limit, tolerance, method, fill_value, copy
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/frame.py", line 4592, in _reindex_axes
    columns, method, copy, level, fill_value, limit, tolerance
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/frame.py", line 4640, in _reindex_columns
    allow_dups=False,
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/generic.py", line 4889, in _reindex_with_indexers
    copy=copy,
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/internals/managers.py", line 670, in reindex_indexer
    self.axes[axis]._validate_can_reindex(indexer)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/nextstrain-local/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 3785, in _validate_can_reindex
    raise ValueError("cannot reindex from a duplicate axis")
ValueError: cannot reindex from a duplicate axis


An error occurred (see above) that likely indicates a bug in Augur.
To report this, please open a new issue and including the original command and the error above:
    <https://github.com/nextstrain/augur/issues/new/choose>
```

For the `FileNotFoundError`s, added a cram test to reflect new behavior.

### Pre-merge

- [ ] squash commits