### PR TITLE
Set numpy and scipy as direct dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,12 @@
 * filter: Standardize exit codes from internal error handling. [#931][] (@victorlin)
 * tree: Suppress the `Cannot specify --substitution-model unless using IQTree` warning when `--substitution-model` is left at its default. [#1127][] (@tsibley)
 * tree: Print the underlying error message when tree building fails. [#1127][] (@tsibley)
+* Previously, `numpy` and `scipy` were installed as dependencies of dependencies. Mark them as direct dependencies since they are used directly within Augur. [#1120][] (@victorlin)
 
 [#931]: https://github.com/nextstrain/augur/pull/931
 [#1118]: https://github.com/nextstrain/augur/pull/1118
 [#1119]: https://github.com/nextstrain/augur/pull/1119
+[#1120]: https://github.com/nextstrain/augur/pull/1120
 [#1127]: https://github.com/nextstrain/augur/pull/1127
 
 ## 19.2.0 (19 December 2022)

--- a/setup.py
+++ b/setup.py
@@ -57,10 +57,12 @@ setuptools.setup(
         "isodate ==0.6.*",
         "jsonschema >=3.0.0, ==3.*",
         "networkx >= 2.5, ==2.*",
+        "numpy ==1.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",
         "phylo-treetime >=0.9.3, ==0.9.*",
         "pyfastx >=0.8.4, ==0.8.*",
+        "scipy ==1.*",
         "xopen[zstd] >=1.7.0, ==1.*"
     ],
     extras_require = {


### PR DESCRIPTION
### Description of proposed changes

These are currently installed as dependencies of dependencies. Since they are directly imported in this codebase, they should be direct dependencies with pinned versions.

### Testing

- [x] Checks pass

### Release tasks

- [ ] For the bioconda update, add numpy and scipy as dependencies in the [augur recipe](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/augur/meta.yaml).

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.