### PR TITLE
filter: Move date logic from `utils` to `dates`

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -17,10 +17,10 @@ import sys
 from tempfile import NamedTemporaryFile
 from typing import Collection
 
-from .dates import numeric_date, numeric_date_type, SUPPORTED_DATE_HELP_TEXT
+from .dates import numeric_date, numeric_date_type, SUPPORTED_DATE_HELP_TEXT, is_date_ambiguous, get_numerical_dates
 from .index import index_sequences, index_vcf
 from .io import open_file, read_metadata, read_sequences, write_sequences
-from .utils import AugurError, is_vcf as filename_is_vcf, read_vcf, read_strains, get_numerical_dates, run_shell_command, shquote, is_date_ambiguous
+from .utils import AugurError, is_vcf as filename_is_vcf, read_vcf, read_strains, run_shell_command, shquote
 
 comment_char = '#'
 

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -9,8 +9,8 @@ from Bio.Align import MultipleSeqAlignment
 
 from .frequency_estimators import get_pivots, alignment_frequencies, tree_frequencies
 from .frequency_estimators import AlignmentKdeFrequencies, TreeKdeFrequencies, TreeKdeFrequenciesError
-from .dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT
-from .utils import read_metadata, read_node_data, write_json, get_numerical_dates
+from .dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT, get_numerical_dates
+from .utils import read_metadata, read_node_data, write_json
 
 
 def register_arguments(parser):

--- a/augur/parse.py
+++ b/augur/parse.py
@@ -5,7 +5,8 @@ import pandas as pd
 import sys
 
 from .io import open_file, read_sequences, write_sequences
