### PR TITLE
dates: Rewrite using regular expressions

### DIFF
--- a/augur/dates.py
+++ b/augur/dates.py
@@ -247,16 +247,36 @@ def relative_iso_to_numeric(backwards_duration_str: str, from_date: datetime.dat
     return numeric_date(from_date - isodate.parse_duration(backwards_duration_str))
 
 
-def numeric_date_type(date):
-    """Get the numeric date from any supported date format.
+def numeric_date_type_min(date):
+    """Get the numeric date from any supported date format, taking the minimum possible value if ambiguous.
 
     This function is intended to be used as the `type` parameter in `argparse.ArgumentParser.add_argument()`
 
     This raises an ArgumentTypeError from InvalidDateFormat exceptions, otherwise the custom exception message won't be shown in console output due to:
     https://github.com/python/cpython/blob/5c4d1f6e0e192653560ae2941a6677fbf4fbd1f2/Lib/argparse.py#L2503-L2513
+
+    >>> round(numeric_date_type_min(2018), 3)
+    2018.001
     """
     try:
-        return numeric_date(date)
+        return numeric_date(date, ambiguity_resolver='min')
+    except InvalidDateFormat as e:
+        raise argparse.ArgumentTypeError(str(e)) from e
+
+
+def numeric_date_type_max(date):
+    """Get the numeric date from any supported date format, taking the maximum possible value if ambiguous.
+
+    This function is intended to be used as the `type` parameter in `argparse.ArgumentParser.add_argument()`
+
+    This raises an ArgumentTypeError from InvalidDateFormat exceptions, otherwise the custom exception message won't be shown in console output due to:
+    https://github.com/python/cpython/blob/5c4d1f6e0e192653560ae2941a6677fbf4fbd1f2/Lib/argparse.py#L2503-L2513
+
+    >>> round(numeric_date_type_max(2018), 3)
+    2018.999
+    """
+    try:
+        return numeric_date(date, ambiguity_resolver='max')
     except InvalidDateFormat as e:
         raise argparse.ArgumentTypeError(str(e)) from e
 

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -17,12 +17,13 @@ SUPPORTED_DATE_HELP_TEXT = dedent("""\
 
 def numeric_date(date):
     """
-    Converts the given *date* string to a :py:class:`float`.
+    Converts the given *date* to a :py:class:`float`.
 
-    *date* may be given as:
-    1. A string or float (number) with year as the integer part
-    2. A string in the YYYY-MM-DD (ISO 8601) syntax
-    3. A string representing a relative date (duration before datetime.date.today())
+    Parameters
+    ----------
+    date
+        Date in any of the supported formats.
+
 
     >>> numeric_date("2020.42")
     2020.42
@@ -63,7 +64,9 @@ def numeric_date(date):
     raise ValueError(f"""Unable to determine date from '{date}'. Ensure it is in one of the supported formats:\n{SUPPORTED_DATE_HELP_TEXT}""")
 
 def numeric_date_type(date):
-    """Wraps numeric_date() for argparse usage.
+    """Get the numeric date from any supported date format.
+
+    This function is intended to be used as the `type` parameter in `argparse.ArgumentParser.add_argument()`
 
     This raises an ArgumentTypeError, otherwise the custom exception message won't be shown in console output due to:
     https://github.com/python/cpython/blob/5c4d1f6e0e192653560ae2941a6677fbf4fbd1f2/Lib/argparse.py#L2503-L2513

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -33,23 +33,25 @@ def numeric_date(date):
     >>> numeric_date("1W") == treetime.utils.numeric_date(datetime.date.today() - isodate.parse_duration("P1W"))
     True
     """
-    # date is a datetime.date
+    # Absolute date as a datetime.date.
     if isinstance(date, datetime.date):
+        # Use a treetime utility function to convert the datetime.date to a
+        # numeric representation.
         return treetime.utils.numeric_date(date)
 
-    # date is numeric
+    # Absolute date in numeric format.
     try:
         return float(date)
     except ValueError:
         pass
 
-    # date is in YYYY-MM-DD form
+    # Absolute date in ISO 8601 date format.
     try:
         return treetime.utils.numeric_date(datetime.date(*map(int, date.split("-", 2))))
     except ValueError:
         pass
 
-    # date is a duration treated as a backwards-looking relative date
+    # Backwards-looking relative date in ISO 8601 duration format.
     try:
         # make a copy of date for this block
         duration_str = str(date)

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -1,4 +1,5 @@
 import argparse
+import calendar
 import datetime
 from textwrap import dedent
 import isodate
@@ -17,7 +18,9 @@ class InvalidDateFormat(ValueError):
 SUPPORTED_DATE_HELP_TEXT = dedent("""\
     1. an Augur-style numeric date with the year as the integer part (e.g. 2020.42) or
     2. a date in ISO 8601 date format (i.e. YYYY-MM-DD) (e.g. '2020-06-04') or
-    3. a backwards-looking relative date in ISO 8601 duration format with optional P prefix (e.g. '1W', 'P1W')
+    3. an ambiguous date in ISO 8601-like format (e.g. '2020-06-XX', '2020-XX-XX') or
+    4. an incomplete date in ISO 8601-like format (e.g. '2020-06', '2020') or
+    5. a backwards-looking relative date in ISO 8601 duration format with optional P prefix (e.g. '1W', 'P1W')
 """)
 
 # Matches floats (e.g. 2018.0, -2018.0).
@@ -28,13 +31,25 @@ RE_NUMERIC_DATE = re.compile(r'^-?[0-9]*\.[0-9]*$')
 # Matches complete ISO 8601 dates (e.g. 2018-03-25).
 RE_ISO_8601_DATE = re.compile(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
 
-# Matches positive integers (e.g. 1, 123, 1234, 12345)
-RE_YEAR_ONLY = re.compile(r'^0*[1-9][0-9]*$')
+# Matches complete ambiguous ISO 8601 dates (e.g. 2018-03-XX).
+RE_AMBIGUOUS_ISO_8601_DATE = re.compile(r'^[0-9X]{4}-[0-9X]{2}-[0-9X]{2}$')
+
+# Matches incomplete ambiguous ISO 8601 dates that are missing the day part (e.g. 2018-03).
+RE_YEAR_MONTH_ONLY = re.compile(r'^[0-9X]{4}-[0-9X]{2}$')
+
+# Matches
+# 1. Incomplete ambiguous ISO 8601 dates that are missing both the month and day
+#    parts (e.g. 2018)
+# 2. Other positive integers (e.g. 1, 123, 12345)
+RE_YEAR_ONLY = re.compile(r'^0*[1-9][0-9X]*$')
 
 # Relative dates (ISO 8601 durations) are also supported - see numeric_date().
 
+# 'X' followed by a specific digit does not make sense.
+RE_INVALID_AMBIGUITY = re.compile(r'.*X[0-9]+.*')
 
-def numeric_date(date):
+
+def numeric_date(date, ambiguity_resolver: str = None):
     """
     Converts the given *date* to a :py:class:`float`.
 
@@ -43,11 +58,22 @@ def numeric_date(date):
     date
         Date in any of the supported formats.
 
+    ambiguity_resolver
+        None: Assume the given ISO 8601 date string is an exact date.
+        'min': Resolve to minimum of ambiguous range.
+        'max': Resolve to maximum of ambiguous range.
+
 
     >>> numeric_date("2020.42")
     2020.42
     >>> numeric_date("2020-06-04")
     2020.42486...
+    >>> round(numeric_date(2018, ambiguity_resolver='min'), 3)
+    2018.001
+    >>> round(numeric_date(2018, ambiguity_resolver='max'), 3)
+    2018.999
+    >>> round(numeric_date(2018.0, ambiguity_resolver='max'), 3)
+    2018.0
     >>> import datetime, isodate, treetime
     >>> numeric_date("1W") == treetime.utils.numeric_date(datetime.date.today() - isodate.parse_duration("P1W"))
     True
@@ -62,18 +88,16 @@ def numeric_date(date):
     date = str(date)
 
     # Absolute date in numeric format.
-    # Note that year-only dates will represent the start of the year (e.g.
-    # 2018 => 2018.0 ≈> 2018-01-01 ). This causes a bug with --max-date¹.
-    # ¹ https://github.com/nextstrain/augur/issues/893
-    if (RE_NUMERIC_DATE.match(date) or RE_YEAR_ONLY.match(date)):
+    if RE_NUMERIC_DATE.match(date):
         return float(date)
 
-    # Absolute date in ISO 8601 date format.
-    if RE_ISO_8601_DATE.match(date):
-        try:
-            return iso_to_numeric(date)
-        except ValueError:
-            pass
+    # Absolute date in potentially incomplete/ambiguous ISO 8601 date format.
+    if (RE_ISO_8601_DATE.match(date) or
+        RE_AMBIGUOUS_ISO_8601_DATE.match(date) or
+        RE_YEAR_MONTH_ONLY.match(date) or
+        RE_YEAR_ONLY.match(date)
+        ):
+        return iso_to_numeric(date, ambiguity_resolver)
 
     # Backwards-looking relative date in ISO 8601 duration format.
     # No regex for this - it would be too complex - just try evaluating last and
@@ -86,21 +110,112 @@ def numeric_date(date):
     raise InvalidDateFormat(f"""Unable to determine date from '{date}'. Ensure it is in one of the supported formats:\n{SUPPORTED_DATE_HELP_TEXT}""")
 
 
-def iso_to_numeric(date: str):
-    """Convert ISO 8601 date string to numeric.
+def iso_to_numeric(date: str, ambiguity_resolver: str = None):
+    """Convert ISO 8601 date string to numeric, resolving any ambiguity detected by explicit 'X' characters or missing date parts.
 
     Parameters
     ----------
     date
         Date string in ISO 8601 format.
 
+    ambiguity_resolver
+        None: Assume the given ISO 8601 date string is an exact date.
+        'min': Resolve to minimum of ambiguous range.
+        'max': Resolve to maximum of ambiguous range.
+
 
     >>> round(iso_to_numeric('2018-01-01'), 3)
     2018.001
     >>> round(iso_to_numeric('2018-03-25'), 2)
     2018.23
+    >>> round(iso_to_numeric('2018-03', ambiguity_resolver='min'), 3)
+    2018.163
+    >>> round(iso_to_numeric('2018-03', ambiguity_resolver='max'), 3)
+    2018.245
+    >>> round(iso_to_numeric('2018', ambiguity_resolver='min'), 3)
+    2018.001
+    >>> round(iso_to_numeric('2018', ambiguity_resolver='max'), 3)
+    2018.999
+    >>> iso_to_numeric('2018')
+    Traceback (most recent call last):
+      ...
+    augur.dates.InvalidDateFormat: Ambiguous date provided without specifying how to resolve ambiguity.
     """
-    return treetime.utils.numeric_date(datetime.date(*map(int, date.split("-", 2))))
+    date_parts = date.split('-', maxsplit=2)
+
+    year = date_parts[0]
+    month = date_parts[1] if len(date_parts) > 1 else 'XX'
+    day = date_parts[2] if len(date_parts) > 2 else 'XX'
+
+    if ambiguity_resolver is None:
+        try:
+            year = int(year)
+            month = int(month)
+            day = int(day)
+        except ValueError as error:
+            raise InvalidDateFormat("Ambiguous date provided without specifying how to resolve ambiguity.")
+
+    else:
+        validate_ambiguity(year, month, day)
+
+        if ambiguity_resolver == 'min':
+            year = year.replace('X', '0')
+            year = int(year)
+
+            month = int(month.replace('X', '0'))
+            if month < 1:
+                month = 1
+
+            day = int(day.replace('X', '0'))
+            if day < 1:
+                day = 1
+
+        elif ambiguity_resolver == 'max':
+            year = year.replace('X', '9')
+            year = int(year)
+
+            max_month = 12
+            month = int(month.replace('X', '9'))
+            if month > max_month:
+                month = max_month
+
+            try:
+                max_day = calendar.monthrange(year, month)[1]
+            except calendar.IllegalMonthError as error:
+                # Month out of bounds is a user error.
+                raise InvalidDateFormat(error) from error
+            day = int(day.replace('X', '9'))
+            if day > max_day:
+                day = max_day
+
+    try:
+        return treetime.utils.numeric_date(datetime.date(year, month, day))
+    except ValueError as error:
+        # Month/day out of bounds errors are user errors.
+        if str(error) == "month must be in 1..12":
+            raise InvalidDateFormat(error) from error
+        if str(error) == "day is out of range for month":
+            raise InvalidDateFormat(error) from error
+        raise error
+
+
+def validate_ambiguity(year: str, month: str, day: str):
+    """Validate ambiguity between date parts."""
+    # Validate between date parts
+    if is_ambiguous(year) and (not is_ambiguous(month) or not is_ambiguous(day)):
+        raise InvalidDateFormat("Invalid date: Year contains uncertainty, so month and day must also be uncertain.")
+    if is_ambiguous(month) and not is_ambiguous(day):
+        raise InvalidDateFormat("Invalid date: Month contains uncertainty, so day must also be uncertain.")
+
+    # Validate within date parts
+    for date_part in (year, month, day):
+        if RE_INVALID_AMBIGUITY.match(date_part):
+            raise InvalidDateFormat("Ambiguity can not be followed by an exact digit.")
+
+
+def is_ambiguous(date_part: str):
+    """Determine if a date part is ambiguous."""
+    return 'X' in date_part
 
 
 def relative_iso_to_numeric(backwards_duration_str: str, from_date: datetime.date = None):

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -39,6 +39,9 @@ def numeric_date(date):
         # numeric representation.
         return treetime.utils.numeric_date(date)
 
+    # All other formats are treated as strings.
+    date = str(date)
+
     # Absolute date in numeric format.
     try:
         return float(date)

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -20,6 +20,15 @@ SUPPORTED_DATE_HELP_TEXT = dedent("""\
     3. a backwards-looking relative date in ISO 8601 duration format with optional P prefix (e.g. '1W', 'P1W')
 """)
 
+# Matches integers and floats (e.g. -1, 0, 123, 2018.0, -2018.0).
+RE_NUMERIC_DATE = re.compile(r'^-?[0-9]*\.?[0-9]*$')
+
+# Matches complete ISO 8601 dates (e.g. 2018-03-25).
+RE_ISO_8601_DATE = re.compile(r'^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
+
+# Relative dates (ISO 8601 durations) are also supported - see numeric_date().
+
+
 def numeric_date(date):
     """
     Converts the given *date* to a :py:class:`float`.
@@ -48,18 +57,19 @@ def numeric_date(date):
     date = str(date)
 
     # Absolute date in numeric format.
-    try:
+    if (RE_NUMERIC_DATE.match(date)):
         return float(date)
-    except ValueError:
-        pass
 
     # Absolute date in ISO 8601 date format.
-    try:
-        return iso_to_numeric(date)
-    except ValueError:
-        pass
+    if RE_ISO_8601_DATE.match(date):
+        try:
+            return iso_to_numeric(date)
+        except ValueError:
+            pass
 
     # Backwards-looking relative date in ISO 8601 duration format.
+    # No regex for this - it would be too complex - just try evaluating last and
+    # let any errors pass to raise the InvalidDateFormat.
     try:
         return relative_iso_to_numeric(date)
     except (ValueError, isodate.ISO8601Error):

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -82,12 +82,14 @@ def numeric_date(date, ambiguity_resolver: str = None):
     if isinstance(date, datetime.date):
         # Use a treetime utility function to convert the datetime.date to a
         # numeric representation.
-        return treetime.utils.numeric_date(date)
+        unbounded_date = treetime.utils.numeric_date(date)
+        # Make one more call to the base case.
+        return numeric_date(unbounded_date)
 
     # All other formats are treated as strings.
     date = str(date)
 
-    # Absolute date in numeric format.
+    # Base case: Absolute date in numeric format.
     if RE_NUMERIC_DATE.match(date):
         return float(date)
 
@@ -189,7 +191,7 @@ def iso_to_numeric(date: str, ambiguity_resolver: str = None):
                 day = max_day
 
     try:
-        return treetime.utils.numeric_date(datetime.date(year, month, day))
+        return numeric_date(datetime.date(year, month, day))
     except ValueError as error:
         # Month/day out of bounds errors are user errors.
         if str(error) == "month must be in 1..12":
@@ -242,7 +244,7 @@ def relative_iso_to_numeric(backwards_duration_str: str, from_date: datetime.dat
         from_date = datetime.date.today()
     if not backwards_duration_str.startswith('P'):
         backwards_duration_str = 'P'+backwards_duration_str
-    return treetime.utils.numeric_date(from_date - isodate.parse_duration(backwards_duration_str))
+    return numeric_date(from_date - isodate.parse_duration(backwards_duration_str))
 
 
 def numeric_date_type(date):

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -316,11 +316,9 @@ def is_date_ambiguous(date, ambiguous_by="any"):
 
 def get_numerical_date_from_value(value, fmt=None, min_max_year=None):
     value = str(value)
-    if re.match(r'^-*\d+\.\d+$', value):
-        # numeric date which can be negative
+    if RE_NUMERIC_DATE.match(value):
         return float(value)
-    if value.isnumeric():
-        # year-only date is ambiguous
+    if RE_YEAR_ONLY.match(value):
         value = fmt.replace('%Y', value).replace('%m', 'XX').replace('%d', 'XX')
     if 'XX' in value:
         ambig_date = ambiguous_date_to_date_range(value, fmt, min_max_year)

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -9,6 +9,11 @@ from .errors import AugurError
 
 from augur.util_support.date_disambiguator import DateDisambiguator
 
+
+class InvalidDateFormat(ValueError):
+    pass
+
+
 SUPPORTED_DATE_HELP_TEXT = dedent("""\
     1. an Augur-style numeric date with the year as the integer part (e.g. 2020.42) or
     2. a date in ISO 8601 date format (i.e. YYYY-MM-DD) (e.g. '2020-06-04') or
@@ -60,7 +65,7 @@ def numeric_date(date):
     except (ValueError, isodate.ISO8601Error):
         pass
 
-    raise ValueError(f"""Unable to determine date from '{date}'. Ensure it is in one of the supported formats:\n{SUPPORTED_DATE_HELP_TEXT}""")
+    raise InvalidDateFormat(f"""Unable to determine date from '{date}'. Ensure it is in one of the supported formats:\n{SUPPORTED_DATE_HELP_TEXT}""")
 
 
 def iso_to_numeric(date: str):
@@ -112,12 +117,12 @@ def numeric_date_type(date):
 
     This function is intended to be used as the `type` parameter in `argparse.ArgumentParser.add_argument()`
 
-    This raises an ArgumentTypeError, otherwise the custom exception message won't be shown in console output due to:
+    This raises an ArgumentTypeError from InvalidDateFormat exceptions, otherwise the custom exception message won't be shown in console output due to:
     https://github.com/python/cpython/blob/5c4d1f6e0e192653560ae2941a6677fbf4fbd1f2/Lib/argparse.py#L2503-L2513
     """
     try:
         return numeric_date(date)
-    except ValueError as e:
+    except InvalidDateFormat as e:
         raise argparse.ArgumentTypeError(str(e)) from e
 
 def ambiguous_date_to_date_range(uncertain_date, fmt, min_max_year=None):

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -1,7 +1,7 @@
 """
 Filter and subsample a sequence set.
 """
-from augur.dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT
+from augur.dates import numeric_date_type_min, numeric_date_type_max, SUPPORTED_DATE_HELP_TEXT
 
 
 # Use sorted() for reproducible output
@@ -27,8 +27,8 @@ def register_arguments(parser):
         Uses Pandas Dataframe querying, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query for syntax.
         (e.g., --query "country == 'Colombia'" or --query "(country == 'USA' & (division == 'Washington'))")"""
     )
-    metadata_filter_group.add_argument('--min-date', type=numeric_date_type, help=f"minimal cutoff for date, the cutoff date is inclusive; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
-    metadata_filter_group.add_argument('--max-date', type=numeric_date_type, help=f"maximal cutoff for date, the cutoff date is inclusive; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
+    metadata_filter_group.add_argument('--min-date', type=numeric_date_type_min, help=f"minimal cutoff for date, the cutoff date is inclusive; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
+    metadata_filter_group.add_argument('--max-date', type=numeric_date_type_max, help=f"maximal cutoff for date, the cutoff date is inclusive; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
     metadata_filter_group.add_argument('--exclude-ambiguous-dates-by', choices=['any', 'day', 'month', 'year'],
                                 help='Exclude ambiguous dates by day (e.g., 2020-09-XX), month (e.g., 2020-XX-XX), year (e.g., 200X-10-01), or any date fields. An ambiguous year makes the corresponding month and day ambiguous, too, even if those fields have unambiguous values (e.g., "201X-10-01"). Similarly, an ambiguous month makes the corresponding day ambiguous (e.g., "2010-XX-01").')
     metadata_filter_group.add_argument('--exclude', type=str, nargs="+", help="file(s) with list of strains to exclude")

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -9,7 +9,7 @@ from Bio.Align import MultipleSeqAlignment
 
 from .frequency_estimators import get_pivots, alignment_frequencies, tree_frequencies
 from .frequency_estimators import AlignmentKdeFrequencies, TreeKdeFrequencies, TreeKdeFrequenciesError
-from .dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT, get_numerical_dates
+from .dates import numeric_date_type_min, numeric_date_type_max, SUPPORTED_DATE_HELP_TEXT, get_numerical_dates
 from .io.metadata import read_metadata
 from .utils import read_node_data, write_json
 
@@ -27,9 +27,9 @@ def register_parser(parent_subparsers):
                         help="number of units between pivots")
     parser.add_argument("--pivot-interval-units", type=str, default="months", choices=['months', 'weeks'],
                         help="space pivots by months (default) or by weeks")
-    parser.add_argument('--min-date', type=numeric_date_type,
+    parser.add_argument('--min-date', type=numeric_date_type_min,
                         help=f"date to begin frequencies calculations; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
-    parser.add_argument('--max-date', type=numeric_date_type,
+    parser.add_argument('--max-date', type=numeric_date_type_max,
                         help=f"date to end frequencies calculations; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
 
     # Tree-specific arguments

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -350,5 +350,7 @@ class TestFilter:
             Unable to determine date from '{argparse_value}'. Ensure it is in one of the supported formats:
             1. an Augur-style numeric date with the year as the integer part (e.g. 2020.42) or
             2. a date in ISO 8601 date format (i.e. YYYY-MM-DD) (e.g. '2020-06-04') or
-            3. a backwards-looking relative date in ISO 8601 duration format with optional P prefix (e.g. '1W', 'P1W')
+            3. an ambiguous date in ISO 8601-like format (e.g. '2020-06-XX', '2020-XX-XX') or
+            4. an incomplete date in ISO 8601-like format (e.g. '2020-06', '2020') or
+            5. a backwards-looking relative date in ISO 8601 duration format with optional P prefix (e.g. '1W', 'P1W')
         """)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -2,7 +2,15 @@ import datetime
 import pytest
 from freezegun import freeze_time
 from augur import dates
+from augur.dates import InvalidDateFormat, numeric_date
 from augur.errors import AugurError
+
+
+def get_numeric_min_max(date):
+    return (
+        numeric_date(date, 'min'),
+        numeric_date(date, 'max'),
+    )
 
 
 class TestDates:
@@ -84,3 +92,124 @@ class TestDates:
         }
         with pytest.raises(AugurError):
             dates.get_numerical_dates(metadata)
+
+    def test_ambiguous_day(self):
+        """Ambiguous day yields a certain min/max range."""
+        date_min, date_max = get_numeric_min_max("2018-01-XX")
+        assert date_min == pytest.approx(2018.001, abs=1e-3)
+        assert date_max == pytest.approx(2018.083, abs=1e-3)
+
+    def test_missing_day(self):
+        """Date without day yields a range equivalent to ambiguous day."""
+        date_min, date_max = get_numeric_min_max("2018-01")
+        assert date_min == pytest.approx(2018.001, abs=1e-3)
+        assert date_max == pytest.approx(2018.083, abs=1e-3)
+
+    def test_ambiguous_month(self):
+        """Ambiguous month yields a certain min/max range."""
+        date_min, date_max = get_numeric_min_max("2018-XX-XX")
+        assert date_min == pytest.approx(2018.001, abs=1e-3)
+        assert date_max == pytest.approx(2018.999, abs=1e-3)
+
+    def test_missing_month(self):
+        """Date without month/day yields a range equivalent to ambiguous month/day."""
+        date_min, date_max = get_numeric_min_max("2018")
+        assert date_min == pytest.approx(2018.001, abs=1e-3)
+        assert date_max == pytest.approx(2018.999, abs=1e-3)
+
+    def test_numerical_exact_year(self):
+        """Numerical year ending in .0 should be interpreted as exact."""
+        date_min, date_max = get_numeric_min_max("2018.0")
+        assert date_min == pytest.approx(2018.001, abs=1e-3)
+        assert date_max == pytest.approx(2018.001, abs=1e-3)
+
+    def test_ambiguous_year(self):
+        """Ambiguous year replaces X with 0 (min) and 9 (max)."""
+        date_min, date_max = get_numeric_min_max("201X-XX-XX")
+        assert date_min == pytest.approx(2010.001, abs=1e-3)
+        assert date_max == pytest.approx(2019.999, abs=1e-3)
+
+    def test_ambiguous_year_incomplete_date(self):
+        """Ambiguous year without month/day yields a range equivalent to ambiguous month/day counterpart."""
+        date_min, date_max = get_numeric_min_max("201X")
+        assert date_min == pytest.approx(2010.001, abs=1e-3)
+        assert date_max == pytest.approx(2019.999, abs=1e-3)
+
+    @pytest.mark.parametrize(
+        "date",
+        [
+            ("201X-01-01"),
+            ("201X-01-XX"),
+            ("201X-XX-01"),
+            ("2010-XX-01"),
+        ],
+    )
+    def test_invalid_ambiguity_between_date_parts(self, date):
+        """Test various forms of invalid ambiguity between date parts."""
+        with pytest.raises(InvalidDateFormat):
+            get_numeric_min_max(date)
+
+    @pytest.mark.parametrize(
+        "date",
+        [
+            ("20X0"),
+            ("20X0-XX-XX"),
+            ("2010-X1"),
+            ("2010-X1-XX"),
+            ("2010-01-X0"),
+        ],
+    )
+    def test_invalid_ambiguity_within_date_part(self, date):
+        """Test various forms of invalid ambiguity within date parts."""
+        with pytest.raises(InvalidDateFormat):
+            get_numeric_min_max(date)
+
+    def test_ambiguous_year_lowercase_x(self):
+        """Ambiguous year with a lowercase x raises an error."""
+        with pytest.raises(InvalidDateFormat):
+            get_numeric_min_max("201x")
+
+    @pytest.mark.parametrize(
+        "date",
+        [
+            ("2018-00-01"),
+            ("2018-13-01"),
+            ("2018-01-00"),
+            ("2018-02-30"),
+        ],
+    )
+    def test_out_of_bounds_error(self, date):
+        """Out-of-bounds month/day cannot be parsed."""
+        with pytest.raises(InvalidDateFormat):
+            get_numeric_min_max(date)
+
+    @pytest.mark.parametrize(
+        "date",
+        [
+            ("-2018-01-01"),
+            ("-2018-XX-XX"),
+            ("-2018-01"),
+            ("-2018"),
+        ],
+    )
+    def test_negative_iso_date_error(self, date):
+        """All forms of negative ISO dates are unsupported."""
+        with pytest.raises(InvalidDateFormat):
+            get_numeric_min_max(date)
+
+    def test_negative_numeric_date(self):
+        """Parse negative numeric date."""
+        date_min, date_max = get_numeric_min_max("-2018.0")
+        assert date_min == pytest.approx(-2018.0, abs=1e-3)
+        assert date_max == pytest.approx(-2018.0, abs=1e-3)
+
+    def test_zero_year_incomplete_error(self):
+        """Zero year-only date is unsupported."""
+        with pytest.raises(InvalidDateFormat):
+            get_numeric_min_max("0")
+
+    def test_zero_year_exact(self):
+        """Parse the date 0.0."""
+        date_min, date_max = get_numeric_min_max("0.0")
+        assert date_min == pytest.approx(0.0, abs=1e-3)
+        assert date_max == pytest.approx(0.0, abs=1e-3)


### PR DESCRIPTION
### Description of proposed changes

This rewrites the date parsing functions currently used by `filter` and `frequencies` `--min-date`/`--max-date` parameters. Note that it doesn't affect the date parsing functions used for the metadata dates within `augur filter`.

### Related issue(s)

- Fixes #893
- Related to #662
- Related to #882

### Testing

- [x] Updated doctests and pytests.
- [x] Checks pass