### PR TITLE
Use pandas.DataFrame.at instead of .loc for single values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@
 
 * Upgrade treetime from 0.8.6 to >= 0.9.2 which enables a speedup of timetree inference in marginal mode due to the use of Fast Fourier Transforms [#1018][]. (@rneher and @anna-parker)
 
+### Bug Fixes
+
+* refine, export v1: Use pandas.DataFrame.at instead of .loc for single values [#979][]. (@victorlin)
+
+[#979]: https://github.com/nextstrain/augur/pull/979
+
 ## 17.0.0 (9 August 2022)
 
 ### Major Changes

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -269,8 +269,8 @@ def add_tsv_metadata_to_nodes(nodes, meta_tsv, meta_json, extra_fields=['authors
             continue
         for field in fields:
             # Allow fields to have value of 0! - but prevent from having value of "" (breaks auspice v1)
-            if field not in node and field in meta_tsv.columns and (meta_tsv.loc[strain, field] or meta_tsv.loc[strain, field]==0):
-                node[field] = meta_tsv.loc[strain, field]
+            if field not in node and field in meta_tsv.columns and (meta_tsv.at[strain, field] or meta_tsv.at[strain, field]==0):
+                node[field] = meta_tsv.at[strain, field]
 
 
 def get_root_sequence(root_node, ref=None, translations=None):

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -211,7 +211,7 @@ def run(args):
         # save input state string for later export
         for n in T.get_terminals():
             if n.name in metadata.index and 'date' in metadata.columns:
-                n.raw_date = metadata.loc[n.name, 'date']
+                n.raw_date = metadata.at[n.name, 'date']
 
         if args.date_confidence:
             time_inference_mode = 'always' if args.date_inference=='marginal' else 'only-final'


### PR DESCRIPTION
### Description of proposed changes

[This is the recommended way by pandas][1]:

> Similar to `loc`, in that both provide label-based lookups. Use `at` if you only need to get or set a single value in a DataFrame or Series.

[1]: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.at.html

### Related issue(s)

- Follow-up to #934
- #970

### Testing

No tests added.