### PR TITLE
Replace FilterException with AugurError

### DIFF
--- a/augur/filter.py
+++ b/augur/filter.py
@@ -108,12 +108,6 @@ def register_parser(parent_subparsers):
     return parser
 
 
-class FilterException(AugurError):
-    """Representation of an error that occurred during filtering.
-    """
-    pass
-
-
 def read_priority_scores(fname):
     def constant_factory(value):
         return lambda: value
@@ -960,7 +954,7 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     >>> get_groups_for_subsampling(strains, metadata, group_by)
     Traceback (most recent call last):
       ...
-    augur.filter.FilterException: The specified group-by categories (['missing_column']) were not found.
+    augur.errors.AugurError: The specified group-by categories (['missing_column']) were not found.
 
     If we try to group by some columns that exist and some that don't, we allow
     grouping to continue and print a warning message to stderr.
@@ -1008,9 +1002,9 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
 
     # If we could not find any requested categories, we cannot complete subsampling.
     if 'date' not in metadata and group_by_set <= GROUP_BY_GENERATED_COLUMNS:
-        raise FilterException(f"The specified group-by categories ({group_by}) were not found. Note that using any of {sorted(GROUP_BY_GENERATED_COLUMNS)} requires a column called 'date'.")
+        raise AugurError(f"The specified group-by categories ({group_by}) were not found. Note that using any of {sorted(GROUP_BY_GENERATED_COLUMNS)} requires a column called 'date'.")
     if not group_by_set & (set(metadata.columns) | GROUP_BY_GENERATED_COLUMNS):
-        raise FilterException(f"The specified group-by categories ({group_by}) were not found.")
+        raise AugurError(f"The specified group-by categories ({group_by}) were not found.")
 
     # Warn/error based on other columns grouped with 'week'.
     if 'week' in group_by_set:

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -15,7 +15,7 @@ from freezegun import freeze_time
 
 import augur.filter
 from augur.io.metadata import read_metadata
-from augur.filter import FilterException
+from augur.errors import AugurError
 
 @pytest.fixture
 def argparser():
@@ -391,7 +391,7 @@ class TestFilterGroupBy:
         groups = ['invalid']
         metadata = valid_metadata.copy()
         strains = metadata.index.tolist()
-        with pytest.raises(FilterException) as e_info:
+        with pytest.raises(AugurError) as e_info:
             augur.filter.get_groups_for_subsampling(strains, metadata, group_by=groups)
         assert str(e_info.value) == "The specified group-by categories (['invalid']) were not found."
 
@@ -471,7 +471,7 @@ class TestFilterGroupBy:
         metadata = valid_metadata.copy()
         metadata = metadata.drop('date', axis='columns')
         strains = metadata.index.tolist()
-        with pytest.raises(FilterException) as e_info:
+        with pytest.raises(AugurError) as e_info:
             augur.filter.get_groups_for_subsampling(strains, metadata, group_by=groups)
         assert str(e_info.value) == "The specified group-by categories (['year']) were not found. Note that using any of ['month', 'week', 'year'] requires a column called 'date'."
 
@@ -480,7 +480,7 @@ class TestFilterGroupBy:
         metadata = valid_metadata.copy()
         metadata = metadata.drop('date', axis='columns')
         strains = metadata.index.tolist()
-        with pytest.raises(FilterException) as e_info:
+        with pytest.raises(AugurError) as e_info:
             augur.filter.get_groups_for_subsampling(strains, metadata, group_by=groups)
         assert str(e_info.value) == "The specified group-by categories (['month']) were not found. Note that using any of ['month', 'week', 'year'] requires a column called 'date'."
 
@@ -489,7 +489,7 @@ class TestFilterGroupBy:
         metadata = valid_metadata.copy()
         metadata = metadata.drop('date', axis='columns')
         strains = metadata.index.tolist()
-        with pytest.raises(FilterException) as e_info:
+        with pytest.raises(AugurError) as e_info:
             augur.filter.get_groups_for_subsampling(strains, metadata, group_by=groups)
         assert str(e_info.value) == "The specified group-by categories (['year', 'month']) were not found. Note that using any of ['month', 'week', 'year'] requires a column called 'date'."
 


### PR DESCRIPTION
### Description of proposed changes

FilterException is not handled exclusively. Instead, these errors are being handled by the top-level AugurError handler.

For that reason, FilterException is an unnecessary piece of complexity that can be removed.

### Related issue(s)

Related to https://github.com/nextstrain/augur/pull/1039#discussion_r998581030

### Testing

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR. Keep headers and formatting consistent with the rest of the file.~ N/A, internal change.
