### PR TITLE
ci: Add token to use GitHub CLI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,3 +40,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: gh workflow run ci.yml --repo nextstrain/docker-base
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}


### PR DESCRIPTION
_[note] this is the same as nextstrain/auspice#1510 for this repo. See that PR for more details._

### Description of proposed changes

The usage of `gh workflow run` has been untested here. It was tested in Auspice, and noted that additional authentication is necessary for it to function properly (nextstrain/auspice#1508). This PR fixes the same problem waiting to happen here.

### Related issue(s)

See links above

### Testing

See nextstrain/auspice#1510