### PR TITLE
tests: pip install without editable mode, fix `ModuleNotFoundError`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         activate-environment: test
     - run: mamba install mafft raxml fasttree iqtree vcftools
     - run: mamba install biopython=${{ matrix.biopython-version }}
-    - run: pip install -e .[dev]
+    - run: pip install .[dev]
     - run: conda info
     - run: conda list
     - run: pytest -c pytest.python3.ini --cov=augur

--- a/devel/test
+++ b/devel/test
@@ -26,7 +26,7 @@ fi
 echo Setting up Conda test environment with ${CONDA}
 ${CONDA} create --yes --quiet -n ${ENV_NAME} -c conda-forge -c bioconda augur
 conda activate ${ENV_NAME}
-python3 -m pip install -e .[dev]
+python3 -m pip install .[dev]
 
 # Run unit and functional tests.
 echo Running tests


### PR DESCRIPTION
### Description of proposed changes

Catches and prevents errors such as `ModuleNotFoundError: No module named 'augur.io_support'`, introduced in #929.

- [x] figure out why CI didn't catch this
- [x] add test to prevent future breakage

### Related issue(s)

_N/A_

### Testing

- See CI status before/after adding `__init__.py`.
- Also tested locally by @rneher and I