### PR TITLE
CI: Ignore scipy warnings

### DIFF
--- a/tests/builds/zika.t
+++ b/tests/builds/zika.t
@@ -86,7 +86,7 @@ Build a time tree from the existing tree topology, the multiple sequence alignme
   >  --date-confidence \
   >  --date-inference marginal \
   >  --clock-filter-iqd 4 \
-  >  --seed 314159 > /dev/null
+  >  --seed 314159 &> /dev/null
 
 Confirm that TreeTime trees match expected topology and branch lengths.
 

--- a/tests/functional/refine.t
+++ b/tests/functional/refine.t
@@ -16,7 +16,7 @@ Try building a time tree.
   >  --date-confidence \
   >  --date-inference marginal \
   >  --clock-filter-iqd 4 \
-  >  --seed 314159 > /dev/null
+  >  --seed 314159 &> /dev/null
 
 Confirm that TreeTime trees match expected topology and branch lengths.
 
@@ -37,7 +37,7 @@ Build a time tree with mutations as the reported divergence unit.
   >  --date-inference marginal \
   >  --clock-filter-iqd 4 \
   >  --seed 314159 \
-  >  --divergence-units mutations > /dev/null
+  >  --divergence-units mutations &> /dev/null
 
 Confirm that TreeTime trees match expected topology and branch lengths.
 
@@ -57,7 +57,7 @@ This is one way to get named internal nodes for downstream analyses and does not
   >  --date-inference marginal \
   >  --clock-filter-iqd 4 \
   >  --seed 314159 \
-  >  --divergence-units mutations-per-site > /dev/null
+  >  --divergence-units mutations-per-site &> /dev/null
 
 Confirm that trees match expected topology and branch lengths, given that the output should not be a time tree.
 
@@ -80,7 +80,7 @@ This approach only works when we provide an alignment FASTA.
   >  --date-inference marginal \
   >  --clock-filter-iqd 4 \
   >  --seed 314159 \
-  >  --divergence-units mutations > /dev/null
+  >  --divergence-units mutations &> /dev/null
 
 Confirm that trees match expected topology and branch lengths, given that the output should not be a time tree.
 


### PR DESCRIPTION
_cherry-picked from fe02380e3197bf87bda56167c9e9b22cc305180c with an updated message_

### Description of proposed changes

Ignores spurious scipy warnings that cause CI to fail. This should be reverted once a new TreeTime version that removes these messages¹ is released and bumped as the minimum supported version in Augur.

¹ https://github.com/neherlab/treetime/issues/223

### Related issue(s)

Related to discussion in #1120

### Testing

- [x] Checks pass

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, dev change
