### PR TITLE
Specify `--verbosity` for TreeTime, improve error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,9 +13,11 @@
 * tree: When using IQtree as tre builder, `--nthreads` now sets the maximum number of threads (IQtree argument `-ntmax`). The actual number of threads to use can be specified by the user through the tree-builder-arg `-nt` which defaults to `-nt AUTO`, causing IQtree to automatically chose the best number of threads to use [#1042][] (@corneliusroemer)
 * Make cvxopt as a required dependency, since it is required for titer models to work [#1035][]. (@victorlin)
 * filter: Fix compatibility with Pandas 1.5.0 which could cause an unexpected `AttributeError` with an invalid `--query` given to `augur filter`. [#1050][] (@tsibley)
-
+* refine: Add `--verbosity` argument that is passed down to TreeTime to facilitate monitoring and debugging. [#1033][] (@anna-parker)
+* Improve handling of errors from TreeTime. [#1033][] (@anna-parker)
 
 [#1010]: https://github.com/nextstrain/augur/pull/1010
+[#1033]: https://github.com/nextstrain/augur/pull/1033
 [#1034]: https://github.com/nextstrain/augur/pull/1034
 [#1035]: https://github.com/nextstrain/augur/pull/1035
 [#1042]: https://github.com/nextstrain/augur/pull/1042

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -9,7 +9,7 @@ import importlib
 import traceback
 from textwrap import dedent
 from types import SimpleNamespace
-from treetime import TreeTimeError, TreeTimeOtherError
+from treetime import TreeTimeError, TreeTimeUnknownError
 
 from .errors import AugurError
 from .io import print_err
@@ -73,19 +73,20 @@ def run(argv):
     except FileNotFoundError as e:
         print_err(f"ERROR: {e.strerror}: '{e.filename}'")
         sys.exit(2)
-    except TreeTimeOtherError as e:
-        print_err(e)
+    except TreeTimeUnknownError as e:
         print_err(dedent("""\
-            ERROR from TreeTime: An error occurred in TreeTime (see above) that has not been properly handled by Augur.
-            This may be due to an issue with TreeTime or Augur. To report this, please open a new issue including the original command and the error above:
-                <https://github.com/nextstrain/augur/issues/new/choose>
+            ERROR from TreeTime: An error occurred in TreeTime (see above). This may be due to an issue with TreeTime or Augur.
+            Please report you are calling TreeTime via Augur. 
             """))
         sys.exit(2)
     except TreeTimeError as e:
-        print_err(f"ERROR from TreeTime: This error is most likely due to a problem with your input data. "
-            "Please check your input data and try again. If you continue to have problems, please open a new issue including "
-            "the original command and the error above: \n  <https://github.com/nextstrain/augur/issues/new/choose>")
-        sys.exit(2)
+        print_err(f"ERROR: {e}")
+        print_err("\n")
+        print_err(dedent("""\
+            ERROR from TreeTime: This error is most likely due to a problem with your input data.
+            Please check your input data and try again. If you continue to have problems, please open a new issue including
+            the original command and the error above:  <https://github.com/nextstrain/augur/issues/new/choose>
+            """))
     except Exception:
         traceback.print_exc(file=sys.stderr)
         print_err("\n")

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -9,7 +9,7 @@ import importlib
 import traceback
 from textwrap import dedent
 from types import SimpleNamespace
-from treetime import TreeTimeError
+from treetime import TreeTimeError, TreeTimeOtherError
 
 from .errors import AugurError
 from .io import print_err
@@ -73,8 +73,17 @@ def run(argv):
     except FileNotFoundError as e:
         print_err(f"ERROR: {e.strerror}: '{e.filename}'")
         sys.exit(2)
+    except TreeTimeOtherError as e:
+        print_err(dedent("""\
+            ERROR from TreeTime: An error occurred in TreeTime (see above) that has not been properly handled by Augur.
+            This may be due to an issue with TreeTime or Augur. To report this, please open a new issue including the original command and the error above:
+                <https://github.com/nextstrain/augur/issues/new/choose>
+            """))
+        sys.exit(2)
     except TreeTimeError as e:
-        print_err(f"ERROR from TreeTime: {e}")
+        print_err(f"ERROR from TreeTime: This error is most likely due to a problem with your input data. "
+            "Please check your input data and try again. If you continue to have problems, please open a new issue including "
+            "the original command and the error above: \n  <https://github.com/nextstrain/augur/issues/new/choose>")
         sys.exit(2)
     except Exception:
         traceback.print_exc(file=sys.stderr)

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -74,6 +74,7 @@ def run(argv):
         print_err(f"ERROR: {e.strerror}: '{e.filename}'")
         sys.exit(2)
     except TreeTimeOtherError as e:
+        print_err(e)
         print_err(dedent("""\
             ERROR from TreeTime: An error occurred in TreeTime (see above) that has not been properly handled by Augur.
             This may be due to an issue with TreeTime or Augur. To report this, please open a new issue including the original command and the error above:

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -9,6 +9,7 @@ import importlib
 import traceback
 from textwrap import dedent
 from types import SimpleNamespace
+from treetime import TreeTimeError
 
 from .errors import AugurError
 from .io import print_err
@@ -71,6 +72,9 @@ def run(argv):
         sys.exit(2)
     except FileNotFoundError as e:
         print_err(f"ERROR: {e.strerror}: '{e.filename}'")
+        sys.exit(2)
+    except TreeTimeError as e:
+        print_err(f"ERROR from TreeTime: {e}")
         sys.exit(2)
     except Exception:
         traceback.print_exc(file=sys.stderr)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -70,7 +70,7 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='a
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
            branch_length_mode=branch_length_inference, resolve_polytomies=resolve_polytomies,
            max_iter=max_iter, fixed_pi=fixed_pi, fixed_clock_rate=clock_rate,
-           vary_rate=vary_rate, use_covariation=covariance, augur=True, **kwarks)
+           vary_rate=vary_rate, use_covariation=covariance, raise_uncaught_exceptions=True, **kwarks)
 
     if confidence:
         for n in tt.tree.find_clades():

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -71,7 +71,7 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='a
     tt.run(infer_gtr=infer_gtr, root=reroot, Tc=Tc, time_marginal=marginal,
            branch_length_mode=branch_length_inference, resolve_polytomies=resolve_polytomies,
            max_iter=max_iter, fixed_pi=fixed_pi, fixed_clock_rate=clock_rate,
-           vary_rate=vary_rate, use_covariation=covariance, **kwarks)
+           vary_rate=vary_rate, use_covariation=covariance, augur=True, **kwarks)
 
     if confidence:
         for n in tt.tree.find_clades():
@@ -219,24 +219,17 @@ def run(args):
             time_inference_mode = 'always' if args.date_inference=='marginal' else 'only-final'
         else:
             time_inference_mode = 'always' if args.date_inference=='marginal' else 'never'
-        try:
-            tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
-                        reroot=args.root, # or 'best', # We now have a default in param spec - this just adds confusion.
-                        Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
-                        use_marginal = time_inference_mode, use_fft=args.use_fft,
-                        branch_length_inference = args.branch_length_inference or 'auto',
-                        precision = 'auto' if args.precision is None else args.precision,
-                        clock_rate=args.clock_rate, clock_std=args.clock_std_dev,
-                        clock_filter_iqd=args.clock_filter_iqd,
-                        covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies), 
-                        verbosity=args.verbosity)
-        except TreeTimeError as err:
-            raise AugurError(f"Was unable to refine time trees:\n\n{err}")
-        except BaseException as err:
-            import traceback 
-            traceback.format_exc()
-            print("ERROR: Was unable to refine time trees:\n")
-            raise err
+        
+        tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
+                    reroot=args.root, # or 'best', # We now have a default in param spec - this just adds confusion.
+                    Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
+                    use_marginal = time_inference_mode, use_fft=args.use_fft,
+                    branch_length_inference = args.branch_length_inference or 'auto',
+                    precision = 'auto' if args.precision is None else args.precision,
+                    clock_rate=args.clock_rate, clock_std=args.clock_std_dev,
+                    clock_filter_iqd=args.clock_filter_iqd,
+                    covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies), 
+                    verbosity=args.verbosity)
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,
                               'intercept': tt.date2dist.intercept,

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -8,9 +8,8 @@ from .dates import get_numerical_dates
 from .io import read_metadata
 from .utils import read_tree, write_json, InvalidTreeError
 from .errors import AugurError
-from treetime.vcf_utils import read_vcf, write_vcf
+from treetime.vcf_utils import read_vcf
 from treetime.seq_utils import profile_maps
-from treetime import TreeTimeError
 
 def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='auto',
              confidence=False, resolve_polytomies=True, max_iter=2, precision='auto',
@@ -219,7 +218,7 @@ def run(args):
             time_inference_mode = 'always' if args.date_inference=='marginal' else 'only-final'
         else:
             time_inference_mode = 'always' if args.date_inference=='marginal' else 'never'
-        
+
         tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
                     reroot=args.root, # or 'best', # We now have a default in param spec - this just adds confusion.
                     Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
@@ -228,7 +227,7 @@ def run(args):
                     precision = 'auto' if args.precision is None else args.precision,
                     clock_rate=args.clock_rate, clock_std=args.clock_std_dev,
                     clock_filter_iqd=args.clock_filter_iqd,
-                    covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies), 
+                    covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies),
                     verbosity=args.verbosity)
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -228,7 +228,12 @@ def run(args):
                         clock_filter_iqd=args.clock_filter_iqd,
                         covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies))
         except BaseException as err:
-            raise AugurError(f"Was unable to refine time trees:\n\n{err}")
+            if type(err).__name__ == "TreeTimeError":
+                raise AugurError(f"Was unable to refine time trees:\n\n{err}")
+            else:
+                import traceback 
+                traceback.format_exc()
+                raise err
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,
                               'intercept': tt.date2dist.intercept,

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setuptools.setup(
         "networkx >= 2.5, ==2.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",
-        "phylo-treetime >=0.9.2, ==0.9.*",
+        "phylo-treetime >=0.9.3, ==0.9.*",
         "xopen >=1.0.1, ==1.*"
     ],
     extras_require = {


### PR DESCRIPTION
### Description of proposed changes
This modification will make sure that if `TreeTime` errors and the error is not of type `TreeTimeError` the full traceback will be printed out. In https://github.com/nextstrain/augur/issues/1032 the new catch statement prevented us from seeing where the error occured in TreeTime as an error that we did not specifically handle (most likely it was handled in scipy or numpy) was not fully printed out. 

This does mean however that errors in `TreeTime` that are "known" should be relabeled as `TreeTimeError` if we do not want `augur` to print their entire stack trace. I hope there are no issues with this. 

### Related issue(s)
https://github.com/nextstrain/augur/issues/1032 

### Testing
- install augur and treetime in local environment 
- cause an "unknown" Exception in treetime (i.e not a `TreeTimeError`), I added a line in _exp_lt 
```
        """
        Parameters
        ----------

         t : float
            time to propagate

        Returns
        --------

         exp_lt : numpy.array
            Array of values exp(lambda(i) * t),
            where (i) - alphabet index (the eigenvalue number).
        """
        log_val = self.mu * t * self.eigenvals
        log_val = np.ones(len(log_val))*750 ##cause an exception
        if any(i > 10 for i in log_val):
            raise ValueError("Error in computing exp(Q * t): Q has positive eigenvalues or the branch length t \n"
                    "is too large. This is most likely caused by incorrect input data. If this error persists \n"
                    "please let us know by filing an issue at: https://github.com/neherlab/treetime/issues")

        return np.exp(log_val)
```
as long as this is a `ValueError` the full stack trace should now show. 
- cause a "known" Exception relabel `ValueError` as `TreeTimeError` (needs to be imported `from . import TreeTimeError`), this should now just show the error described above. 

install modified treetime in local environment (pip install .)
run augur refine on the CLI using data from the tests folder:
```augur refine -t tests/functional/refine/tree.nwk -a tests/functional/refine/aligned.fasta --metadata tests/functional/refine/metadata.tsv --timetree --root 'min_dev' --coalescent 'opt' --output-tree augur.tree.nwk --output-node augur.branch_lengths.json --divergence-units 'mutations'```


### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
