### PR TITLE
Fix compatibility with Pandas 1.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,12 @@
 
 * 17.1.0 updated TreeTime to version 0.9.2 and introduced the flag `--use-fft`. This makes previously costly marginal date inference cheaper. This update adjusts when `refine` runs marginal date inference during its iterative optimization. Without the `use-fft` flag, it will now have as it did before 17.1.0 (marginal inference only during final iterations). With the `--use-fft` flag, marginal date inference will be used at every step during the iteration if refine is run with `--date-inference marginal` [#1034][]. (@rneher)
 * Make cvxopt as a required dependency, since it is required for titer models to work [#1035]. (@victorlin)
+* filter: Fix compatibility with Pandas 1.5.0 which could cause an unexpected `AttributeError` with an invalid `--query` given to `augur filter`. [#1050][] (@tsibley)
 
 [#1010]: https://github.com/nextstrain/augur/pull/1010
 [#1034]: https://github.com/nextstrain/augur/pull/1034
 [#1035]: https://github.com/nextstrain/augur/pull/1035
+[#1050]: https://github.com/nextstrain/augur/pull/1050
 
 ## 17.1.0 (19 August 2022)
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -863,7 +863,12 @@ def apply_filters(metadata, exclude_by, include_by):
             )
         except Exception as e:
             if filter_function.__name__ == 'filter_by_query':
-                if isinstance(e, pd.core.computation.ops.UndefinedVariableError):
+                try:
+                    # pandas ≥1.5.0 only
+                    UndefinedVariableError = pd.errors.UndefinedVariableError
+                except AttributeError:
+                    UndefinedVariableError = pd.core.computation.ops.UndefinedVariableError
+                if isinstance(e, UndefinedVariableError):
                     raise AugurError(f"Query contains a column that does not exist in metadata.") from e
                 raise AugurError(f"Error when applying query. Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.") from e
             else:


### PR DESCRIPTION
Pandas 1.5.0 was released earlier this morning and moved an exception class we use.  Routine CI caught this backwards-incompatible change affecting our error handling for `augur filter --query …` evaluation.

I audited for usage of other exceptions moved in the same upstream change (as noted in the release notes) and found none in Augur.

Resolves: <https://github.com/nextstrain/augur/issues/1049>
Related-to: <https://github.com/pandas-dev/pandas/issues/27656>
