### PR TITLE
Report actual missing filename for index paths

### DIFF
--- a/augur/index.py
+++ b/augur/index.py
@@ -206,8 +206,8 @@ def run(args):
             tot_length = None
         else:
             num_of_seqs, tot_length = index_sequences(args.sequences, args.output)
-    except FileNotFoundError:
-        print(f"ERROR: Could not open sequences file '{args.sequences}'.", file=sys.stderr)
+    except FileNotFoundError as error:
+        print(f"ERROR: Could not open file '{error.filename}'.", file=sys.stderr)
         return 1
 
     if args.verbose:

--- a/tests/functional/index.t
+++ b/tests/functional/index.t
@@ -13,12 +13,21 @@ Index Zika sequences.
   $ rm -f "$TMP/sequence_index.tsv"
 
 Try indexing sequences that do not exist.
-This should fail.
+This should fail with an error about the missing input.
 
   $ ${AUGUR} index \
   >   --sequences index/missing_sequences.fasta \
   >   --output "$TMP/sequence_index.tsv"
-  ERROR: Could not open sequences file 'index/missing_sequences.fasta'.
+  ERROR: Could not open file 'index/missing_sequences.fasta'.
+  [1]
+
+Try indexing sequences into an output directory that does not exist.
+This should fail with an error about the missing directory.
+
+  $ ${AUGUR} index \
+  >   --sequences index/sequences.fasta \
+  >   --output missing/sequence_index.tsv
+  ERROR: Could not open file 'missing/sequence_index.tsv'.
   [1]
 
   $ popd > /dev/null


### PR DESCRIPTION
## Description of proposed changes

Fixes a confusing error message produced by augur index when the output directory for the sequence index does not exist but the error message says the sequences file is missing. The fix is to use the actual filename associated with the `FileNotFoundError` to report the "missing" file, instead of assuming that the missing file is the input.

## Testing

 - [x] Adds a functional test to capture this expected behavior.
 - [ ] Tested by CI