### PR TITLE
adapt date inference to profit from fft more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+ * 17.1.0 updated TreeTime to version 0.9.2 and introduced the flag `--use-fft`. This makes previously costly marginal date inference cheaper. This update adjusts when `refine` runs marginal date inference during its iterative optimization. Without the `use-fft` flag, it will now have as it did before 17.1.0 (marginal inference only during final iterations). With the `--use-fft` flag, marginal date inference will be used at every step during the iteration if refine is run with `--date-inference marginal` [#1034][]. (@rneher)
+
+[#1034]: https://github.com/nextstrain/augur/pull/1034
 
 ## 17.1.0 (19 August 2022)
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -55,9 +55,9 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='a
     if confidence and use_marginal:
         # estimate confidence intervals via marginal ML and assign
         # marginal ML times to nodes
-        marginal = 'assign'
+        marginal = 'always' if use_fft else 'assign'
     else:
-        marginal = confidence
+        marginal = 'only-final' if confidence else False
 
     # uncertainty of the the clock rate is relevant if confidence intervals are estimated
     if confidence and clock_std:


### PR DESCRIPTION
This PR changes how treetime uses `joint` and `marginal` date inference. 

with `--use-fft`, this will make use of the speed-up through fft in more cases.

without this flag, the behavior will be closer to the previous behavior (doing marginal only in the last iteration to save time) 