### PR TITLE
Invalid none key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## __NEXT__
 
+### Major Changes
+
+* export v2: The string "none" is now an invalid value for `--color-by-metadata` and `--metadata-columns` options and will be ignored to prevent clashes with Auspice's internal use of "none". [#1113][] (@joverlee521)
+* schema: The string "none" is now an invalid branch label, node_attr key, and coloring key. [#1113][] (@joverlee521)
+
+[#1113]: https://github.com/nextstrain/augur/pull/1113
 
 ## 27.2.0 (22 January 2025)
 

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -22,7 +22,8 @@
                 "properties": {
                     "key": {
                         "description": "They key used to access the value of this coloring on each node",
-                        "type": "string"
+                        "type": "string",
+                        "not": {"const": "none"}
                     },
                     "title": {
                         "description": "Text to be displayed in the \"color by\" dropdown and legends",
@@ -265,7 +266,7 @@
             "$comment": "These columns will not be used as coloring options in Auspice but will be visible in the tree.",
             "type": "array",
             "uniqueItems": true,
-            "items": {"type": "string"}
+            "items": {"type": "string", "not": {"const": "none"}}
         },
         "extensions": {
             "description": "Data to be passed through to the the resulting dataset JSON",

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -281,7 +281,8 @@
                                     "type": "number"
                                 }
                             }
-                        }
+                        },
+                        "^none$": false
                     }
                 },
                 "branch_attrs": {
@@ -296,7 +297,8 @@
                                     "$comment": "e.g. clade->3c3a",
                                     "$comment": "string is parsed unchanged by Auspice",
                                     "type": "string"
-                                }
+                                },
+                                "^none$": false
                             }
                         },
                         "mutations": {

--- a/tests/functional/export_v2/cram/metadata-with-none-column.t
+++ b/tests/functional/export_v2/cram/metadata-with-none-column.t
@@ -1,0 +1,39 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Run export with metadata that contains "none" column and asked to use as coloring.
+This is expected to output a warning that "none" is an invalid coloring column and skip it in colorings.
+
+  $ ${AUGUR} export v2 \
+  >   --tree "$TESTDIR/../data/tree.nwk" \
+  >   --node-data "$TESTDIR/../data/div_node-data.json" "$TESTDIR/../data/location_node-data.json" \
+  >   --metadata "$TESTDIR/../data/none_column_metadata.tsv" \
+  >   --color-by-metadata "none" \
+  >   --maintainers "Nextstrain Team" \
+  >   --output dataset1.json >/dev/null
+  WARNING: You asked for a color-by for trait 'none', but this is an invalid coloring key.
+  It will be ignored during export, please rename field if you would like to use it as a coloring.
+  \s{0} (re)
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-without-none-column.json" dataset1.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+
+Run export with metadata that contains "none" column and asked to use as metadata.
+This is expected to output a warning that "none" is an invalid node_attr and skip it in metadata.
+
+  $ ${AUGUR} export v2 \
+  >   --tree "$TESTDIR/../data/tree.nwk" \
+  >   --node-data "$TESTDIR/../data/div_node-data.json" "$TESTDIR/../data/location_node-data.json" \
+  >   --metadata "$TESTDIR/../data/none_column_metadata.tsv" \
+  >   --metadata-column "none" \
+  >   --maintainers "Nextstrain Team" \
+  >   --output dataset2.json >/dev/null
+  WARNING: You asked for a metadata field 'none', but this is an invalid field.
+  It will be ignored during export, please rename field if you would like to include as a metadata field.
+  \s{0} (re)
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-without-none-column.json" dataset2.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}

--- a/tests/functional/export_v2/data/dataset-without-none-column.json
+++ b/tests/functional/export_v2/data/dataset-without-none-column.json
@@ -1,0 +1,114 @@
+{
+  "version": "v2",
+  "meta": {
+    "updated": "2025-01-13",
+    "maintainers": [
+      {
+        "name": "Nextstrain Team"
+      }
+    ],
+    "colorings": [
+      {
+        "key": "location",
+        "title": "location",
+        "type": "categorical"
+      }
+    ],
+    "filters": [
+      "location"
+    ],
+    "panels": [
+      "tree"
+    ]
+  },
+  "tree": {
+    "name": "ROOT",
+    "node_attrs": {
+      "div": 0
+    },
+    "branch_attrs": {},
+    "children": [
+      {
+        "name": "tipA",
+        "node_attrs": {
+          "div": 1,
+          "location": {
+            "value": "delta"
+          }
+        },
+        "branch_attrs": {}
+      },
+      {
+        "name": "internalBC",
+        "node_attrs": {
+          "div": 2
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipB",
+            "node_attrs": {
+              "div": 3,
+              "location": {
+                "value": "gamma"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipC",
+            "node_attrs": {
+              "div": 3,
+              "location": {
+                "value": "gamma"
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      },
+      {
+        "name": "internalDEF",
+        "node_attrs": {
+          "div": 5,
+          "location": {
+            "value": "alpha"
+          }
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipD",
+            "node_attrs": {
+              "div": 8,
+              "location": {
+                "value": "alpha"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipE",
+            "node_attrs": {
+              "div": 9,
+              "location": {
+                "value": "alpha"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipF",
+            "node_attrs": {
+              "div": 6,
+              "location": {
+                "value": "beta"
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/functional/export_v2/data/none_column_metadata.tsv
+++ b/tests/functional/export_v2/data/none_column_metadata.tsv
@@ -1,0 +1,4 @@
+name	none
+tipA	true
+tipB	true
+tipC	true


### PR DESCRIPTION
### Description of proposed changes
- Updates the export v2 schema to make "none" an invalid key for colorings and branch labels. 
- Updates `export v2` to warn about invalid "none" key and ignore it in exports. 
- Does _not_ include changes in `export v2` for branch labels to ignore the "none" key because it is currently hard-coded to only export "clades" and "aa" as branch labels. We should ignore "none" keys for branch labels once we allow for arbitrary labels in #728.


### Related issue(s)
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Related to https://github.com/nextstrain/auspice/pull/1618

### Testing
* Added new functional test for export v2 using a "none" coloring key.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