-from .utils import AugurError, get_numerical_date_from_value
+from .dates import get_numerical_date_from_value
+from .utils import AugurError
 
 forbidden_characters = str.maketrans(
     {' ': None,

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -4,7 +4,8 @@ Refine an initial tree using sequence metadata.
 import numpy as np
 import os, shutil, time, sys
 from Bio import Phylo
-from .utils import read_metadata, read_tree, get_numerical_dates, write_json, InvalidTreeError
+from .dates import get_numerical_dates
+from .utils import read_metadata, read_tree, write_json, InvalidTreeError
 from treetime.vcf_utils import read_vcf, write_vcf
 from treetime.seq_utils import profile_maps
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,59 @@
+import datetime
+from freezegun import freeze_time
+from augur import dates
+
+
+class TestDates:
+    def test_ambiguous_date_to_date_range_not_ambiguous(self):
+        assert dates.ambiguous_date_to_date_range("2000-03-29", "%Y-%m-%d") == (
+            datetime.date(year=2000, month=3, day=29),
+            datetime.date(year=2000, month=3, day=29),
+        )
+
+    def test_ambiguous_date_to_date_range_ambiguous_day(self):
+        assert dates.ambiguous_date_to_date_range("2000-01-XX", "%Y-%m-%d") == (
+            datetime.date(year=2000, month=1, day=1),
+            datetime.date(year=2000, month=1, day=31),
+        )
+
+    def test_ambiguous_date_to_date_range_ambiguous_month_and_day(self):
+        assert dates.ambiguous_date_to_date_range("2000-XX-XX", "%Y-%m-%d") == (
+            datetime.date(year=2000, month=1, day=1),
+            datetime.date(year=2000, month=12, day=31),
+        )
+
+    @freeze_time("2000-02-20")
+    def test_ambiguous_date_to_date_range_current_day_limit(self):
+        assert dates.ambiguous_date_to_date_range("2000-02-XX", "%Y-%m-%d") == (
+            datetime.date(year=2000, month=2, day=1),
+            datetime.date(year=2000, month=2, day=20),
+        )
+
+    def test_is_date_ambiguous(self):
+        """is_date_ambiguous should return true for ambiguous dates and false for valid dates."""
+        # Test complete date strings with ambiguous values.
+        assert dates.is_date_ambiguous("2019-0X-0X", "any")
+        assert dates.is_date_ambiguous("2019-XX-09", "month")
+        assert dates.is_date_ambiguous("2019-03-XX", "day")
+        assert dates.is_date_ambiguous("201X-03-09", "year")
+        assert dates.is_date_ambiguous("20XX-01-09", "month")
+        assert dates.is_date_ambiguous("2019-XX-03", "day")
+        assert dates.is_date_ambiguous("20XX-01-03", "day")
+
+        # Test incomplete date strings with ambiguous values.
+        assert dates.is_date_ambiguous("2019", "any")
+        assert dates.is_date_ambiguous("201X", "year")
+        assert dates.is_date_ambiguous("2019-XX", "month")
+        assert dates.is_date_ambiguous("2019-10", "day")
+        assert dates.is_date_ambiguous("2019-XX", "any")
+        assert dates.is_date_ambiguous("2019-XX", "day")
+
+        # Test complete date strings without ambiguous dates for the requested field.
+        assert not dates.is_date_ambiguous("2019-09-03", "any")
+        assert not dates.is_date_ambiguous("2019-03-XX", "month")
+        assert not dates.is_date_ambiguous("2019-09-03", "day")
+        assert not dates.is_date_ambiguous("2019-XX-XX", "year")
+
+        # Test incomplete date strings without ambiguous dates for the requested fields.
+        assert not dates.is_date_ambiguous("2019", "year")
+        assert not dates.is_date_ambiguous("2019-10", "month")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,39 +1,12 @@
-import datetime
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from freezegun import freeze_time
 
 from augur import utils
 from test_filter import write_metadata
 
 class TestUtils:
-    def test_ambiguous_date_to_date_range_not_ambiguous(self):
-        assert utils.ambiguous_date_to_date_range("2000-03-29", "%Y-%m-%d") == (
-            datetime.date(year=2000, month=3, day=29),
-            datetime.date(year=2000, month=3, day=29),
-        )
-
-    def test_ambiguous_date_to_date_range_ambiguous_day(self):
-        assert utils.ambiguous_date_to_date_range("2000-01-XX", "%Y-%m-%d") == (
-            datetime.date(year=2000, month=1, day=1),
-            datetime.date(year=2000, month=1, day=31),
-        )
-
-    def test_ambiguous_date_to_date_range_ambiguous_month_and_day(self):
-        assert utils.ambiguous_date_to_date_range("2000-XX-XX", "%Y-%m-%d") == (
-            datetime.date(year=2000, month=1, day=1),
-            datetime.date(year=2000, month=12, day=31),
-        )
-
-    @freeze_time("2000-02-20")
-    def test_ambiguous_date_to_date_range_current_day_limit(self):
-        assert utils.ambiguous_date_to_date_range("2000-02-XX", "%Y-%m-%d") == (
-            datetime.date(year=2000, month=2, day=1),
-            datetime.date(year=2000, month=2, day=20),
-        )
-
     @pytest.mark.parametrize("extension", ["bed","BED"])
     @patch('augur.utils.read_bed_file')
     def test_load_mask_sites_recognizes_bed_file(self, m_read_bed_file, extension):
@@ -102,35 +75,6 @@ class TestUtils:
         with open(drm_file, "w") as fh:
             fh.write("\n".join(drm_lines))
         assert utils.read_mask_file(drm_file) == expected_sites
-
-    def test_is_date_ambiguous(self):
-        """is_date_ambiguous should return true for ambiguous dates and false for valid dates."""
-        # Test complete date strings with ambiguous values.
-        assert utils.is_date_ambiguous("2019-0X-0X", "any")
-        assert utils.is_date_ambiguous("2019-XX-09", "month")
-        assert utils.is_date_ambiguous("2019-03-XX", "day")
-        assert utils.is_date_ambiguous("201X-03-09", "year")
-        assert utils.is_date_ambiguous("20XX-01-09", "month")
-        assert utils.is_date_ambiguous("2019-XX-03", "day")
-        assert utils.is_date_ambiguous("20XX-01-03", "day")
-
-        # Test incomplete date strings with ambiguous values.
-        assert utils.is_date_ambiguous("2019", "any")
-        assert utils.is_date_ambiguous("201X", "year")
-        assert utils.is_date_ambiguous("2019-XX", "month")
-        assert utils.is_date_ambiguous("2019-10", "day")
-        assert utils.is_date_ambiguous("2019-XX", "any")
-        assert utils.is_date_ambiguous("2019-XX", "day")
-
-        # Test complete date strings without ambiguous dates for the requested field.
-        assert not utils.is_date_ambiguous("2019-09-03", "any")
-        assert not utils.is_date_ambiguous("2019-03-XX", "month")
-        assert not utils.is_date_ambiguous("2019-09-03", "day")
-        assert not utils.is_date_ambiguous("2019-XX-XX", "year")
-
-        # Test incomplete date strings without ambiguous dates for the requested fields.
-        assert not utils.is_date_ambiguous("2019", "year")
-        assert not utils.is_date_ambiguous("2019-10", "month")
 
     def test_read_strains(self, tmpdir):
         # Write one list of filenames with some unnecessary whitespace.


### PR DESCRIPTION
### Description of proposed changes

This PR moves date logic from `utils` into the new `dates` module introduced in 2b9ba068b0c6b9a56e4f25ef8aae3466e74fbbab.

There is still [augur/util_support/date_disambiguator.py](https://github.com/nextstrain/augur/blob/6e6d4ce7e5da85bb9c5743598644f7abf67f24e0/augur/util_support/date_disambiguator.py) but leaving that one for now.

### Related issue(s)

_N/A_

### Testing

Moved tests: 5644c304a77251d494f863d7307ba83f3b05d7ba