### PR TITLE
fix(tree): --nthreads corresponds to IQtrees `-ntmax` not `-nt`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,17 +4,19 @@
 
 ### Bug Fixes
 
-* 17.1.0 updated TreeTime to version 0.9.2 and introduced the flag `--use-fft`. This makes previously costly marginal date inference cheaper. This update adjusts when `refine` runs marginal date inference during its iterative optimization. Without the `use-fft` flag, it will now have as it did before 17.1.0 (marginal inference only during final iterations). With the `--use-fft` flag, marginal date inference will be used at every step during the iteration if refine is run with `--date-inference marginal` [#1034][]. (@rneher)
-* Make cvxopt as a required dependency, since it is required for titer models to work [#1035]. (@victorlin)
+* refine: 17.1.0 updated TreeTime to version 0.9.2 and introduced the `refine` flag `--use-fft`. This makes previously costly marginal date inference cheaper. This update adjusts when `refine` runs marginal date inference during its iterative optimization. Without the `use-fft` flag, it will now behave as it did before 17.1.0 (marginal inference only during final iterations). With the `--use-fft` flag, marginal date inference will be used at every step during the iteration if refine is run with `--date-inference marginal` [#1034][]. (@rneher)
+* tree: When using IQtree as tre builder, `--nthreads` now sets the maximum number of threads (IQtree argument `-ntmax`). The actual number of threads to use can be specified by the user through the tree-builder-arg `-nt` which defaults to `-nt AUTO`, causing IQtree to automatically chose the best number of threads to use [#1042][] (@corneliusroemer)
+* Make cvxopt as a required dependency, since it is required for titer models to work [#1035][]. (@victorlin)
 
 [#1034]: https://github.com/nextstrain/augur/pull/1034
 [#1035]: https://github.com/nextstrain/augur/pull/1035
+[#1042]: https://github.com/nextstrain/augur/pull/1042
 
 ## 17.1.0 (19 August 2022)
 
 ### Features
 
-* refine: Upgrade TreeTime from 0.8.6 to >= 0.9.2 which enables a speedup of timetree inference in marginal mode due to the use of Fast Fourier Transforms [#1018][]. (@rneher and @anna-parker)
+* refine: Upgrade TreeTime from 0.8.6 to >= 0.9.2 which enables a speedup of timetree inference in marginal mode due to the use of Fast Fourier Transforms [#1018][]. (@rneher and @anna-parker). Use the `refine` flag `--use-fft` to use this feature.
 
 ### Bug Fixes
 

--- a/tests/functional/tree.t
+++ b/tests/functional/tree.t
@@ -11,15 +11,6 @@ Try building a tree with IQ-TREE.
   >  --output "$TMP/tree_raw.nwk" \
   >  --nthreads 1 > /dev/null
 
-Try building a tree with IQ-TREE with more threads (4) than there are input sequences (3).
-
-  $ ${AUGUR} tree \
-  >  --alignment tree/aligned.fasta \
-  >  --method iqtree \
-  >  --output "$TMP/tree_raw.nwk" \
-  >  --nthreads 4 > /dev/null
-  WARNING: more threads requested than there are sequences; falling back to IQ-TREE's `-nt AUTO` mode.
-
 Try building a tree with IQ-TREE using its ModelTest functionality, by supplying a substitution model of "auto".
 
   $ ${AUGUR} tree \

--- a/tests/functional/tree.t
+++ b/tests/functional/tree.t
@@ -11,6 +11,14 @@ Try building a tree with IQ-TREE.
   >  --output "$TMP/tree_raw.nwk" \
   >  --nthreads 1 > /dev/null
 
+Try building a tree with IQ-TREE with more threads (4) than there are input sequences (3).
+
+  $ ${AUGUR} tree \
+  >  --alignment tree/aligned.fasta \
+  >  --method iqtree \
+  >  --output "$TMP/tree_raw.nwk" \
+  >  --nthreads 4 > /dev/null
+
 Try building a tree with IQ-TREE using its ModelTest functionality, by supplying a substitution model of "auto".
 
   $ ${AUGUR} tree \


### PR DESCRIPTION
### Description of proposed changes
We used to map augur's `--nthreads` to IQtree's `-nt`. This caused problems as it made it impossible to use IQtree's important `-nt AUTO` option.

IQtree has two thread arguments: `-ntmax` sets the max number of threads, `-nt` sets the actual number of threads to use.

Since adding more threads can slow IQtree down, it's best to set `-nt` to `AUTO` and restrict `-ntmax` instead if one wants to have an upper bound.

With this change, we can set the max number of threads to use with `--nthreads` and IQtree will then choose the optimal number itself, since `-nt AUTO` will be added as default argument, that can be overwritten by an opinionated user. 

### Related issue(s)
Fixes #1041 
Resolves #1037 

### Testing
Tested with current monkeypox workflow and works as expected:

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/25161793/189997109-a36c94e0-e84e-490b-9325-442987a5c311.png">

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
- [x] Test that there's no regression when using more cores than sequences
