### PR TITLE
Make release commit using github-actions[bot]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,8 @@ jobs:
           python-version: '3.10'
       - name: Set Nextstrain bot as git user
         run: |
-          git config --global user.email "hello@nextstrain.org"
-          git config --global user.name "Nextstrain bot"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
       - run: python3 -m pip install --upgrade build twine
       - run: devel/release ${{ github.event.inputs.version}}
       - run: devel/test


### PR DESCRIPTION
### Description of proposed changes

Previously the commit was created under nextstrain-bot. Might as well use github-actions[bot] since this is being done via GitHub Actions.

Sources:

- https://github.com/actions/checkout/discussions/479#discussioncomment-625461
- https://github.community/t/github-actions-bot-email-address/17204

### Related issue(s)

_N/A_

### Testing

_N/A_