### PR TITLE
Check if metadata is empty after dropping ambiguous dates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* filter: Fixed a bug where `--group-by week` would fail when all samples in a chunk have been dropped due to ambiguous dates. [#1080][] (@victorlin)
+
+[#1080]: https://github.com/nextstrain/augur/pull/1080
 
 ## 18.1.0 (26 October 2022)
 

--- a/augur/filter.py
+++ b/augur/filter.py
@@ -1058,6 +1058,10 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
             metadata.drop([record['strain'] for record in ambiguous_date_strains], inplace=True)
             skipped_strains.extend(ambiguous_date_strains)
 
+            # Check again if metadata is empty after dropping ambiguous dates.
+            if metadata.empty:
+                return group_by_strain, skipped_strains
+
             # Generate columns.
             if 'year' in generated_columns_requested:
                 metadata['year'] = metadata[f'{temp_prefix}year']

--- a/tests/functional/filter/cram/subsample-ambiguous-dates-error.t
+++ b/tests/functional/filter/cram/subsample-ambiguous-dates-error.t
@@ -1,0 +1,88 @@
+Setup
+
+  $ pushd "$TESTDIR" > /dev/null
+  $ source _setup.sh
+
+Metadata with ambiguous days on all strains should error when grouping by week.
+
+  $ cat >$TMP/metadata.tsv <<~~
+  > strain	date
+  > SEQ1	2000-01-XX
+  > SEQ2	2000-02-XX
+  > SEQ3	2000-03-XX
+  > SEQ4	2000-04-XX
+  > ~~
+
+  $ ${AUGUR} filter \
+  >   --metadata $TMP/metadata.tsv \
+  >   --group-by week \
+  >   --sequences-per-group 1 \
+  >   --subsample-seed 0 \
+  >   --output-metadata $TMP/metadata-filtered.tsv \
+  >   --output-log $TMP/filtered_log.tsv
+  ERROR: All samples have been dropped! Check filter rules and metadata file format.
+  4 strains were dropped during filtering
+  \t4 were dropped during grouping due to ambiguous day information (esc)
+  \t0 of these were dropped because of subsampling criteria (esc)
+  [1]
+  $ cat $TMP/filtered_log.tsv | grep "skip_group_by_with_ambiguous_day" | wc -l
+  \s*4 (re)
+  $ cat $TMP/metadata-filtered.tsv
+  strain	date
+  $ rm -f $TMP/filtered_log.tsv $TMP/metadata-filtered.tsv
+
+Metadata with ambiguous months on all strains should error when grouping by month.
+
+  $ cat >$TMP/metadata.tsv <<~~
+  > strain	date
+  > SEQ1	2000-XX-XX
+  > SEQ2	2000-XX-XX
+  > SEQ3	2000-XX-XX
+  > SEQ4	2000-XX-XX
+  > ~~
+
+  $ ${AUGUR} filter \
+  >   --metadata $TMP/metadata.tsv \
+  >   --group-by month \
+  >   --sequences-per-group 1 \
+  >   --subsample-seed 0 \
+  >   --output-metadata $TMP/metadata-filtered.tsv \
+  >   --output-log $TMP/filtered_log.tsv
+  ERROR: All samples have been dropped! Check filter rules and metadata file format.
+  4 strains were dropped during filtering
+  \t4 were dropped during grouping due to ambiguous month information (esc)
+  \t0 of these were dropped because of subsampling criteria (esc)
+  [1]
+  $ cat $TMP/filtered_log.tsv | grep "skip_group_by_with_ambiguous_month" | wc -l
+  \s*4 (re)
+  $ cat $TMP/metadata-filtered.tsv
+  strain	date
+  $ rm -f $TMP/filtered_log.tsv $TMP/metadata-filtered.tsv
+
+Metadata with ambiguous years on all strains should error when grouping by year.
+
+  $ cat >$TMP/metadata.tsv <<~~
+  > strain	date
+  > SEQ1	XXXX-XX-XX
+  > SEQ2	XXXX-XX-XX
+  > SEQ3	XXXX-XX-XX
+  > SEQ4	XXXX-XX-XX
+  > ~~
+
+  $ ${AUGUR} filter \
+  >   --metadata $TMP/metadata.tsv \
+  >   --group-by year \
+  >   --sequences-per-group 1 \
+  >   --subsample-seed 0 \
+  >   --output-metadata $TMP/metadata-filtered.tsv \
+  >   --output-log $TMP/filtered_log.tsv
+  ERROR: All samples have been dropped! Check filter rules and metadata file format.
+  4 strains were dropped during filtering
+  \t4 were dropped during grouping due to ambiguous year information (esc)
+  \t0 of these were dropped because of subsampling criteria (esc)
+  [1]
+  $ cat $TMP/filtered_log.tsv | grep "skip_group_by_with_ambiguous_year" | wc -l
+  \s*4 (re)
+  $ cat $TMP/metadata-filtered.tsv
+  strain	date
+  $ rm -f $TMP/filtered_log.tsv $TMP/metadata-filtered.tsv


### PR DESCRIPTION
### Description of proposed changes

This avoids side effects of working with an empty DataFrame. Subsequent lines to compute `group_by_strain` are unnecessary anyways since there won't be any strains to group when the metadata is empty.

### Related issue(s)

Fixes #1079

### Testing


- [x] Checks pass
- [x] Added test in cd4ccef79856ff771c3ddbb3df50412d8d24557b

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
