### PR TITLE
export: Allow `--node-data` to be repeated to build up a file list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@
         columns = metadata.columns
         metadata = metadata.to_dict(orient="index")
         ```
+* export: The `--node-data` option may now be given multiple times to provide additional `.json` files.  Previously, subsequent occurrences of the option overrode prior occurrences.  This is a **breaking change**, although we expect few usages to be impacted.  Each occurrence of the option may still specify multiple files at a time. [#1010][] (@tsibley)
 
 ### Features
 
@@ -73,6 +74,7 @@
 [#1002]: https://github.com/nextstrain/augur/pull/1002
 [#1006]: https://github.com/nextstrain/augur/pull/1006
 [#1008]: https://github.com/nextstrain/augur/pull/1008
+[#1010]: https://github.com/nextstrain/augur/pull/1010
 [#1017]: https://github.com/nextstrain/augur/pull/1017
 
 ## 16.0.3 (6 July 2022)

--- a/augur/argparse_.py
+++ b/augur/argparse_.py
@@ -57,3 +57,22 @@ class HideAsFalseAction(Action):
     """
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, option_string[2:6] != 'hide')
+
+
+# XXX TODO: Drop this when we drop support for 3.7 and use builtin "extend"
+# action.
+class ExtendAction(Action):
+    """
+    Loosely backported version of builtin "extend" action
+    (argparse._ExtendAction) in CPython v3.10.5-172-gf118661a18.  Some of the
+    ceremony we don't need has been ditched.
+
+    >>> import argparse
+    >>> p = argparse.ArgumentParser()
+    >>> a = p.add_argument("-x", action=ExtendAction, nargs="+")
+    >>> p.parse_args(["-x", "a", "b", "-x", "c", "-x", "d"]).x
+    ['a', 'b', 'c', 'd']
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        current = getattr(namespace, self.dest, None) or []
+        setattr(namespace, self.dest, [*current, *values])

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -9,6 +9,7 @@ import numpy as np
 from Bio import Phylo
 from argparse import SUPPRESS
 from collections import defaultdict
+from .argparse_ import ExtendAction
 from .io import read_metadata
 from .utils import read_node_data, write_json, read_config, read_lat_longs, read_colors
 
@@ -311,7 +312,7 @@ def add_core_args(parser):
     core = parser.add_argument_group("REQUIRED")
     core.add_argument('--tree','-t', required=True, help="tree to perform trait reconstruction on")
     core.add_argument('--metadata', required=True, metavar="FILE", help="sequence metadata, as CSV or TSV")
-    core.add_argument('--node-data', required=True, nargs='+', help="JSON files with meta data for each node")
+    core.add_argument('--node-data', required=True, nargs='+', action=ExtendAction, help="JSON files with meta data for each node")
     core.add_argument('--output-tree', help="JSON file name that is passed on to auspice (e.g., zika_tree.json).")
     core.add_argument('--output-meta', help="JSON file name that is passed on to auspice (e.g., zika_meta.json).")
     core.add_argument('--auspice-config', help="file with auspice configuration")

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -10,6 +10,7 @@ import numbers
 import re
 from Bio import Phylo
 
+from .argparse_ import ExtendAction
 from .io import read_metadata
 from .utils import read_node_data, write_json, read_config, read_lat_longs, read_colors
 from .validate import export_v2 as validate_v2, auspice_config_v2 as validate_auspice_config_v2, ValidateError
@@ -826,7 +827,7 @@ def register_parser(parent_subparsers):
         title="REQUIRED"
     )
     required.add_argument('--tree','-t', metavar="newick", required=True, help="Phylogenetic tree, usually output from `augur refine`")
-    required.add_argument('--node-data', metavar="JSON", required=True, nargs='+', help="JSON files containing metadata for nodes in the tree")
+    required.add_argument('--node-data', metavar="JSON", required=True, nargs='+', action=ExtendAction, help="JSON files containing metadata for nodes in the tree")
     required.add_argument('--output', metavar="JSON", required=True, help="Ouput file (typically for visualisation in auspice)")
 
     config = parser.add_argument_group(

--- a/tests/functional/export_v2.t
+++ b/tests/functional/export_v2.t
@@ -33,6 +33,19 @@ Export with auspice config JSON which defines scale & legend settings
   {}
 
 
+...same but with repeated --node-data options instead of a single multi-valued option
+  $ ${AUGUR} export v2 \
+  >   --tree export_v2/tree.nwk \
+  >   --node-data export_v2/div_node-data.json \
+  >   --node-data export_v2/location_node-data.json \
+  >   --auspice-config export_v2/auspice_config1.json \
+  >   --output "$TMP/dataset1.json" &>/dev/null
+
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py"  export_v2/dataset1.json "$TMP/dataset1.json" \
+  >   --exclude-paths "root['meta']['updated']"
+  {}
+
+
 Export with auspice config JSON with an extensions block
   $ ${AUGUR} export v2 \
   >   --tree export_v2/tree.nwk \


### PR DESCRIPTION
### Description of proposed changes
…instead of each repetition overriding the last values.  While there is some theoretical utility in being able to override one list of node data files with another in a subsequent option, I think it's more likely that repetition is intended to built up a single list.  I was surprised, at least.

See also <https://discussion.nextstrain.org/t/1194/4>.

### Testing
- [x] New and updated tests pass locally
- [x] CI passes

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
- [ ] Note that this would be a **backwards incompatible** change in the changelog.