### PR TITLE
filter: Handle errors from `filter_by_query`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+## Bug Fixes
+
+* filter: Handle errors from `filter_by_query` [#942][] (@victorlin)
+
+[#942]: https://github.com/nextstrain/augur/pull/942
 
 ## 15.0.2 (5 May 2022)
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -788,10 +788,18 @@ def apply_filters(metadata, exclude_by, include_by):
     for filter_function, filter_kwargs in exclude_by:
         # Apply the current function with its given arguments. Each function
         # returns a set of strains that passed the corresponding filter.
-        passed = metadata.pipe(
-            filter_function,
-            **filter_kwargs,
-        )
+        try:
+            passed = metadata.pipe(
+                filter_function,
+                **filter_kwargs,
+            )
+        except Exception as e:
+            if filter_function.__name__ == 'filter_by_query':
+                if isinstance(e, pd.core.computation.ops.UndefinedVariableError):
+                    raise AugurError(f"Query contains a column that does not exist in metadata.") from e
+                raise AugurError(f"Error when applying query. Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.") from e
+            else:
+                raise
 
         # Track the strains that failed this filter, so we can explain why later
         # on and update the list of strains to keep to intersect with the

--- a/tests/functional/filter/cram/filter-query-errors.t
+++ b/tests/functional/filter/cram/filter-query-errors.t
@@ -1,0 +1,34 @@
+Setup
+
+  $ pushd "$TESTDIR" > /dev/null
+  $ source _setup.sh
+
+Using a pandas query with a nonexistent column results in a specific error.
+
+  $ ${AUGUR} filter \
+  >  --metadata filter/data/metadata.tsv \
+  >  --query "invalid == 'value'" \
+  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  ERROR: Query contains a column that does not exist in metadata.
+  [2]
+
+
+Using pandas queries with bad syntax results in a generic errors.
+
+This raises a ValueError internally (https://github.com/nextstrain/augur/issues/940):
+
+  $ ${AUGUR} filter \
+  >  --metadata filter/data/metadata.tsv \
+  >  --query "invalid = 'value'" \
+  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  ERROR: Error when applying query. Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  [2]
+
+This raises a SyntaxError internally (https://github.com/nextstrain/augur/issues/941):
+
+  $ ${AUGUR} filter \
+  >  --metadata filter/data/metadata.tsv \
+  >  --query "some bad syntax" \
+  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  ERROR: Error when applying query. Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  [2]


### PR DESCRIPTION
### Description of proposed changes

- The underlying pandas engine used for `--query` can raise various errors depending on the input.
- The query call is invoked by a loop through all filtering functions.

Based on the above points, this change wraps the line executing filter functions and catches all errors, but only handles the errors from filter_by_query.

For the errors from filter_by_query, the [`UndefinedVariableError`](https://github.com/pandas-dev/pandas/blob/f469af7b381075a5a0e974462169ce8800258f0d/pandas/core/computation/ops.py#L68) is predictable enough to mean that a column does not exist. For all other errors, raise a generic error message directing users to the pandas query syntax doc page.

### Related issue(s)

- Fixes #939
- Fixes #940
- Fixes #941

### Testing

Added functional tests.