### PR TITLE
Report names of metadata duplicates in filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,14 +17,16 @@
 ### Features
 
 * export: `--skip-validation` now also skips version compatibility checks [#902][]. (@corneliusroemer)
+* filter: Report names of duplicate strains found during metadata parsing [#1008][] (@huddlej)
 
 ### Bug Fixes
 
 * filter: Rename internal force inclusion filtering functions [#1006][] (@victorlin)
 
+[#902]: https://github.com/nextstrain/augur/pull/902
 [#1002]: https://github.com/nextstrain/augur/pull/1002
 [#1006]: https://github.com/nextstrain/augur/pull/1006
-[#902]: https://github.com/nextstrain/augur/pull/902
+[#1008]: https://github.com/nextstrain/augur/pull/1008
 
 ## 16.0.3 (6 July 2022)
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1403,9 +1403,14 @@ def run(args):
         chunk_size=args.metadata_chunk_size,
     )
     for metadata in metadata_reader:
-        if any(metadata.index.duplicated()) or any(metadata.index.isin(metadata_strains)):
+        duplicate_strains = (
+            set(metadata.index[metadata.index.duplicated()]) |
+            set(metadata.index[metadata.index.isin(metadata_strains)])
+        )
+        if len(duplicate_strains) > 0:
             _cleanup_outputs(args)
-            raise AugurError(f"Duplicate found in '{args.metadata}'.")
+            raise AugurError(f"The following strains are duplicated in '{args.metadata}':\n" + "\n".join(sorted(duplicate_strains)))
+
         # Maintain list of all strains seen.
         metadata_strains.update(set(metadata.index.values))
 

--- a/tests/functional/filter/cram/filter-metadata-duplicates-error.t
+++ b/tests/functional/filter/cram/filter-metadata-duplicates-error.t
@@ -20,7 +20,8 @@ Error on duplicates in metadata within same chunk.
   >   --subsample-seed 0 \
   >   --metadata-chunk-size 10 \
   >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
-  ERROR: Duplicate found in .* (re)
+  ERROR: The following strains are duplicated in .* (re)
+  a
   [2]
   $ cat $TMP/metadata-filtered.tsv
   cat: .*: No such file or directory (re)
@@ -35,7 +36,8 @@ Error on duplicates in metadata in separate chunks.
   >   --subsample-seed 0 \
   >   --metadata-chunk-size 1 \
   >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
-  ERROR: Duplicate found in .* (re)
+  ERROR: The following strains are duplicated in .* (re)
+  a
   [2]
   $ cat $TMP/metadata-filtered.tsv
   cat: .*: No such file or directory (re)


### PR DESCRIPTION
## Description of proposed changes

Reports the names of duplicate strains as part of the error message when augur filter finds duplicates in the metadata, so the user knows where to start debugging their data.

## Related issue(s)

Related to #918

## Testing

 - [x] Tested by CI