### PR TITLE
Export zero value colors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,10 @@
 
 * docs: Update the API documentation to reflect the latest state of things in the codebase. [#1087][] (@victorlin)
 * Fix support for Biopython version 1.80 which deprecated `Bio.Seq.Seq.ungap()`. [#1102][] (@victorlin)
+* export v2: Fixed a bug where colorings for zero values via `--colors` would not get applied to the exported Auspice JSON. [#1100][] (@joverlee521)
 
 [#1087]: https://github.com/nextstrain/augur/pull/1087
+[#1100]: https://github.com/nextstrain/augur/pull/1100
 [#1102]: https://github.com/nextstrain/augur/pull/1102
 
 ## 18.2.0 (15 November 2022)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -182,7 +182,7 @@ def update_deprecated_names(name):
 def get_values_across_nodes(node_attrs, key):
     vals = set()
     for data in node_attrs.values():
-        if data.get(key):
+        if is_valid(data.get(key)):
             vals.add(data.get(key))
     return vals
 

--- a/tests/functional/export_v2.t
+++ b/tests/functional/export_v2.t
@@ -151,4 +151,19 @@ Check the output from the above command against its expected contents
   >   --exclude-paths "root['meta']['updated']"
   {}
 
+Run export with metadata and external colors TSV that contains zero values.
+  $ ${AUGUR} export v2 \
+  >   --tree export_v2/tree.nwk \
+  >   --node-data export_v2/div_node-data.json export_v2/location_node-data.json \
+  >   --auspice-config export_v2/auspice_config4.json \
+  >   --metadata export_v2/zero_value_metadata.tsv \
+  >   --colors export_v2/zero_value_colors.tsv \
+  >   --output "$TMP/dataset6.json" &> /dev/null
+
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" export_v2/dataset3.json "$TMP/dataset6.json" \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+  $ rm -f "$TMP/dataset6.json"
+
+
   $ popd > /dev/null

--- a/tests/functional/export_v2.t
+++ b/tests/functional/export_v2.t
@@ -143,8 +143,9 @@ Skipping validation allows mismatched augur versions to be used without error.
   >   --output "$TMP/dataset5.json" \
   >   --skip-validation
   WARNING: You didn't provide information on who is maintaining this analysis.
-  
-  
+  \s{0} (re)
+  \s{0} (re)
+
 Check the output from the above command against its expected contents
   $ python3 "$TESTDIR/../../scripts/diff_jsons.py"  export_v2/dataset2.json "$TMP/dataset5.json" \
   >   --exclude-paths "root['meta']['updated']"

--- a/tests/functional/export_v2/auspice_config4.json
+++ b/tests/functional/export_v2/auspice_config4.json
@@ -1,0 +1,41 @@
+{
+  "colorings": [
+    {
+      "key": "location",
+      "title": "Location",
+      "type": "categorical",
+      "legend": [
+          {"value": "alpha", "display": "α"},
+          {"value": "beta"}
+      ],
+      "scale": [
+          ["beta", "#bd0026"],
+          ["gamma", "#6a51a3"]
+      ]
+    },
+    {
+      "key": "mutation_length",
+      "title": "Mutations per branch",
+      "type": "continuous",
+      "legend": [
+          {"value": 1, "display": "0-2", "bounds": [-1,2]},
+          {"value": 3, "display": "3-5", "bounds": [2,5]},
+          {"value": 5, "display": ">5", "bounds": [5, 10]}
+      ],
+      "scale": [
+          [1, "#081d58"],
+          [3, "#1d91c0"],
+          [5, "#c7e9b4"]
+      ]
+    },
+    {
+      "key": "zero_value",
+      "title": "Zero",
+      "type": "ordinal"
+    }
+  ],
+  "filters": [
+    "location",
+    "zero_value"
+  ]
+}

--- a/tests/functional/export_v2/dataset3.json
+++ b/tests/functional/export_v2/dataset3.json
@@ -1,0 +1,245 @@
+{
+  "version": "v2",
+  "meta": {
+    "updated": "2022-11-16",
+    "colorings": [
+      {
+        "key": "location",
+        "title": "Location",
+        "type": "categorical",
+        "scale": [
+          [
+            "beta",
+            "#bd0026"
+          ],
+          [
+            "gamma",
+            "#6a51a3"
+          ]
+        ],
+        "legend": [
+          {
+            "value": "alpha",
+            "display": "\u03b1"
+          },
+          {
+            "value": "beta"
+          }
+        ]
+      },
+      {
+        "key": "mutation_length",
+        "title": "Mutations per branch",
+        "type": "continuous",
+        "scale": [
+          [
+            1,
+            "#081d58"
+          ],
+          [
+            3,
+            "#1d91c0"
+          ],
+          [
+            5,
+            "#c7e9b4"
+          ]
+        ],
+        "legend": [
+          {
+            "value": 1,
+            "display": "0-2",
+            "bounds": [
+              -1,
+              2
+            ]
+          },
+          {
+            "value": 3,
+            "display": "3-5",
+            "bounds": [
+              2,
+              5
+            ]
+          },
+          {
+            "value": 5,
+            "display": ">5",
+            "bounds": [
+              5,
+              10
+            ]
+          }
+        ]
+      },
+      {
+        "key": "zero_value",
+        "title": "Zero",
+        "type": "ordinal",
+        "scale": [
+          [
+            0,
+            "#4042C7"
+          ]
+        ]
+      },
+      {
+        "key": "location",
+        "title": "Location",
+        "type": "categorical",
+        "scale": [
+          [
+            "beta",
+            "#bd0026"
+          ],
+          [
+            "gamma",
+            "#6a51a3"
+          ]
+        ],
+        "legend": [
+          {
+            "value": "alpha",
+            "display": "\u03b1"
+          },
+          {
+            "value": "beta"
+          }
+        ]
+      }
+    ],
+    "filters": [
+      "location",
+      "zero_value"
+    ],
+    "panels": [
+      "tree"
+    ]
+  },
+  "tree": {
+    "name": "ROOT",
+    "node_attrs": {
+      "div": 0,
+      "mutation_length": {
+        "value": 0
+      }
+    },
+    "branch_attrs": {},
+    "children": [
+      {
+        "name": "tipA",
+        "node_attrs": {
+          "div": 1,
+          "mutation_length": {
+            "value": 1
+          },
+          "location": {
+            "value": "delta"
+          },
+          "zero_value": {
+            "value": 0
+          }
+        },
+        "branch_attrs": {}
+      },
+      {
+        "name": "internalBC",
+        "node_attrs": {
+          "div": 2,
+          "mutation_length": {
+            "value": 2
+          }
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipB",
+            "node_attrs": {
+              "div": 3,
+              "mutation_length": {
+                "value": 1
+              },
+              "location": {
+                "value": "gamma"
+              },
+              "zero_value": {
+                "value": 0
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipC",
+            "node_attrs": {
+              "div": 3,
+              "mutation_length": {
+                "value": 1
+              },
+              "location": {
+                "value": "gamma"
+              },
+              "zero_value": {
+                "value": 0
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      },
+      {
+        "name": "internalDEF",
+        "node_attrs": {
+          "div": 5,
+          "mutation_length": {
+            "value": 5
+          },
+          "location": {
+            "value": "alpha"
+          }
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipD",
+            "node_attrs": {
+              "div": 8,
+              "mutation_length": {
+                "value": 3
+              },
+              "location": {
+                "value": "alpha"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipE",
+            "node_attrs": {
+              "div": 9,
+              "mutation_length": {
+                "value": 4
+              },
+              "location": {
+                "value": "alpha"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipF",
+            "node_attrs": {
+              "div": 6,
+              "mutation_length": {
+                "value": 1
+              },
+              "location": {
+                "value": "beta"
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/functional/export_v2/zero_value_colors.tsv
+++ b/tests/functional/export_v2/zero_value_colors.tsv
@@ -1,0 +1,1 @@
+zero_value	0	#4042C7

--- a/tests/functional/export_v2/zero_value_metadata.tsv
+++ b/tests/functional/export_v2/zero_value_metadata.tsv
@@ -1,0 +1,4 @@
+name	zero_value
+tipA	0
+tipB	0
+tipC	0


### PR DESCRIPTION
### Description of proposed changes

Falsy values were previously excluded from the node values in `get_values_across_nodes` even if they
are valid node values (e.g. zero values). This PR updates the falsy value check to a valid value check to include these values.

This fixes a bug reported via the [discussion board](https://discussion.nextstrain.org/t/zero-value-for-coloring-in-nextstrain/1266) where a zero value in
a colors TSV was not being properly applied to the exported JSON.

### Testing
Added functional test for exporting colors for zero values. 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
