### PR TITLE
filter: Error when any group-by column is not found

### DIFF
--- a/tests/functional/filter.t
+++ b/tests/functional/filter.t
@@ -469,3 +469,33 @@ Try to output to a directory that does not exist.
   >  --output-strains "directory-does-not-exist/filtered_strains.txt" > /dev/null
   ERROR: No such file or directory: 'directory-does-not-exist/filtered_strains.txt'
   [2]
+
+Error on missing group-by columns.
+
+  $ cat >$TMP/metadata-no-date.tsv <<~~
+  > strain	col
+  > SEQ1	a
+  > SEQ2	b
+  > ~~
+
+  $ ${AUGUR} filter \
+  >   --metadata $TMP/metadata-no-date.tsv \
+  >   --group-by year \
+  >   --sequences-per-group 1 \
+  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
+  ERROR: The specified group-by categories (['year']) were not found. Note that using 'year' or 'year month' requires a column called 'date'.
+  [2]
+  $ cat $TMP/metadata-filtered.tsv
+  cat: .*: No such file or directory (re)
+  [1]
+
+  $ ${AUGUR} filter \
+  >   --metadata $TMP/metadata-no-date.tsv \
+  >   --group-by invalid \
+  >   --sequences-per-group 1 \
+  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
+  ERROR: The specified group-by categories (['invalid']) were not found.
+  [2]
+  $ cat $TMP/metadata-filtered.tsv
+  cat: .*: No such file or directory (re)
+  [1]

--- a/tests/test_filter_groupby.py
+++ b/tests/test_filter_groupby.py
@@ -45,7 +45,7 @@ class TestFilterGroupBy:
         strains = metadata.index.tolist()
         with pytest.raises(FilterException) as e_info:
             get_groups_for_subsampling(strains, metadata, group_by=groups)
-        assert str(e_info.value) == "The specified group-by categories (['invalid']) were not found. No sequences-per-group sampling will be done."
+        assert str(e_info.value) == "The specified group-by categories (['invalid']) were not found."
 
     def test_filter_groupby_invalid_warn(self, valid_metadata: pd.DataFrame, capsys):
         groups = ['country', 'year', 'month', 'invalid']
@@ -125,7 +125,7 @@ class TestFilterGroupBy:
         strains = metadata.index.tolist()
         with pytest.raises(FilterException) as e_info:
             get_groups_for_subsampling(strains, metadata, group_by=groups)
-        assert str(e_info.value) == "The specified group-by categories (['year']) were not found. No sequences-per-group sampling will be done. Note that using 'year' or 'year month' requires a column called 'date'."
+        assert str(e_info.value) == "The specified group-by categories (['year']) were not found. Note that using 'year' or 'year month' requires a column called 'date'."
 
     def test_filter_groupby_missing_month_error(self, valid_metadata: pd.DataFrame):
         groups = ['month']
@@ -134,7 +134,7 @@ class TestFilterGroupBy:
         strains = metadata.index.tolist()
         with pytest.raises(FilterException) as e_info:
             get_groups_for_subsampling(strains, metadata, group_by=groups)
-        assert str(e_info.value) == "The specified group-by categories (['month']) were not found. No sequences-per-group sampling will be done. Note that using 'year' or 'year month' requires a column called 'date'."
+        assert str(e_info.value) == "The specified group-by categories (['month']) were not found. Note that using 'year' or 'year month' requires a column called 'date'."
 
     def test_filter_groupby_missing_year_and_month_error(self, valid_metadata: pd.DataFrame):
         groups = ['year', 'month']
@@ -143,7 +143,7 @@ class TestFilterGroupBy:
         strains = metadata.index.tolist()
         with pytest.raises(FilterException) as e_info:
             get_groups_for_subsampling(strains, metadata, group_by=groups)
-        assert str(e_info.value) == "The specified group-by categories (['year', 'month']) were not found. No sequences-per-group sampling will be done. Note that using 'year' or 'year month' requires a column called 'date'."
+        assert str(e_info.value) == "The specified group-by categories (['year', 'month']) were not found. Note that using 'year' or 'year month' requires a column called 'date'."
 
     def test_filter_groupby_missing_date_warn(self, valid_metadata: pd.DataFrame, capsys):
         groups = ['country', 'year', 'month']


### PR DESCRIPTION
### Description of proposed changes

Actualizing the TODO removed in this change:

> TODO: We should consider treating this case as an actual error and exiting here with a nonzero code.

With 2342f07b75f2ba9953cab8254ebef3d5febb5b5d, raising `FilterException(AugurError)` alone is sufficient to exit with a nonzero code.

Also updated error text to remove message "No sequences-per-group sampling will be done", which was part of a warning. Implicitly, nothing will be done when exiting with an ERROR.

### Related issue(s)

- Fixes #754
- Fixes #932

### Testing

Added cram tests.