### PR TITLE
Update release docs

### DIFF
--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -187,6 +187,13 @@ Versions for this project, Augur, from 3.0.0 onwards aim to follow the
     2. In **New version X.X.X**, provide the new version number.
     3. Select **Run workflow**.
 3. Ensure workflow runs successfully.
+    - Ensure the [docker-base CI action triggered by nextstrain-bot](https://github.com/nextstrain/docker-base/actions/workflows/ci.yml?query=branch%3Amaster+actor%3Anextstrain-bot) runs successfully.
+4. Create a [new GitHub release](https://github.com/nextstrain/augur/releases/new).
+    1. Choose the tag for the new version number.
+    2. In **Release title**, provide the new version number.
+    3. In **Describe this release**, copy over changes for this new version from [CHANGES.md](../../CHANGES.md).
+    4. Ensure **Set as the latest release** is checked.
+    5. Publish release.
 
 ##### 4. Update on Bioconda
 
@@ -208,6 +215,13 @@ For versions with dependency changes:
 5. Add a comment in the auto-bump PR `Please close this in favor of #<your PR number>`.
 
 [bioconda-recipes]: https://github.com/bioconda/bioconda-recipes/pull/34509
+
+##### 5. Build/Release Nextstrain/conda-base
+
+1. Wait for the bioconda-recipe PR to be merged.
+2. Wait for the new version of Augur to be available in on bioconda.
+3. Manually run the [conda-base CI workflow](https://github.com/nextstrain/conda-base/actions/workflows/ci.yaml) on the `master` branch.
+4. Ensure workflow runs successfully.
 
 #### Notes
 


### PR DESCRIPTION
Add in steps for release that are not completely automated yet based on my experience with the last two releases of Augur.

Related to 

- https://github.com/nextstrain/augur/pull/957
- https://github.com/nextstrain/conda-base/issues/2