### PR TITLE
Try using titers with values below threshold

### DIFF
--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -74,6 +74,10 @@ class TiterCollection(object):
                         val = float(entries[4])
                     except:
                         continue
+                        if entries[4].startswith("<") and len(entries[4]) > 1:
+                            val = float(entries[4][1:]) / 2.0
+                        else:
+                            continue
                     test, ref_virus, serum, src_id = (entries[0], entries[1],entries[2],
                                                       entries[3])
 


### PR DESCRIPTION
## Description of proposed changes
Attempts to include more titer data into models by detecting measurement values that are below a given threshold (e.g., "<40") and converting those values to a reasonable numerical value that is one two-fold dilution value less than the threshold (e.g., 20, in the example above). This change allows us to at least include these values in our titer models and the measurements panel, so we have a complete picture of all the data available. If this general approach makes sense, we might consider a similar approach for values _above_ a given threshold, too.

## Testing

 - [ ] Add functional tests
 - [ ] Confirm functional tests pass CI

## Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
