### PR TITLE
docs: Install nextstrain.sphinx.theme extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,14 @@ author = prose_list(git_authors())
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['recommonmark', 'sphinx.ext.autodoc', 'sphinxarg.ext', 'sphinx.ext.napoleon', 'sphinx_markdown_tables', 'sphinx.ext.intersphinx']
+extensions = [
+    'recommonmark',
+    'sphinx.ext.autodoc',
+    'sphinxarg.ext',
+    'sphinx.ext.napoleon',
+    'sphinx_markdown_tables',
+    'sphinx.ext.intersphinx',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_markdown_tables',
     'sphinx.ext.intersphinx',
+    'nextstrain.sphinx.theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setuptools.setup(
             "cram >=0.7",
             "deepdiff >=4.3.2",
             "freezegun >=0.3.15",
-            "nextstrain-sphinx-theme >=2020.3",
+            "nextstrain-sphinx-theme >=2022.5",
             "pylint >=1.7.6",
             "pytest >=5.4.1",
             "pytest-cov >=2.8.1",


### PR DESCRIPTION
## Description of proposed changes

The new extension has sphinx_copybutton pre-installed and configured. This change enables it here.
This also makes it easier to configure other extensions across multiple docs projects.

## Related issue(s)

https://github.com/nextstrain/sphinx-theme/issues/30

## Testing

- [x] copy button works on RTD preview build