### PR TITLE
Add "livehtml" make target using sphinx-autobuild

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,3 +17,6 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+livehtml:
+	sphinx-autobuild -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -303,6 +303,12 @@ Build the HTML output format by running:
 make -C docs html
 ```
 
+To monitor the source files for changes and automatically rebuild as necessary, run:
+
+```bash
+make -C docs livehtml
+```
+
 Sphinx can build other formats, such as epub. To see other available formats, run:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
             "recommonmark >=0.5.0",
             "snakemake >=5.4.0",
             "Sphinx >=2.0.1",
+            "sphinx-autobuild >=2021.3.14",
             "sphinx-argparse >=0.2.5",
             "sphinx-markdown-tables >= 0.0.9",
             "sphinx-rtd-theme >=0.4.3",


### PR DESCRIPTION
### Description of proposed changes

Super handy for edit/preview cycles in dev.

Originally from https://github.com/nextstrain/docs.nextstrain.org/commit/2598f4e18ed79a357f0f3ac4b11f9a234fe9fa76

Pin of sphinx-autobuild >=2021.3.14 (latest version) is only there since other dev dependencies are pinned. Older versions should work too.

### Related issue(s)

_N/A_

### Testing

- [x] `make livehtml` works locally

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, dev change.
