### PR TITLE
schemas: Add missing display_default properties for Auspice config v2

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -176,8 +176,10 @@
                     "enum": ["rect", "radial", "unrooted", "clock"]
                 },
                 "branch_label": {
+                    "description": "What branch label should be displayed by default, or 'none' to hide labels by default.",
+                    "$comment": "Should be a key present in the per-node branch_attrs.labels object of the exported JSON; pattern is from the schema for that object",
                     "type": "string",
-                    "enum": ["clade", "aa", "none"]
+                    "pattern": "^(none|[a-zA-Z0-9]+)$"
                 },
                 "transmission_lines": {
                     "type": "boolean"

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -181,6 +181,25 @@
                 },
                 "transmission_lines": {
                     "type": "boolean"
+                },
+                "language": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "A BCP 47 language tag specifying the default language in which to display Auspice's interface (if supported)"
+                },
+                "sidebar": {
+                    "type": "string",
+                    "enum": ["open", "closed"]
+                },
+                "panels": {
+                    "type": "array",
+                    "description": "The panels to display by default.",
+                    "$comment": "optional, but if present must not be empty",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string",
+                        "enum": ["tree", "map", "frequencies", "entropy"]
+                    }
                 }
             }
         },
@@ -197,7 +216,7 @@
         },
         "panels": {
             "type": "array",
-            "description": "Which panels should auspice display",
+            "description": "The panels available for display.",
             "$comment": "optional",
             "minItems": 1,
             "items": {

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -258,8 +258,10 @@
                             "type": "boolean"
                         },
                         "branch_label": {
-                            "description": "What branch label should be displayed by default.",
-                            "type": "string"
+                            "description": "What branch label should be displayed by default, or 'none' to hide labels by default.",
+                            "$comment": "Should be a key present in the per-node branch_attrs.labels object of the exported JSON; pattern is from the schema for that object",
+                            "type": "string",
+                            "pattern": "^(none|[a-zA-Z0-9]+)$"
                         },
                         "transmission_lines": {
                             "description": "Should transmission lines (if available) be displaye by default",

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -264,6 +264,25 @@
                         "transmission_lines": {
                             "description": "Should transmission lines (if available) be displaye by default",
                             "type": "boolean"
+                        },
+                        "language": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "A BCP 47 language tag specifying the default language in which to display Auspice's interface (if supported)"
+                        },
+                        "sidebar": {
+                            "type": "string",
+                            "enum": ["open", "closed"]
+                        },
+                        "panels": {
+                            "type": "array",
+                            "description": "The panels to display by default.",
+                            "$comment": "optional, but if present must not be empty",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string",
+                                "enum": ["tree", "map", "frequencies", "entropy"]
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
Resolves <https://github.com/nextstrain/augur/issues/911> which noted
"language".  In confirming that, I cross-referenced Auspice's view
settings doc¹ and code² which revealed "sidebar" and "panels" too.
Clarifies the purpose of the two different "panels" keys.

¹ https://docs.nextstrain.org/projects/auspice/en/stable/advanced-functionality/view-settings.html#dataset-json-configurable-defaults
² https://github.com/nextstrain/auspice/blob/ce8380f7/src/actions/recomputeReduxState.js#L699-L718

### Testing
Not yet tested. Will look at CI tests and maybe add a test case too.