### PR TITLE
numeric_date: Add tests and support for date objects

### DIFF
--- a/augur/dates.py
+++ b/augur/dates.py
@@ -32,6 +32,10 @@ def numeric_date(date):
     >>> numeric_date("1W") == treetime.utils.numeric_date(datetime.date.today() - isodate.parse_duration("P1W"))
     True
     """
+    # date is a datetime.date
+    if isinstance(date, datetime.date):
+        return treetime.utils.numeric_date(date)
+
     # date is numeric
     try:
         return float(date)

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -6,6 +6,20 @@ from augur.errors import AugurError
 
 
 class TestDates:
+    @freeze_time("2000-02-20")
+    def test_numeric_date(self):
+        # Test different representations of February 20, 2000.
+        assert dates.numeric_date("2000.138") == pytest.approx(2000.138, abs=1e-3)
+        assert dates.numeric_date("2000-02-20") == pytest.approx(2000.138, abs=1e-3)
+        assert dates.numeric_date(datetime.date(year=2000, month=2, day=20)) == pytest.approx(2000.138, abs=1e-3)
+
+        # Test relative dates based on freeze_time.
+        assert dates.numeric_date("1D") == pytest.approx(2000.135, abs=1e-3)
+        assert dates.numeric_date("1W") == pytest.approx(2000.119, abs=1e-3)
+        assert dates.numeric_date("1M") == pytest.approx(2000.053, abs=1e-3)
+        assert dates.numeric_date("1Y") == pytest.approx(1999.138, abs=1e-3)
+        assert dates.numeric_date("1Y1M1W") == pytest.approx(1999.034, abs=1e-3)
+
     def test_ambiguous_date_to_date_range_not_ambiguous(self):
         assert dates.ambiguous_date_to_date_range("2000-03-29", "%Y-%m-%d") == (
             datetime.date(year=2000, month=3, day=29),


### PR DESCRIPTION
### Description of proposed changes

This removes the necessity to convert date objects to `YYYY-MM-DD` form, only to be converted back into date objects to be passed to `treetime.utils.numeric_date`. Also adds tests for good measure.

### Related issue(s)

N/A

### Testing

- [x] Tests added
- [x] Checks pass

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, not a user-facing change.
