### PR TITLE
fix: parse `source` from gff to add `nuc` annotation

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -147,7 +147,7 @@ def load_features(reference, feature_names=None):
         except ImportError:
             print("ERROR: Package BCBio.GFF not found! Please install using \'pip install bcbio-gff\' before re-running.")
             return None
-        limit_info = dict( gff_type = ['gene'] )
+        limit_info = dict( gff_type = ['gene', 'source'] )
 
         with open(reference, encoding='utf-8') as in_handle:
             for rec in GFF.parse(in_handle, limit_info=limit_info):
@@ -164,6 +164,9 @@ def load_features(reference, feature_names=None):
                             fname = feat.qualifiers["gene"][0]
                         else:
                             fname = feat.qualifiers["locus_tag"][0]
+                    if feat.type == "source":
+                        fname = "nuc"
+
                     if fname:
                         features[fname] = feat
 


### PR DESCRIPTION
partially resolves BUG: `augur translate` not faithful to `gff3` standard, can't annotate nucs, which are required. #953

### Description of proposed changes
What is the goal of this pull request? What does this pull request change?

### Related issue(s)
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #
Related to #

### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
