### PR TITLE
filter: Reduce file size with `filter_support/`

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -17,6 +17,8 @@ import sys
 from tempfile import NamedTemporaryFile
 from typing import Collection
 
+from augur.filter_support.exceptions import FilterException
+
 from .dates import numeric_date, numeric_date_type, SUPPORTED_DATE_HELP_TEXT, is_date_ambiguous, get_numerical_dates
 from .index import index_sequences, index_vcf
 from .io import open_file, read_metadata, read_sequences, write_sequences, is_vcf as filename_is_vcf, write_vcf
@@ -28,12 +30,6 @@ SEQUENCE_ONLY_FILTERS = (
     "min_length",
     "non_nucleotide",
 )
-
-
-class FilterException(AugurError):
-    """Representation of an error that occurred during filtering.
-    """
-    pass
 
 
 def read_priority_scores(fname):
@@ -869,7 +865,7 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     >>> get_groups_for_subsampling(strains, metadata, group_by)
     Traceback (most recent call last):
       ...
-    augur.filter.FilterException: The specified group-by categories (['missing_column']) were not found.
+    augur.filter_support.exceptions.FilterException: The specified group-by categories (['missing_column']) were not found.
 
     If we try to group by some columns that exist and some that don't, we allow
     grouping to continue and print a warning message to stderr.

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -18,6 +18,7 @@ from tempfile import NamedTemporaryFile
 from typing import Collection
 
 from augur.filter_support.exceptions import FilterException
+from augur.filter_support.output import filter_kwargs_to_str
 
 from .dates import numeric_date, numeric_date_type, SUPPORTED_DATE_HELP_TEXT, is_date_ambiguous, get_numerical_dates
 from .index import index_sequences, index_vcf
@@ -649,56 +650,6 @@ def construct_filters(args, sequence_index):
         ))
 
     return exclude_by, include_by
-
-
-def filter_kwargs_to_str(kwargs):
-    """Convert a dictionary of kwargs to a JSON string for downstream reporting.
-
-    This structured string can be converted back into a Python data structure
-    later for more sophisticated reporting by specific kwargs.
-
-    This function excludes data types from arguments like pandas DataFrames and
-    also converts floating point numbers to a fixed precision for better
-    readability and reproducibility.
-
-    Parameters
-    ----------
-    kwargs : dict
-        Dictionary of kwargs passed to a given filter function.
-
-    Returns
-    -------
-    str :
-        String representation of the kwargs for reporting.
-
-
-    >>> sequence_index = pd.DataFrame([{"strain": "strain1", "ACGT": 28000}, {"strain": "strain2", "ACGT": 26000}, {"strain": "strain3", "ACGT": 5000}]).set_index("strain")
-    >>> exclude_by = [(filter_by_sequence_length, {"sequence_index": sequence_index, "min_length": 27000})]
-    >>> filter_kwargs_to_str(exclude_by[0][1])
-    '[["min_length", 27000]]'
-    >>> exclude_by = [(filter_by_date, {"max_date": numeric_date("2020-04-01"), "min_date": numeric_date("2020-03-01")})]
-    >>> filter_kwargs_to_str(exclude_by[0][1])
-    '[["max_date", 2020.25], ["min_date", 2020.17]]'
-
-    """
-    # Sort keys prior to processing to guarantee the same output order
-    # regardless of the input order.
-    sorted_keys = sorted(kwargs.keys())
-
-    kwarg_list = []
-    for key in sorted_keys:
-        value = kwargs[key]
-
-        # Handle special cases for data types that we want to represent
-        # differently from their defaults or not at all.
-        if isinstance(value, pd.DataFrame):
-            continue
-        elif isinstance(value, float):
-            value = round(value, 2)
-
-        kwarg_list.append((key, value))
-
-    return json.dumps(kwarg_list)
 
 
 def apply_filters(metadata, exclude_by, include_by):

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1,7 +1,6 @@
 """
 Filter and subsample a sequence set.
 """
-from Bio import SeqIO
 from collections import defaultdict
 import csv
 import heapq
@@ -11,7 +10,6 @@ import numpy as np
 import operator
 import os
 import pandas as pd
-import random
 import re
 import sys
 from tempfile import NamedTemporaryFile
@@ -25,7 +23,6 @@ from .index import index_sequences, index_vcf
 from .io import open_file, read_metadata, read_sequences, write_sequences, is_vcf as filename_is_vcf, write_vcf
 from .utils import AugurError, read_strains
 
