### PR TITLE
doc: Switch order of export v1 and v2 to make v2 show up first in docs

### DIFF
--- a/augur/export.py
+++ b/augur/export.py
@@ -5,8 +5,8 @@ from .argparse_ import add_command_subparsers
 from . import export_v1, export_v2
 
 SUBCOMMANDS = [
-    export_v1,
     export_v2,
+    export_v1,
 ]
 
 


### PR DESCRIPTION
### Description of proposed changes

Resolves #1090 

It works, it puts v2 at the top, which makes sense given that everyone uses v2 now.

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/25161793/200443415-322984fb-65cf-4937-acc5-b14d6097ab6f.png">

https://nextstrain--1092.org.readthedocs.build/projects/augur/en/1092/usage/cli/export.html#augur-export
