### PR TITLE
fix: translate `-` strand annotation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* translate: Fix annotation of `-` strands in augur/auspice genemap format [#966][] (@corneliusroemer)
+
+[#966]: https://github.com/nextstrain/augur/pull/966
 
 ## 15.0.2 (5 May 2022)
 

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -382,7 +382,7 @@ def run(args):
                               'type':feat.type,
                               'start':int(feat.location.start)+1,
                               'end':int(feat.location.end),
-                              'strand': '+' if feat.location.strand else '-'}
+                              'strand': '+' if feat.location.strand == 1 else '-'}
     if is_vcf: #need to add our own nuc
         annotations['nuc'] = {'seqid':args.reference_sequence,
                               'type':feat.type,

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -382,7 +382,7 @@ def run(args):
                               'type':feat.type,
                               'start':int(feat.location.start)+1,
                               'end':int(feat.location.end),
-                              'strand': '+' if feat.location.strand == 1 else '-'}
+                              'strand': '-' if feat.location.strand == -1 else '+'}
     if is_vcf: #need to add our own nuc
         annotations['nuc'] = {'seqid':args.reference_sequence,
                               'type':feat.type,


### PR DESCRIPTION
Annotations output by augur translate always contained `+` irrespective
of what the input gff or gb file specified and biopython returned

This bug was down to the assumption that biopython `feat.location.strand`
returns a boolean, when it in fact returns numeric `1` or `-1` for pos/neg strand

In order to be backwards compatible and output `+` by default, for example when no strand directionality is given, I reversed the test, so it puts `-` iff strand is `-1`, otherwise it's `+`

### Testing
The change is minimal, it's a very localized bug fix.

There is almost no testing for `augur translate`, so this would be good to set up at some point, but it shouldn't block this important fix (it's directly relevant for all MPX builds). Maybe @victorlin can add this to the backlog of Augur work?

This makes Auspice display pos and neg strands correctly as shown below:
<img width="2292" alt="image" src="https://user-images.githubusercontent.com/25161793/172432953-9c85b998-1052-4f01-a017-0534a7aab0a8.png">