-comment_char = '#'
 
 SEQUENCE_ONLY_FILTERS = (
     "min_length",

--- a/augur/filter_support/exceptions.py
+++ b/augur/filter_support/exceptions.py
@@ -1,0 +1,7 @@
+from augur.utils import AugurError
+
+
+class FilterException(AugurError):
+    """Representation of an error that occurred during filtering.
+    """
+    pass

--- a/augur/filter_support/output.py
+++ b/augur/filter_support/output.py
@@ -23,12 +23,9 @@ def filter_kwargs_to_str(kwargs):
         String representation of the kwargs for reporting.
 
 
-    >>> sequence_index = pd.DataFrame([{"strain": "strain1", "ACGT": 28000}, {"strain": "strain2", "ACGT": 26000}, {"strain": "strain3", "ACGT": 5000}]).set_index("strain")
-    >>> exclude_by = [(filter_by_sequence_length, {"sequence_index": sequence_index, "min_length": 27000})]
-    >>> filter_kwargs_to_str(exclude_by[0][1])
+    >>> filter_kwargs_to_str({"sequence_index": pd.DataFrame(), "min_length": 27000})
     '[["min_length", 27000]]'
-    >>> exclude_by = [(filter_by_date, {"max_date": numeric_date("2020-04-01"), "min_date": numeric_date("2020-03-01")})]
-    >>> filter_kwargs_to_str(exclude_by[0][1])
+    >>> filter_kwargs_to_str({"max_date": 2020.25, "min_date": 2020.17})
     '[["max_date", 2020.25], ["min_date", 2020.17]]'
 
     """

--- a/augur/filter_support/output.py
+++ b/augur/filter_support/output.py
@@ -1,0 +1,52 @@
+import json
+import pandas as pd
+
+
+def filter_kwargs_to_str(kwargs):
+    """Convert a dictionary of kwargs to a JSON string for downstream reporting.
+
+    This structured string can be converted back into a Python data structure
+    later for more sophisticated reporting by specific kwargs.
+
+    This function excludes data types from arguments like pandas DataFrames and
+    also converts floating point numbers to a fixed precision for better
+    readability and reproducibility.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Dictionary of kwargs passed to a given filter function.
+
+    Returns
+    -------
+    str :
+        String representation of the kwargs for reporting.
+
+
+    >>> sequence_index = pd.DataFrame([{"strain": "strain1", "ACGT": 28000}, {"strain": "strain2", "ACGT": 26000}, {"strain": "strain3", "ACGT": 5000}]).set_index("strain")
+    >>> exclude_by = [(filter_by_sequence_length, {"sequence_index": sequence_index, "min_length": 27000})]
+    >>> filter_kwargs_to_str(exclude_by[0][1])
+    '[["min_length", 27000]]'
+    >>> exclude_by = [(filter_by_date, {"max_date": numeric_date("2020-04-01"), "min_date": numeric_date("2020-03-01")})]
+    >>> filter_kwargs_to_str(exclude_by[0][1])
+    '[["max_date", 2020.25], ["min_date", 2020.17]]'
+
+    """
+    # Sort keys prior to processing to guarantee the same output order
+    # regardless of the input order.
+    sorted_keys = sorted(kwargs.keys())
+
+    kwarg_list = []
+    for key in sorted_keys:
+        value = kwargs[key]
+
+        # Handle special cases for data types that we want to represent
+        # differently from their defaults or not at all.
+        if isinstance(value, pd.DataFrame):
+            continue
+        elif isinstance(value, float):
+            value = round(value, 2)
+
+        kwarg_list.append((key, value))
+
+    return json.dumps(kwarg_list)


### PR DESCRIPTION
### Description of proposed changes

Currently, [filter.py](https://github.com/nextstrain/augur/blob/a3cd1589c7642b784ccd02281e3c593adce07f26/augur/filter.py) at 1897 lines is  large and can be difficult to work with. This PR introduces a `filter_support/` directory similar to `util_support/`, to help reduce the size of the subcommand files.

Starting with these, up for discussion:

- `FilterException` -> `filter_support.exceptions.FilterException`
- `filter_kwargs_to_str` -> `filter_support.output.filter_kwargs_to_str`

Thinking about the future, this also allows easier sharing of functions/variables between internal engines (see https://github.com/nextstrain/augur/issues/920#issuecomment-1125408882).

### Related issue(s)

_N/A_

### Testing

Doctests updated accordingly.