### PR TITLE
tree: RAxML bootstrapping

### DIFF
--- a/augur/tree.py
+++ b/augur/tree.py
@@ -108,7 +108,7 @@ def find_executable(names, default = None):
 
 def build_raxml(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_args=None):
     '''
-    build tree using RAxML with parameters '-f d -m GTRCAT -c 25 -p 235813 -n tre"
+    build tree using RAxML
     '''
 
     raxml = find_executable([
@@ -161,7 +161,7 @@ def build_raxml(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_args
 
 def build_fasttree(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_args=None):
     '''
-    build tree using fasttree with parameters "-nt"
+    build tree using fasttree
     '''
     log_file = out_file + ".log"
 
@@ -206,7 +206,7 @@ def build_fasttree(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_a
 
 def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nthreads=1, tree_builder_args=None):
     '''
-    build tree using IQ-Tree with parameters "-fast"
+    build tree using IQ-Tree
     arguments:
         aln_file    file name of input aligment
         out_file    file name to write tree to

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -400,7 +400,7 @@ def register_parser(parent_subparsers):
     parser.add_argument('--method', default='iqtree', choices=["fasttree", "raxml", "iqtree"], help="tree builder to use")
     parser.add_argument('--output', '-o', type=str, help='file name to write tree to')
     parser.add_argument('--substitution-model', default=DEFAULT_SUBSTITUTION_MODEL,
-                                help='substitution model to use. Specify \'auto\' to run ModelTest. Currently, only available for IQTREE.')
+                                help='substitution model to use. Specify \'auto\' to run ModelTest. Currently, only available for IQ-TREE.')
     parser.add_argument('--nthreads', type=nthreads_value, default=1,
                                 help="maximum number of threads to use; specifying the value 'auto' will cause the number of available CPU cores on your system, if determinable, to be used")
     parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
@@ -455,7 +455,7 @@ def run(args):
         fasta = aln
 
     if args.method != "iqtree" and args.substitution_model is not DEFAULT_SUBSTITUTION_MODEL:
-        print(f"Cannot specify --substitution-model unless using IQTree. Model specification {args.substitution_model!r} ignored.", file=sys.stderr)
+        print(f"Cannot specify --substitution-model unless using IQ-TREE. Model specification {args.substitution_model!r} ignored.", file=sys.stderr)
 
     # Allow users to keep default args, override them, or augment them.
     if args.tree_builder_args is None:

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -40,6 +40,9 @@ DEFAULT_ARGS = {
     "iqtree": "-ninit 2 -n 2 -me 0.05 -nt AUTO -redo",
 }
 
+# IQ-TREE only; see usage below
+DEFAULT_SUBSTITUTION_MODEL = "GTR"
+
 class ConflictingArgumentsException(Exception):
     """Exception when user-provided tree builder arguments conflict with the
     requested tree builder's hardcoded defaults (e.g., the path to the
@@ -396,7 +399,7 @@ def register_parser(parent_subparsers):
     parser.add_argument('--alignment', '-a', required=True, help="alignment in fasta or VCF format")
     parser.add_argument('--method', default='iqtree', choices=["fasttree", "raxml", "iqtree"], help="tree builder to use")
     parser.add_argument('--output', '-o', type=str, help='file name to write tree to')
-    parser.add_argument('--substitution-model', default="GTR",
+    parser.add_argument('--substitution-model', default=DEFAULT_SUBSTITUTION_MODEL,
                                 help='substitution model to use. Specify \'auto\' to run ModelTest. Currently, only available for IQTREE.')
     parser.add_argument('--nthreads', type=nthreads_value, default=1,
                                 help="maximum number of threads to use; specifying the value 'auto' will cause the number of available CPU cores on your system, if determinable, to be used")
@@ -451,8 +454,8 @@ def run(args):
     else:
         fasta = aln
 
-    if args.substitution_model and not args.method=='iqtree':
-        print("Cannot specify model unless using IQTree. Model specification ignored.")
+    if args.method != "iqtree" and args.substitution_model is not DEFAULT_SUBSTITUTION_MODEL:
+        print(f"Cannot specify --substitution-model unless using IQTree. Model specification {args.substitution_model!r} ignored.", file=sys.stderr)
 
     # Allow users to keep default args, override them, or augment them.
     if args.tree_builder_args is None:

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -153,8 +153,9 @@ def build_raxml(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_args
             os.remove("RAxML_parsimonyTree.%s"%(random_string))
             os.remove("RAxML_result.%s"%(random_string))
 
-    except:
+    except Exception as error:
         print("ERROR: TREE BUILDING FAILED")
+        print(f"ERROR: {error}")
         if os.path.isfile("RAxML_log.%s"%(random_string)):
             print("Please see the log file for more details: {}".format("RAxML_log.%s"%(random_string)))
         T=None
@@ -198,8 +199,9 @@ def build_fasttree(aln_file, out_file, clean_up=True, nthreads=1, tree_builder_a
     try:
         run_shell_command(cmd, raise_errors = True, extra_env = extra_env)
         T = Phylo.read(out_file, 'newick')
-    except:
+    except Exception as error:
         print("ERROR: TREE BUILDING FAILED")
+        print(f"ERROR: {error}")
         if os.path.isfile(log_file):
             print("Please see the log file for more details: {}".format(log_file))
         T=None
@@ -276,8 +278,9 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
             for ext in [".bionj",".ckp.gz",".iqtree",".mldist",".model.gz",".treefile",".uniqueseq.phy",".model"]:
                 if os.path.isfile(tmp_aln_file + ext):
                     os.remove(tmp_aln_file + ext)
-    except:
+    except Exception as error:
         print("ERROR: TREE BUILDING FAILED")
+        print(f"ERROR: {error}")
         if os.path.isfile(log_file):
             print("Please see the log file for more details: {}".format(log_file))
         T=None


### PR DESCRIPTION
### Description of proposed changes
Resolves several inter-related issues in `augur tree --method raxml` when a user-provided `--tree-builder-args` enables bootstrapping.

### Related issue(s)

https://support.nextstrain.org/agent/nextstrain/nextstrain/tickets/details/668036000002953001

### Testing

Manually tested various invocations of `augur tree` exercising the changes. (The existing `augur tree` tests seem focused on basic functionality.)

I also modified zika-tutorial with this patch to reproduce the problem reported via support:

```diff
diff --git a/Snakefile b/Snakefile
index 47b55a2..a60e8e9 100644
--- a/Snakefile
+++ b/Snakefile
@@ -88,7 +88,10 @@ rule tree:
         """
         augur tree \
             --alignment {input.alignment} \
-            --output {output.tree}
+            --output {output.tree} \
+            --method raxml \
+            --tree-builder-args '-m GTRCAT -p $RANDOM -f a -x $RANDOM -N 10' \
+            --override-default-args
         """
 
 rule refine:
```

and tested it completes successfully now with these changes by running:

    nextstrain build --augur=augur/ zika-tutorial/ tree

It does.

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
