### PR TITLE
Allow full stop character in gene names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Features
+
+* schema: Allow full stop character (`.`) in gene names. [#955][] (@jameshadfield)
+
+[#955]: https://github.com/nextstrain/augur/pull/955
 
 ## 31.0.0 (19 May 2025)
 

--- a/augur/data/schema-annotations.json
+++ b/augur/data/schema-annotations.json
@@ -26,7 +26,7 @@
     "required": ["nuc"],
     "additionalProperties": false,
     "patternProperties": {
-        "^(?!nuc$)[a-zA-Z0-9*_-]+$": {
+        "^(?!nuc$)[a-zA-Z0-9*_.-]+$": {
             "$comment": "Each object here defines a single CDS",
             "type": "object",
             "oneOf": [{ "$ref": "#/$defs/startend" }, { "$ref": "#/$defs/segments" }],

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -333,7 +333,7 @@
                                 }
                             },
                             "patternProperties": {
-                                "^(?!nuc$)[a-zA-Z0-9*_-]+$": {
+                                "^(?!nuc$)[a-zA-Z0-9*_.-]+$": {
                                     "description": "Amino acid mutations for this CDS",
                                     "$comment": "properties must exist in the meta.JSON -> annotation object",
                                     "type": "array",


### PR DESCRIPTION
Auspice already handled these, it was an oversight that they weren't
allowed in the schema.