### PR TITLE
filter: Update developer docs for refactor

### DIFF
--- a/docs/api/developer/augur.filter._run.rst
+++ b/docs/api/developer/augur.filter._run.rst
@@ -1,0 +1,7 @@
+augur.filter._run
+=================
+
+.. automodule:: augur.filter._run
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/developer/augur.filter.include_exclude_rules.rst
+++ b/docs/api/developer/augur.filter.include_exclude_rules.rst
@@ -1,0 +1,7 @@
+augur.filter.include_exclude_rules
+==================================
+
+.. automodule:: augur.filter.include_exclude_rules
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/developer/augur.filter.io.rst
+++ b/docs/api/developer/augur.filter.io.rst
@@ -1,0 +1,7 @@
+augur.filter.io
+===============
+
+.. automodule:: augur.filter.io
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/developer/augur.filter.rst
+++ b/docs/api/developer/augur.filter.rst
@@ -5,3 +5,11 @@ augur.filter
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. toctree::
+
+   augur.filter._run
+   augur.filter.include_exclude_rules
+   augur.filter.io
+   augur.filter.subsample
+   augur.filter.validate_arguments

--- a/docs/api/developer/augur.filter.subsample.rst
+++ b/docs/api/developer/augur.filter.subsample.rst
@@ -1,0 +1,7 @@
+augur.filter.subsample
+======================
+
+.. automodule:: augur.filter.subsample
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/developer/augur.filter.validate_arguments.rst
+++ b/docs/api/developer/augur.filter.validate_arguments.rst
@@ -1,0 +1,7 @@
+augur.filter.validate_arguments
+===============================
+
+.. automodule:: augur.filter.validate_arguments
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
### Description of proposed changes

In 656ebad97b99ceb2ad044d69269e1b7f1f86223b and subsequent commits, filter.py was refactored into a package but the docs were not updated accordingly. This fixes that.

### Related issue(s)

Follow-up to #997

### Testing

- [x] Checks pass, though docs build warnings are not surfaced here (this should be fixed by #1047).
- [x] Local docs build does not show any warnings related to the `augur filter` refactor.
- [x] Preview docs build looks good

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, dev change
