### PR TITLE
Properly error on duplicates in `parse` and `filter`, handle `AugurError` globally

### DIFF
--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -8,7 +8,7 @@ import os
 import sys
 import importlib
 from types import SimpleNamespace
-from .utils import first_line
+from .utils import AugurError, first_line
 
 recursion_limit = os.environ.get("AUGUR_RECURSION_LIMIT")
 if recursion_limit:
@@ -73,6 +73,9 @@ def run(argv):
     args = make_parser().parse_args(argv)
     try:
         return args.__command__.run(args)
+    except AugurError as e:
+        print(f"ERROR: {e}")
+        sys.exit(2)
     except RecursionError:
         print("FATAL: Maximum recursion depth reached. You can set the env variable AUGUR_RECURSION_LIMIT to adjust this (current limit: {})".format(sys.getrecursionlimit()))
         sys.exit(2)

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -8,6 +8,8 @@ import os
 import sys
 import importlib
 from types import SimpleNamespace
+
+from .io import print_err
 from .utils import AugurError, first_line
 
 recursion_limit = os.environ.get("AUGUR_RECURSION_LIMIT")
@@ -74,10 +76,10 @@ def run(argv):
     try:
         return args.__command__.run(args)
     except AugurError as e:
-        print(f"ERROR: {e}")
+        print_err(f"ERROR: {e}")
         sys.exit(2)
     except RecursionError:
-        print("FATAL: Maximum recursion depth reached. You can set the env variable AUGUR_RECURSION_LIMIT to adjust this (current limit: {})".format(sys.getrecursionlimit()))
+        print_err("FATAL: Maximum recursion depth reached. You can set the env variable AUGUR_RECURSION_LIMIT to adjust this (current limit: {})".format(sys.getrecursionlimit()))
         sys.exit(2)
 
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -20,7 +20,7 @@ from typing import Collection
 from .dates import numeric_date, numeric_date_type, SUPPORTED_DATE_HELP_TEXT
 from .index import index_sequences, index_vcf
 from .io import open_file, read_metadata, read_sequences, write_sequences
-from .utils import is_vcf as filename_is_vcf, read_vcf, read_strains, get_numerical_dates, run_shell_command, shquote, is_date_ambiguous
+from .utils import AugurError, is_vcf as filename_is_vcf, read_vcf, read_strains, get_numerical_dates, run_shell_command, shquote, is_date_ambiguous
 
 comment_char = '#'
 
@@ -30,7 +30,7 @@ SEQUENCE_ONLY_FILTERS = (
 )
 
 
-class FilterException(Exception):
+class FilterException(AugurError):
     """Representation of an error that occurred during filtering.
     """
     pass

--- a/augur/io.py
+++ b/augur/io.py
@@ -3,6 +3,7 @@
 """
 import Bio.SeqIO
 import Bio.SeqRecord
+import sys
 from contextlib import contextmanager
 import pandas as pd
 from pathlib import Path
@@ -194,3 +195,7 @@ def write_sequences(sequences, path_or_buffer, format="fasta"):
         )
 
     return sequences_written
+
+
+def print_err(*args):
+    print(*args, file=sys.stderr)

--- a/augur/parse.py
+++ b/augur/parse.py
@@ -5,7 +5,7 @@ import pandas as pd
 import sys
 
 from .io import open_file, read_sequences, write_sequences
-from .utils import get_numerical_date_from_value
+from .utils import AugurError, get_numerical_date_from_value
 
 forbidden_characters = str.maketrans(
     {' ': None,
@@ -176,6 +176,8 @@ def run(args):
                 args.prettify_fields,
                 args.fix_dates
             )
+            if sequence_record.id in meta_data:
+                raise AugurError(f"Duplicate found for '{sequence_record.id}'.")
             meta_data[sequence_record.id] = sequence_metadata
 
             sequences_written = write_sequences(

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -24,7 +24,7 @@ from augur.util_support.node_data_reader import NodeDataReader
 from augur.util_support.shell_command_runner import ShellCommandRunner
 
 
-class AugurException(Exception):
+class AugurError(Exception):
     pass
 
 

--- a/tests/functional/filter.t
+++ b/tests/functional/filter.t
@@ -411,3 +411,41 @@ This should fail with a helpful error message.
   >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
   ERROR: You must specify a number of sequences per group or maximum sequences to subsample.
   [1]
+
+Error on duplicates in metadata within same chunk.
+
+  $ cat >$TMP/metadata-duplicates.tsv <<~~
+  > strain	date
+  > a	2010-10-10
+  > a	2010-10-10
+  > b	2010-10-10
+  > c	2010-10-10
+  > d	2010-10-10
+  > ~~
+  $ ${AUGUR} filter \
+  >   --metadata $TMP/metadata-duplicates.tsv \
+  >   --group-by year \
+  >   --sequences-per-group 2 \
+  >   --subsample-seed 0 \
+  >   --metadata-chunk-size 10 \
+  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
+  ERROR: Duplicate found in .* (re)
+  [2]
+  $ cat $TMP/metadata-filtered.tsv
+  cat: .*: No such file or directory (re)
+  [1]
+
+Error on duplicates in metadata in separate chunks.
+
+  $ ${AUGUR} filter \
+  >   --metadata $TMP/metadata-duplicates.tsv \
+  >   --group-by year \
+  >   --sequences-per-group 2 \
+  >   --subsample-seed 0 \
+  >   --metadata-chunk-size 1 \
+  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
+  ERROR: Duplicate found in .* (re)
+  [2]
+  $ cat $TMP/metadata-filtered.tsv
+  cat: .*: No such file or directory (re)
+  [1]

--- a/tests/functional/parse.t
+++ b/tests/functional/parse.t
@@ -31,4 +31,24 @@ Parse compressed Zika sequences into sequences and metadata.
   $ diff -u "parse/metadata.tsv" "$TMP/metadata.tsv"
   $ rm -f "$TMP/sequences.fasta" "$TMP/metadata.tsv"
 
+Error on the first duplicate.
+
+  $ cat >$TMP/data.fasta <<~~
+  > >SEQ1
+  > AAA
+  > >SEQ1
+  > AAA
+  > >SEQ2
+  > AAA
+  > >SEQ2
+  > AAA
+  > ~~
+  $ ${AUGUR} parse \
+  >   --sequences $TMP/data.fasta \
+  >   --output-sequences "$TMP/sequences.fasta" \
+  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --fields strain
+  ERROR: Duplicate found for 'SEQ1'.
+  [2]
+
   $ popd > /dev/null


### PR DESCRIPTION
### Description of proposed changes

This PR introduces a new `AugurError` and uses it in `parse` and `filter` to properly error on duplicates. See individual commits.

### Related issue(s)

- Fixes #616
- Fixes #915

### Testing

Added tests for new error messages.