### PR TITLE
Error when metadata to `get_numerical_dates()` is not a pandas DataFrame

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,10 @@
 ### Bug Fixes
 
 * refine, export v1: Use pandas.DataFrame.at instead of .loc for single values [#979][]. (@victorlin)
+* dates: Raise an error when metadata to `get_numerical_dates()` is not a pandas DataFrame [#1026][]. (@victorlin)
 
 [#979]: https://github.com/nextstrain/augur/pull/979
+[#1026]: https://github.com/nextstrain/augur/pull/1026
 
 ## 17.0.0 (9 August 2022)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 * dates: Raise an error when metadata to `get_numerical_dates()` is not a pandas DataFrame [#1026][]. (@victorlin)
 
 [#979]: https://github.com/nextstrain/augur/pull/979
+[#1018]: https://github.com/nextstrain/augur/pull/1018
 [#1026]: https://github.com/nextstrain/augur/pull/1026
 
 ## 17.0.0 (9 August 2022)

--- a/augur/dates.py
+++ b/augur/dates.py
@@ -5,6 +5,7 @@ import isodate
 import pandas as pd
 import re
 import treetime.utils
+from .errors import AugurError
 
 from augur.util_support.date_disambiguator import DateDisambiguator
 
@@ -122,7 +123,7 @@ def get_numerical_date_from_value(value, fmt=None, min_max_year=None):
 
 def get_numerical_dates(metadata:pd.DataFrame, name_col = None, date_col='date', fmt=None, min_max_year=None):
     if not isinstance(metadata, pd.DataFrame):
-        return {}
+        raise AugurError("Metadata should be a pandas.DataFrame.")
     if fmt:
         strains = metadata.index.values
         dates = metadata[date_col].apply(

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,6 +1,8 @@
 import datetime
+import pytest
 from freezegun import freeze_time
 from augur import dates
+from augur.errors import AugurError
 
 
 class TestDates:
@@ -57,3 +59,14 @@ class TestDates:
         # Test incomplete date strings without ambiguous dates for the requested fields.
         assert not dates.is_date_ambiguous("2019", "year")
         assert not dates.is_date_ambiguous("2019-10", "month")
+
+    def test_get_numerical_dates_dict_error(self):
+        """Using get_numerical_dates with metadata represented as a dict should raise an error."""
+        metadata = {
+            "example": {
+                "strain": "example",
+                "date": "2000-03-29"
+            }
+        }
+        with pytest.raises(AugurError):
+            dates.get_numerical_dates(metadata)


### PR DESCRIPTION
### Description of proposed changes

See commit messages and #1025.

### Related issue(s)

- Fixes #1025

### Testing

- [x] Added 84a4b0397e90c80947a48ab9f1e811382933f323 which fails, then fixed it with the following commit.

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
