### PR TITLE
fix: allows nuc annotation to be pulled in through `.gff`

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -147,7 +147,7 @@ def load_features(reference, feature_names=None):
         except ImportError:
             print("ERROR: Package BCBio.GFF not found! Please install using \'pip install bcbio-gff\' before re-running.")
             return None
-        limit_info = dict( gff_type = ['gene'] )
+        limit_info = dict( gff_type = ['gene', 'source'] )
 
         with open(reference, encoding='utf-8') as in_handle:
             for rec in GFF.parse(in_handle, limit_info=limit_info):


### PR DESCRIPTION
Currently, `augur translate` cannot output `nuc` annotation, if `.gff` is used as input. This is due to the features being loaded being overly restrictive to genes.

Allowing `source` to be read in as features allows the `.gff` to contain nuc annotations in the following format:
```
MT903344.1	Genbank	source	1	197233	.	+	.	locus_tag=nuc
```

That way `augur export doesn't crash if a `.gff` is used as annotation input for translate.

### Related issue(s)
Related to #881 

This fix allows me to use the same `genemap.gff` for both Nextclade and the workflow that creates the Nextclade ref tree. This is very good for consistency and reduced maintenance effort when Monkeypox genemap is changing a lot.

### Testing
I don't know if this touches any other functionality. It's a util function so there's a risk. But then at the same time, it shouldn't be wrong to output a genemap with nuc annotated.

CI passes so looks good. One may want to systematically check every function where this gff load utility is used. But first would be good to see if this PR is usable or it has some systematic flaw.