### PR TITLE
add better error handling if treetime fails

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -222,9 +222,7 @@ def run(args):
                         clock_filter_iqd=args.clock_filter_iqd,
                         covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies))
         except BaseException as err:
-            print("ERROR: Was unable to refine time trees:\n", file=sys.stderr)
-            print(err, file=sys.stderr)
-            return 1
+            raise AugurError(f"Was unable to refine time trees:\n\n{err}")
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,
                               'intercept': tt.date2dist.intercept,

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -7,6 +7,7 @@ from Bio import Phylo
 from .dates import get_numerical_dates
 from .io import read_metadata
 from .utils import read_tree, write_json, InvalidTreeError
+from .errors import AugurError
 from treetime.vcf_utils import read_vcf, write_vcf
 from treetime.seq_utils import profile_maps
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -211,15 +211,20 @@ def run(args):
             if n.name in metadata.index and 'date' in metadata.columns:
                 n.raw_date = metadata.loc[n.name, 'date']
 
-        tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
-                    reroot=args.root, # or 'best', # We now have a default in param spec - this just adds confusion.
-                    Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
-                    use_marginal = args.date_inference == 'marginal',
-                    branch_length_inference = args.branch_length_inference or 'auto',
-                    precision = 'auto' if args.precision is None else args.precision,
-                    clock_rate=args.clock_rate, clock_std=args.clock_std_dev,
-                    clock_filter_iqd=args.clock_filter_iqd,
-                    covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies))
+        try:
+            tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
+                        reroot=args.root, # or 'best', # We now have a default in param spec - this just adds confusion.
+                        Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
+                        use_marginal = args.date_inference == 'marginal',
+                        branch_length_inference = args.branch_length_inference or 'auto',
+                        precision = 'auto' if args.precision is None else args.precision,
+                        clock_rate=args.clock_rate, clock_std=args.clock_std_dev,
+                        clock_filter_iqd=args.clock_filter_iqd,
+                        covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies))
+        except BaseException as err:
+            print("ERROR: Was unable to refine time trees:\n", file=sys.stderr)
+            print(err, file=sys.stderr)
+            return 1
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,
                               'intercept': tt.date2dist.intercept,


### PR DESCRIPTION
Resolves #1013 

### Description of proposed changes
Hi, after https://github.com/nextstrain/augur/issues/1013 it appears that errors in augur (refine) that occur while running `treetime` are not handled in a clear way in `augur`, and give a very long and not very understandable error message. This is a small change that will make the errors more understandable. 

For example the output of the error described in the issue above will change from 
![image](https://user-images.githubusercontent.com/50943381/184098772-99775b8b-bed7-4a0d-8ead-0bc4d91ebed4.png)
to 
![image](https://user-images.githubusercontent.com/50943381/184098938-39e551d2-042a-40cc-9dca-8a3cf5d1fe18.png)

### Testing
- install `augur` and `treetime` in local environment (branch `fix/augur_bug` has slightly better error messages but will hopefully soon be merged into the master)
- create an Exception in `treetime`, I added a line in `_exp_lt` to force and error in this function, as this is where the error arose in the issue above, e.g. 
```    def _exp_lt(self, t):
        """
        Parameters
        ----------

         t : float
            time to propagate

        Returns
        --------

         exp_lt : numpy.array
            Array of values exp(lambda(i) * t),
            where (i) - alphabet index (the eigenvalue number).
        """
        log_val = self.mu * t * self.eigenvals
        log_val = np.ones(len(log_val))*750 ##cause an exception
        if any(i > 10 for i in log_val):
            raise ValueError("Error in computing exp(Q * t): Q has positive eigenvalues or the branch length t \n"
                    "is too large. This is most likely caused by incorrect input data. If this error persists \n"
                    "please let us know by filing an issue at: https://github.com/neherlab/treetime/issues")

        return np.exp(log_val)
```
this can be done with other functions or using data which causes an exception. 
- install modified `treetime` in local environment (pip install .) 
- run augur refine on the CLI using data from the tests folder:
```
augur refine -t tests/functional/refine/tree.nwk -a tests/functional/refine/aligned.fasta --metadata tests/functional/refine/metadata.tsv --timetree --root 'min_dev' --coalescent 'opt' --output-tree augur.tree.nwk --output-node augur.branch_lengths.json --divergence-units 'mutations'
```

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
