### PR TITLE
ci: Move --quiet flag to accommodate snakemake=7.7.0 behavior

### DIFF
--- a/tests/builds/runner.sh
+++ b/tests/builds/runner.sh
@@ -19,7 +19,7 @@ mkdir auspice
 for snakefile in ./*/Snakefile; do
     echo -e "\nRunning ${snakefile} (quietly)\n"
     pushd $(dirname "${snakefile}") >/dev/null
-    snakemake --cores 1 --quiet clean 1>/dev/null
+    snakemake --cores 1 clean --quiet 1>/dev/null
     snakemake --cores 1 --quiet 1>/dev/null
     cp auspice/*.json ../auspice
     popd >/dev/null


### PR DESCRIPTION
_Note: I would rather see the Snakemake issue addressed than have this PR merged._

### Description of proposed changes

Snakemake 7.7.0 will try to read any target following `--quiet` as a parameter to the argument, which is unintended here. [See failing CI run](https://github.com/victorlin/augur/actions/runs/2334621503).

### Related issue(s)

- snakemake/snakemake#1660

### Testing

See test runs.