### PR TITLE
Mask gap characters

### DIFF
--- a/tests/functional/mask.t
+++ b/tests/functional/mask.t
@@ -35,6 +35,12 @@ Try masking sequences without any specified mask.
   No masking sites provided. Must include one of --mask, --mask-from-beginning, --mask-from-end, --mask-invalid, or --mask-sites
   [1]
 
+Try masking a VCF with a FASTA-only argument
+
+  $ ${AUGUR} mask --sequences mask/variants.vcf.gz --mask-gaps all --mask-sites 1 2 3
+  Cannot use --mask-from-beginning, --mask-from-end, --mask-gaps or --mask-invalid with VCF files!
+  [1]
+
 Mask sequences with a BED file and no specified output file.
 Since no output is provided, the input file is overridden with the masked sequences.
 


### PR DESCRIPTION
This extends `augur mask` to be able to
(a) mask all gaps in all sequences
(b) mask all gaps in sequences which have gaps but no Ns.

A quick scan of 100k SARS-CoV-2 samples (samples over time & geography)
reveals that around a third have gap characters but no Ns. This
indicates bioinformatics pipelines using gap characters to represent
missing data are widespread. Option (b) above is intended to fix this.

The current implementation results in no noticeable slowdown. Testing on
the above 100k data set with our common nCoV pipeline masking parameters
takes ~13s. Masking gap characters doesn't change this.

Closes #1043

Note that our nCoV pipeline uses [a script](https://github.com/nextstrain/ncov/blob/master/scripts/mask-alignment.py) instead of `augur mask`. Looking at this I think the only extra functionality is the ability to mask terminal gaps. This would be trivial to add to `augur mask` (but if we are going to mask all gaps in all sequences then we don't need it). I would suggest adding this as another flag `--mask-terminal-gaps` as it doesn't fit well with `--mask-gaps` in this PR. An alternative would be to change this PR to use `--mask-all-gaps` + `--mask-gaps-if-no-Ns` flags. 🤔 

