### PR TITLE
Fix misplaced changelog entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,16 @@
 
 ## __NEXT__
 
+### Major Changes
+
+* export: The `--node-data` option may now be given multiple times to provide additional `.json` files.  Previously, subsequent occurrences of the option overrode prior occurrences.  This is a **breaking change**, although we expect few usages to be impacted.  Each occurrence of the option may still specify multiple files at a time. [#1010][] (@tsibley)
+
 ### Bug Fixes
 
 * 17.1.0 updated TreeTime to version 0.9.2 and introduced the flag `--use-fft`. This makes previously costly marginal date inference cheaper. This update adjusts when `refine` runs marginal date inference during its iterative optimization. Without the `use-fft` flag, it will now have as it did before 17.1.0 (marginal inference only during final iterations). With the `--use-fft` flag, marginal date inference will be used at every step during the iteration if refine is run with `--date-inference marginal` [#1034][]. (@rneher)
 * Make cvxopt as a required dependency, since it is required for titer models to work [#1035]. (@victorlin)
 
+[#1010]: https://github.com/nextstrain/augur/pull/1010
 [#1034]: https://github.com/nextstrain/augur/pull/1034
 [#1035]: https://github.com/nextstrain/augur/pull/1035
 
@@ -57,7 +62,6 @@
         columns = metadata.columns
         metadata = metadata.to_dict(orient="index")
         ```
-* export: The `--node-data` option may now be given multiple times to provide additional `.json` files.  Previously, subsequent occurrences of the option overrode prior occurrences.  This is a **breaking change**, although we expect few usages to be impacted.  Each occurrence of the option may still specify multiple files at a time. [#1010][] (@tsibley)
 
 ### Features
 
@@ -74,7 +78,6 @@
 [#1002]: https://github.com/nextstrain/augur/pull/1002
 [#1006]: https://github.com/nextstrain/augur/pull/1006
 [#1008]: https://github.com/nextstrain/augur/pull/1008
-[#1010]: https://github.com/nextstrain/augur/pull/1010
 [#1017]: https://github.com/nextstrain/augur/pull/1017
 
 ## 16.0.3 (6 July 2022)


### PR DESCRIPTION
When resolving conflicts prior to merging¹, I didn't notice that the new entry I was adding was now under an already-released version.

¹ https://github.com/nextstrain/augur/pull/1010
