### PR TITLE
Update PR template changelog checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,4 @@ If you added or changed behavior in the codebase, did you update the tests, or d
 
 ### Checklist
 
-- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.
+- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.


### PR DESCRIPTION
Creating this PR for discussion around the idea that we should keep the changelog as end user focused changes only. 

Motivated by @tsibley's [recent comment](https://github.com/nextstrain/augur/pull/1039#discussion_r1014473787): 
> a changelog for something like Augur is (IMO) best viewed/used as a document for end users.