### PR TITLE
Rename force inclusion filtering functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,12 @@
     * `utils.HideAsFalseAction` -> `argparse_.HideAsFalseAction`
 * Subcommands must include a `register_parser` function to add their own parser instead of a `register_arguments` function [#1002][]. (@joverlee521)
 
+### Bug Fixes
+
+* filter: Rename internal force inclusion filtering functions [#1006][] (@victorlin)
+
 [#1002]: https://github.com/nextstrain/augur/pull/1002
+[#1006]: https://github.com/nextstrain/augur/pull/1006
 
 ## 16.0.3 (6 July 2022)
 

--- a/tests/functional/filter/data/filtered_log.tsv
+++ b/tests/functional/filter/data/filtered_log.tsv
@@ -3,4 +3,4 @@ HND/2016/HU_ME59	filter_by_sequence_index	[]
 COL/FLR_00008/2015	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
 Colombia/2016/ZC204Se	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
 COL/FLR_00024/2015	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
-COL/FLR_00008/2015	include	"[[""include_file"", ""filter/data/include.txt""]]"
+COL/FLR_00008/2015	force_include_strains	"[[""include_file"", ""filter/data/include.txt""]]"


### PR DESCRIPTION
### Description of proposed changes

- include -> force_include_strains
- include_by_include_where -> force_include_where

I found the existing names a bit vague/confusing. These names are more descriptive in my opinion. Open to other suggestions.

### Related issue(s)

_N/A_

### Testing

- [x] Updated test data file
- [x] CI passes

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
