### PR TITLE
Print warnings if alignment names will be changed by IQtree

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -2,7 +2,6 @@
 Build a tree using a variety of methods.
 """
 
-from glob import escape
 import os
 import shlex
 import shutil

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -239,13 +239,12 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
                     #check if l is a character that IQ-tree changes
                     if l.isalnum()==False and l !='_' and l != '-' and l != '.' and l !='\n':
                         if l not in escape_dict: #characters outside of escape dictionary might not be properly handled in treetime 
-                            print("WARNING: Offending character: \'%s\' detected in taxon name: %s Replacing character with '_'. " 
-                                "To avoid issues downstream replace offending characters with '_' in alignment file."
+                            print("WARNING: Potentially offending character: \'%s\' detected in taxon name: %s" 
+                                "We recommend replacing offending characters with '_' in the alignment file to avoid issues downstream."
                                 % (l, format(line))
                             )
-                            tmp_line = tmp_line[:pos] + '_' + line[(i+1):]  # replace offending characters
-                            pos = pos + 1
-                        else:
+                            escape_dict[l] = f'_{prefix}-{random_string(20)}_'
+                            reverse_escape_dict[escape_dict[l]] = l
                             tmp_line = tmp_line[:pos] + escape_dict[l] + line[(i+1):]  # replace offending characters
                             pos = pos + len(escape_dict[l])
                     else:

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -2,6 +2,7 @@
 Build a tree using a variety of methods.
 """
 
+from glob import escape
 import os
 import shlex
 import shutil
@@ -232,8 +233,23 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
             tmp_line = line
             if line.startswith(">"):
                 num_seqs += 1
-                for c,v in escape_dict.items():
-                    tmp_line = tmp_line.replace(c,v)
+                pos = 1
+                for i in range(1, len(line)):
+                    l = line[i]
+                    #check if l is a character that IQ-tree changes
+                    if l.isalnum()==False and l !='_' and l != '-' and l != '.' and l !='\n':
+                        if l not in escape_dict: #characters outside of escape dictionary might not be properly handled in treetime 
+                            print("WARNING: Offending character: \'%s\' detected in taxon name: %s Replacing character with '_'. " 
+                                "To avoid issues downstream replace offending characters with '_' in alignment file."
+                                % (l, format(line))
+                            )
+                            tmp_line = tmp_line[:pos] + '_' + line[(i+1):]  # replace offending characters
+                            pos = pos + 1
+                        else:
+                            tmp_line = tmp_line[:pos] + escape_dict[l] + line[(i+1):]  # replace offending characters
+                            pos = pos + len(escape_dict[l])
+                    else:
+                        pos += 1
 
             ofile.write(tmp_line)
 


### PR DESCRIPTION
### Description of proposed changes
IQtree changes "offending characters" in alignment names to a `'_'` character. Offending characters are defined in: https://github.com/Cibiv/IQ-TREE/blob/6776a95f15a2eccda2aa330497291dc246575995/utils/tools.cpp#L503 (i.e. if the character is not alphanumeric and not in '.', '-' or '_') . Currently, augur will make sure that the offending characters `'/|()*'` are not modified, however all other offending characters will be modified by IQtree. IQtree writes all modifications to a `.log` file. This is not conveyed to the user and alignment information can no longer be used when iterating over the tree. 

I extend augur's current technique for not modifying `'/|()*`' to not modify any offending character. However, treetime might not be able to handle all offending characters. (For example `treetime`'s alignment module reports that `"'"` and `"\'"` are not equivalent - I am not quite sure why -and even if an alignment name with a `'` is not modified the alignment information still cannot be used downstream, for example by `refine`). For offending characters outside of  `'/|()*'` print a warning and a recommendation to change the character to `'_'` to avoid later issues. 

![image](https://user-images.githubusercontent.com/50943381/199219541-a2a57f51-ba53-4c60-b10a-257d0ca45d0f.png)


### Related issue(s)
https://github.com/nextstrain/augur/issues/1084

### Testing
Modify a sequence name in an alignment file to include an offending character, such as `,@$`, run 
```
augur tree --alignment modified.fasta --tree-builder-args '-ninit 10 -n 4' --output tree_modified.nwk --nthreads 1
```
Check error warning and node names in `tree_modified.nwk`. 