### PR TITLE
Bump xopen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ setuptools.setup(
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",
         "phylo-treetime >=0.9.3, ==0.9.*",
-        "xopen >=1.0.1, ==1.*",
-        "pyfastx >=0.8.4, ==0.8.*"
+        "pyfastx >=0.8.4, ==0.8.*",
+        "xopen[zstd] >=1.7.0, ==1.*"
     ],
     extras_require = {
         'dev': [

--- a/tests/io/test_file.py
+++ b/tests/io/test_file.py
@@ -45,7 +45,7 @@ class TestFile:
         with augur.io.file.open_file(path) as f_read:
             assert f_read.read() == 'foo\nbar\n'
 
-    def test_open_file_read_lzma(self, tmpdir):
+    def test_open_file_write_lzma(self, tmpdir):
         """Write a text file compressed with LZMA."""
         import lzma
         path = str(tmpdir / 'test.txt.xz')

--- a/tests/io/test_file.py
+++ b/tests/io/test_file.py
@@ -53,3 +53,21 @@ class TestFile:
             f_write.write('foo\nbar\n')
         with lzma.open(path, 'rt') as f_read:
             assert f_read.read() == 'foo\nbar\n'
+
+    def test_open_file_read_zstd(self, tmpdir):
+        """Read a text file compressed with zstd."""
+        import zstandard as zstd
+        path = str(tmpdir / 'test.txt.zst')
+        with zstd.open(path, 'wt') as f_write:
+            f_write.write('foo\nbar\n')
+        with augur.io.file.open_file(path) as f_read:
+            assert f_read.read() == 'foo\nbar\n'
+
+    def test_open_file_write_zstd(self, tmpdir):
+        """Write a text file compressed with zstd."""
+        import zstandard as zstd
+        path = str(tmpdir / 'test.txt.zst')
+        with augur.io.file.open_file(path, 'w') as f_write:
+            f_write.write('foo\nbar\n')
+        with zstd.open(path, 'rt') as f_read:
+            assert f_read.read() == 'foo\nbar\n'


### PR DESCRIPTION
### Description of proposed changes
Support reading/writing zstd compressed files by bumping xopen to 1.7.0 and including the extra `zstd` dependency. 

### Related issue(s)
Resolves #1073 

### Testing
Added functional tests for reading/writing zstd compressed files with `augur.io.files.open_file`. 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
