### PR TITLE
chore: use `--cores all` in snakemake CI test, format .sh script

### DIFF
--- a/tests/builds/add_to_alignment/Snakefile
+++ b/tests/builds/add_to_alignment/Snakefile
@@ -134,7 +134,7 @@ rule export:
         auspice = rules.all.input.auspice
     shell:
         """
-        snakemake --cores 1 check
+        snakemake --cores all check
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \

--- a/tests/builds/runner.sh
+++ b/tests/builds/runner.sh
@@ -17,8 +17,8 @@ mkdir auspice
 for snakefile in ./*/Snakefile; do
   echo -e "\nRunning ${snakefile} (quietly)\n"
   pushd $(dirname "${snakefile}") >/dev/null
-  snakemake --cores 1 clean --quiet 1>/dev/null
-  snakemake --cores 1 --quiet 1>/dev/null
+  snakemake --cores all clean --quiet 1>/dev/null
+  snakemake --cores all --quiet 1>/dev/null
   cp auspice/*.json ../auspice
   popd >/dev/null
 done

--- a/tests/builds/runner.sh
+++ b/tests/builds/runner.sh
@@ -1,4 +1,3 @@
-
 function errorFound {
   echo -e "\nTest Script Failed at Line $1"
   exit 2
@@ -11,20 +10,18 @@ echo -e "Running all tests\n-----------------\n\n"
 cd $(dirname "$BASH_SOURCE")
 
 if [ -d ./auspice ]; then
-    rm -rf auspice
+  rm -rf auspice
 fi
 mkdir auspice
 
-
 for snakefile in ./*/Snakefile; do
-    echo -e "\nRunning ${snakefile} (quietly)\n"
-    pushd $(dirname "${snakefile}") >/dev/null
-    snakemake --cores 1 clean --quiet 1>/dev/null
-    snakemake --cores 1 --quiet 1>/dev/null
-    cp auspice/*.json ../auspice
-    popd >/dev/null
+  echo -e "\nRunning ${snakefile} (quietly)\n"
+  pushd $(dirname "${snakefile}") >/dev/null
+  snakemake --cores 1 clean --quiet 1>/dev/null
+  snakemake --cores 1 --quiet 1>/dev/null
+  cp auspice/*.json ../auspice
+  popd >/dev/null
 done
 
 echo -e "\nAll tests passed. You can view the results by running"
 echo -e "auspice view --datasetDir $(pwd)/auspice"
-


### PR DESCRIPTION
If testing locally, we have more than 1 core available, so why not make use of it.

For CI it shouldn't change anything since the runners only have 1 core.

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.~ Not necessary for small change in tests.