### PR TITLE
Fix Biopython deprecation warning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,10 @@
 ### Bug Fixes
 
 * docs: Update the API documentation to reflect the latest state of things in the codebase. [#1087][] (@victorlin)
+* Fix support for Biopython version 1.80 which deprecated `Bio.Seq.Seq.ungap()`. [#1102][] (@victorlin)
 
 [#1087]: https://github.com/nextstrain/augur/pull/1087
+[#1102]: https://github.com/nextstrain/augur/pull/1102
 
 ## 18.2.0 (15 November 2022)
 

--- a/augur/align.py
+++ b/augur/align.py
@@ -337,7 +337,11 @@ def analyse_insertions(aln, ungapped, insertion_csv):
     insertions = [defaultdict(list) for ins in insertion_coords]
     for idx, insertion_coord in enumerate(insertion_coords):
         for seq in aln:
-            s = seq[insertion_coord[0]:insertion_coord[1]].seq.ungap("-").ungap("N").ungap("?")
+            s = (seq[insertion_coord[0]:insertion_coord[1]].seq
+                .ungap("-")
+                .ungap("N")
+                .ungap("?")
+            )
             if len(s):
                 insertions[idx][str(s)].append(seq.name)
 

--- a/augur/align.py
+++ b/augur/align.py
@@ -337,11 +337,20 @@ def analyse_insertions(aln, ungapped, insertion_csv):
     insertions = [defaultdict(list) for ins in insertion_coords]
     for idx, insertion_coord in enumerate(insertion_coords):
         for seq in aln:
-            s = (seq[insertion_coord[0]:insertion_coord[1]].seq
-                .ungap("-")
-                .ungap("N")
-                .ungap("?")
-            )
+            try:
+                # biopython>=1.80 does not have seq.ungap()
+                s = (seq[insertion_coord[0]:insertion_coord[1]].seq
+                    .replace("-", "")
+                    .replace("N", "")
+                    .replace("?", "")
+                )
+            except AttributeError:
+                # biopython<1.79 does not have seq.replace()
+                s = (seq[insertion_coord[0]:insertion_coord[1]].seq
+                    .ungap("-")
+                    .ungap("N")
+                    .ungap("?")
+                )
             if len(s):
                 insertions[idx][str(s)].append(seq.name)
 


### PR DESCRIPTION
### Description of proposed changes

CI is [failing](https://github.com/nextstrain/augur/actions/runs/3517256850/jobs/5894814001) with the latest Biopython release.

> BiopythonDeprecationWarning: myseq.ungap(gap) is deprecated; please use myseq.replace(gap, "") instead.

This PR applies the recommendation while retaining support for older Biopython versions.

### Related issue(s)

_N/A_

### Testing

- [x] Checks pass

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
