### PR TITLE
ci: Add job to create GitHub release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Release
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,10 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
           TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+      - name: Create GitHub Release
+        run: ./devel/create-github-release "${{github.event.inputs.version}}" dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   rebuild-docker-image:
     needs: [run]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           name: dist
           path: dist/
       - run: git push origin master tag ${{ github.event.inputs.version}}
-      - name: 'Publish to PyPI'
+      - name: Publish to PyPI
         run: twine upload dist/*
         env:
           TWINE_USERNAME: __token__

--- a/devel/changes
+++ b/devel/changes
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Extract changelog for a specified version (or __NEXT__ if no version
+specified).
+"""
+from pathlib import Path
+from sys import argv, exit, stdout, stderr
+
+
+CHANGELOG = Path(__file__).parent / "../CHANGES.md"
+
+
+def main(version = "__NEXT__"):
+    with CHANGELOG.open(encoding = "utf-8") as file:
+        for line in file:
+            # Find the heading for this version
+            if line.rstrip("\n") == f"# {version}" or line.startswith(f"# {version} "):
+
+                # Print subsequent lines until we reach the next version heading
+                for line in file:
+                    if line.startswith("# "):
+                        break
+                    stdout.write(line)
+                return 0
+
+        print(f"No changes found for {version!r}.", file = stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    exit(main(*argv[1:]))

--- a/devel/changes
+++ b/devel/changes
@@ -14,11 +14,11 @@ def main(version = "__NEXT__"):
     with CHANGELOG.open(encoding = "utf-8") as file:
         for line in file:
             # Find the heading for this version
-            if line.rstrip("\n") == f"# {version}" or line.startswith(f"# {version} "):
+            if line.rstrip("\n") == f"## {version}" or line.startswith(f"## {version} "):
 
                 # Print subsequent lines until we reach the next version heading
                 for line in file:
-                    if line.startswith("# "):
+                    if line.startswith("## "):
                         break
                     stdout.write(line)
                 return 0

--- a/devel/create-github-release
+++ b/devel/create-github-release
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s extglob
+
+devel="$(dirname "$0")"
+
+main() {
+    local version="${1:?version is required}"
+    local commit pre_release
+    shift
+    local -a assets=("$@")
+
+    if [[ ${#assets[@]} -eq 0 ]]; then
+        echo "ERROR: no assets provided" >&2
+        exit 1
+    fi
+
+    # Asserts that $version is an actual tag, not a branch name or other ref.
+    git rev-parse --verify "$version^{tag}" >/dev/null
+
+    # Translate from tag into commit for `gh release create --target`.
+    commit="$(git rev-parse --verify "$version^{commit}")"
+
+    if is-pre-release "$version"; then
+        pre_release=1
+    fi
+
+    gh release create \
+        "$version" \
+        --repo "${GITHUB_REPOSITORY:-nextstrain/cli}" \
+        --title "$version" \
+        --target "$commit" \
+        ${pre_release:+--prerelease} \
+        --notes-file <(preamble; "$devel"/changes "$version") \
+        "${assets[@]}"
+}
+
+is-pre-release() {
+    # See https://peps.python.org/pep-0440/
+    local version="$1"
+    case "$version" in
+        *@(a|b|rc|c)+([0-9])*)  # alpha, beta, release candidate (PEP 440 pre-releases)
+            return 0;;
+        *.dev+([0-9])*)         # dev release
+            return 0;;
+        *+*)                    # local version
+            return 0;;
+        *)
+            return 1;;
+    esac
+}
+
+preamble() {
+    cat <<~~
+
+_These release notes are automatically extracted from the full [changelog][]._
+
+[changelog]: https://github.com/nextstrain/cli/blob/master/CHANGES.md#readme
+
+~~
+}
+
+main "$@"

--- a/devel/create-github-release
+++ b/devel/create-github-release
@@ -27,7 +27,7 @@ main() {
 
     gh release create \
         "$version" \
-        --repo "${GITHUB_REPOSITORY:-nextstrain/cli}" \
+        --repo "${GITHUB_REPOSITORY:-nextstrain/augur}" \
         --title "$version" \
         --target "$commit" \
         ${pre_release:+--prerelease} \
@@ -55,7 +55,7 @@ preamble() {
 
 _These release notes are automatically extracted from the full [changelog][]._
 
-[changelog]: https://github.com/nextstrain/cli/blob/master/CHANGES.md#readme
+[changelog]: https://github.com/nextstrain/augur/blob/-/CHANGES.md#readme
 
 ~~
 }

--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -195,12 +195,6 @@ Versions for this project, Augur, from 3.0.0 onwards aim to follow the
     3. Select **Run workflow**.
 3. Ensure workflow runs successfully.
     - Ensure the [docker-base CI action triggered by nextstrain-bot](https://github.com/nextstrain/docker-base/actions/workflows/ci.yml?query=branch%3Amaster+actor%3Anextstrain-bot) runs successfully.
-4. Create a [new GitHub release](https://github.com/nextstrain/augur/releases/new).
-    1. Choose the tag for the new version number.
-    2. In **Release title**, provide the new version number.
-    3. In **Describe this release**, copy over changes for this new version from [CHANGES.md](../../CHANGES.md).
-    4. Ensure **Set as the latest release** is checked.
-    5. Publish release.
 
 ##### 4. Update on Bioconda
 


### PR DESCRIPTION
### Description of proposed changes

This copies scripts from https://github.com/nextstrain/cli/pull/186 to create a GitHub Release at the end of the release workflow.

### Related issue(s)

- Closes #907

### Testing

Tested the new job over at my fork victorlin/augur, [see successful run](https://github.com/victorlin/augur/actions/runs/4249390409/jobs/7389499824) and [GitHub Release](https://github.com/victorlin/augur/releases/tag/21.0.2).