### PR TITLE
Split codecov into separate job, combine coverage of all matrix jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
+    env:
+      COVERAGE_FILE: ${{ github.workspace }}/.coverage@python=${{ matrix.python-version }},biopython=${{ matrix.biopython-version || 'latest' }}
+      COVERAGE_RCFILE: ${{ github.workspace }}/.coveragerc
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
@@ -46,11 +49,29 @@ jobs:
     - run: cram --shell=/bin/bash tests/
       env:
         AUGUR: coverage run -a ${{ github.workspace }}/bin/augur
-        COVERAGE_FILE: ${{ github.workspace }}/.coverage
-        COVERAGE_RCFILE: ${{ github.workspace }}/.coveragerc
-    - run: coverage xml
     - run: bash tests/builds/runner.sh
-    - if: github.repository == 'nextstrain/augur' && matrix.python-version == '3.10' && matrix.biopython-version == ''
-      uses: codecov/codecov-action@v2
+    - uses: actions/upload-artifact@v3
       with:
-        fail_ci_if_error: true
+        name: coverage
+        path: "${{ env.COVERAGE_FILE }}"
+
+  codecov:
+    if: github.repository == 'nextstrain/augur'
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+      - run: pip install coverage
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage
+
+      - run: coverage combine .coverage@*
+      - run: coverage xml
+
+      - uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true


### PR DESCRIPTION
### Description of proposed changes

Combining coverage from all matrix jobs is beneficial for any version-dependent code paths.

Originally proposed in https://github.com/nextstrain/augur/pull/899#discussion_r863063378.

### Related issue(s)

- Fixes #845

### Testing

See CI run.