### PR TITLE
filter: Update working directory of cram tests

### DIFF
--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -125,6 +125,13 @@ To compare JSON outputs with stochastic numerical values, use `scripts/diff_json
 
 Both tree and JSON comparison scripts rely on [deepdiff](https://deepdiff.readthedocs.io/en/latest/) for underlying comparisons.
 
+##### Tips for writing Cram tests
+
+Cram is a simple testing framework that is also very versatile. Over time, we have changed the way we design and organize Augur's Cram tests. You might find older practices in existing tests that haven't been updated yet, but these are the latest guidelines that we've discovered to be helpful.
+
+1. Keep cram files modular. This makes it easier to see which command is failing.
+2. Create files in the initial working directory, as it is a temporary working directory unique to the test. Note that the name of the `$TMP` directory is misleading - although it is temporary, it is shared across all tests so you'll have to explicitly remove files at the end of each test to avoid affecting other tests. The initial directory of each test is a unique directory within `$TMP`.
+
 #### Running Tests
 
 You've written tests and now you want to run them to see if they are passing.

--- a/tests/functional/filter/cram/_setup.sh
+++ b/tests/functional/filter/cram/_setup.sh
@@ -1,2 +1,1 @@
-pushd "$TESTDIR/../../" > /dev/null
-export AUGUR="${AUGUR:-../../bin/augur}"
+export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"

--- a/tests/functional/filter/cram/filter-exclude-include.t
+++ b/tests/functional/filter/cram/filter-exclude-include.t
@@ -1,17 +1,15 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter with exclude query for two regions that comprise all but one strain.
 This filter should leave a single record from Oceania.
 Force include one South American record by country to get two total records.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --exclude-where "region=South America" "region=North America" "region=Southeast Asia" \
   >  --include-where "country=Ecuador" \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
-  $ wc -l "$TMP/filtered_strains.txt"
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ wc -l filtered_strains.txt
   \s*2 .* (re)
-  $ rm -f "$TMP/filtered_strains.txt"

--- a/tests/functional/filter/cram/filter-force-include-no-duplicates.t
+++ b/tests/functional/filter/cram/filter-force-include-no-duplicates.t
@@ -1,7 +1,6 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 
 Test that a force-included strain is only output once.
@@ -9,14 +8,14 @@ Test that a force-included strain is only output once.
 
 Create some files for testing.
 
-  $ cat >$TMP/metadata.tsv <<~~
+  $ cat >metadata.tsv <<~~
   > strain	col
   > a	1
   > b	2
   > c	3
   > d	4
   > ~~
-  $ cat >$TMP/sequences.fasta <<~~
+  $ cat >sequences.fasta <<~~
   > >a
   > NNNN
   > >b
@@ -30,26 +29,26 @@ Create some files for testing.
 Test all outputs with --include-where.
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata.tsv \
-  >   --sequences $TMP/sequences.fasta \
+  >   --metadata metadata.tsv \
+  >   --sequences sequences.fasta \
   >   --subsample-max-sequences 4 \
   >   --include-where col=1 \
   >   --subsample-seed 0 \
-  >   --output-metadata $TMP/metadata-filtered.tsv \
-  >   --output-strains $TMP/strains-filtered.txt \
-  >   --output-sequences $TMP/sequences-filtered.fasta \
+  >   --output-metadata metadata-filtered.tsv \
+  >   --output-strains strains-filtered.txt \
+  >   --output-sequences sequences-filtered.fasta \
   >   > /dev/null 2>&1
-  $ cat $TMP/metadata-filtered.tsv | tail -n+2 | sort -k1
+  $ cat metadata-filtered.tsv | tail -n+2 | sort -k1
   a\t1 (esc)
   b\t2 (esc)
   c\t3 (esc)
   d\t4 (esc)
-  $ cat $TMP/strains-filtered.txt | sort
+  $ cat strains-filtered.txt | sort
   a
   b
   c
   d
-  $ cat $TMP/sequences-filtered.fasta
+  $ cat sequences-filtered.fasta
   >a
   NNNN
   >b
@@ -61,30 +60,30 @@ Test all outputs with --include-where.
 
 Test all outputs with --include.
 
-  $ cat >$TMP/include.txt <<~~
+  $ cat >include.txt <<~~
   > a
   > ~~
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata.tsv \
-  >   --sequences $TMP/sequences.fasta \
+  >   --metadata metadata.tsv \
+  >   --sequences sequences.fasta \
   >   --subsample-max-sequences 4 \
-  >   --include $TMP/include.txt \
+  >   --include include.txt \
   >   --subsample-seed 0 \
-  >   --output-metadata $TMP/metadata-filtered.tsv \
-  >   --output-strains $TMP/strains-filtered.txt \
-  >   --output-sequences $TMP/sequences-filtered.fasta \
+  >   --output-metadata metadata-filtered.tsv \
+  >   --output-strains strains-filtered.txt \
+  >   --output-sequences sequences-filtered.fasta \
   >   > /dev/null 2>&1
-  $ cat $TMP/metadata-filtered.tsv | tail -n+2 | sort -k1
+  $ cat metadata-filtered.tsv | tail -n+2 | sort -k1
   a\t1 (esc)
   b\t2 (esc)
   c\t3 (esc)
   d\t4 (esc)
-  $ cat $TMP/strains-filtered.txt | sort
+  $ cat strains-filtered.txt | sort
   a
   b
   c
   d
-  $ cat $TMP/sequences-filtered.fasta
+  $ cat sequences-filtered.fasta
   >a
   NNNN
   >b

--- a/tests/functional/filter/cram/filter-metadata-duplicates-error.t
+++ b/tests/functional/filter/cram/filter-metadata-duplicates-error.t
@@ -1,11 +1,10 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Error on duplicates in metadata within same chunk.
 
-  $ cat >$TMP/metadata-duplicates.tsv <<~~
+  $ cat >metadata-duplicates.tsv <<~~
   > strain	date
   > a	2010-10-10
   > a	2010-10-10
@@ -14,31 +13,31 @@ Error on duplicates in metadata within same chunk.
   > d	2010-10-10
   > ~~
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata-duplicates.tsv \
+  >   --metadata metadata-duplicates.tsv \
   >   --group-by year \
   >   --sequences-per-group 2 \
   >   --subsample-seed 0 \
   >   --metadata-chunk-size 10 \
-  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
+  >   --output-metadata metadata-filtered.tsv > /dev/null
   ERROR: The following strains are duplicated in .* (re)
   a
   [2]
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   cat: .*: No such file or directory (re)
   [1]
 
 Error on duplicates in metadata in separate chunks.
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata-duplicates.tsv \
+  >   --metadata metadata-duplicates.tsv \
   >   --group-by year \
   >   --sequences-per-group 2 \
   >   --subsample-seed 0 \
   >   --metadata-chunk-size 1 \
-  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
+  >   --output-metadata metadata-filtered.tsv > /dev/null
   ERROR: The following strains are duplicated in .* (re)
   a
   [2]
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   cat: .*: No such file or directory (re)
   [1]

--- a/tests/functional/filter/cram/filter-metadata-not-found-error.t
+++ b/tests/functional/filter/cram/filter-metadata-not-found-error.t
@@ -1,7 +1,6 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Try to filter on an metadata file that does not exist.
 
@@ -9,6 +8,6 @@ Try to filter on an metadata file that does not exist.
   >  --metadata file-does-not-exist.tsv \
   >  --group-by year month \
   >  --sequences-per-group 1 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   ERROR: No such file or directory: 'file-does-not-exist.tsv'
   [2]

--- a/tests/functional/filter/cram/filter-metadata-sequence-strains-mismatch.t
+++ b/tests/functional/filter/cram/filter-metadata-sequence-strains-mismatch.t
@@ -1,7 +1,6 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Confirm that filtering omits strains without metadata or sequences.
 The input sequences are missing one strain that is in the metadata.
@@ -10,20 +9,25 @@ The list of strains to include has one strain with no metadata/sequence and one 
 The query initially filters 3 strains from Colombia, one of which is added back by the include.
 
   $ ${AUGUR} filter \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "country != 'Colombia'" \
   >  --non-nucleotide \
   >  --exclude-ambiguous-dates-by year \
-  >  --include filter/data/include.txt \
-  >  --output-strains "$TMP/filtered_strains.txt" \
-  >  --output-log "$TMP/filtered_log.tsv"
+  >  --include "$TESTDIR/../data/include.txt" \
+  >  --output-strains filtered_strains.txt \
+  >  --output-log filtered_log.tsv
   4 strains were dropped during filtering
   \t1 had no metadata (esc)
   \t1 had no sequence data (esc)
   \t3 of these were filtered out by the query: "country != 'Colombia'" (esc)
-  \t1 strains were added back because they were in filter/data/include.txt (esc)
+  \\t1 strains were added back because they were in .*include\.txt.* (re)
   9 strains passed all filters
 
-  $ diff -u <(sort -k 1,1 filter/data/filtered_log.tsv) <(sort -k 1,1 "$TMP/filtered_log.tsv")
-  $ rm -f "$TMP/filtered_strains.txt"
+  $ (head -n1; sort -k 1,1) < filtered_log.tsv
+  strain	filter	kwargs
+  COL/FLR_00008/2015	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
+  COL/FLR_00008/2015\tforce_include_strains\t"[[""include_file"", ""*/data/include.txt""]]" (esc) (glob)
+  COL/FLR_00024/2015	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
+  Colombia/2016/ZC204Se	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
+  HND/2016/HU_ME59	filter_by_sequence_index	[]

--- a/tests/functional/filter/cram/filter-min-date.t
+++ b/tests/functional/filter/cram/filter-min-date.t
@@ -1,13 +1,11 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter using only metadata without a sequence index.
 This should work because the requested filters don't rely on sequence information.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2012 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
-  $ rm -f "$TMP/filtered_strains.txt"
+  >  --output-strains filtered_strains.txt > /dev/null

--- a/tests/functional/filter/cram/filter-min-length-no-sequence-index-error.t
+++ b/tests/functional/filter/cram/filter-min-length-no-sequence-index-error.t
@@ -1,14 +1,13 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Try to filter using only metadata without a sequence index.
 This should fail because the requested filters rely on sequence information.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-length 10000 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   ERROR: You need to provide a sequence index or sequences to filter on sequence-specific information.
   [2]

--- a/tests/functional/filter/cram/filter-min-length-output-metadata.t
+++ b/tests/functional/filter/cram/filter-min-length-output-metadata.t
@@ -1,19 +1,17 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter using only metadata without sequence input or output and save results as filtered metadata.
 
   $ ${AUGUR} filter \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2012 \
   >  --min-length 10500 \
-  >  --output-metadata "$TMP/filtered_metadata.tsv" > /dev/null
+  >  --output-metadata filtered_metadata.tsv > /dev/null
 
 Output should include the 8 sequences matching the filters and a header line.
 
-  $ wc -l "$TMP/filtered_metadata.tsv"
+  $ wc -l filtered_metadata.tsv
   \s*9 .* (re)
-  $ rm -f "$TMP/filtered_metadata.tsv"

--- a/tests/functional/filter/cram/filter-min-length-output-strains.t
+++ b/tests/functional/filter/cram/filter-min-length-output-strains.t
@@ -1,19 +1,17 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter using only metadata and save results as a list of filtered strains.
 
   $ ${AUGUR} filter \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2012 \
   >  --min-length 10500 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
 
 Output should include only the 8 sequences matching the filters (without a header line).
 
-  $ wc -l "$TMP/filtered_strains.txt"
+  $ wc -l filtered_strains.txt
   \s*8 .* (re)
-  $ rm -f "$TMP/filtered_strains.txt"

--- a/tests/functional/filter/cram/filter-min-max-date-output.t
+++ b/tests/functional/filter/cram/filter-min-max-date-output.t
@@ -1,15 +1,14 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Check output of min/max date filters.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2015-01-01 \
   >  --max-date 2016-02-01 \
-  >  --output-metadata "$TMP/filtered_metadata.tsv"
+  >  --output-metadata filtered_metadata.tsv
   8 strains were dropped during filtering
   \t1 of these were dropped because they were earlier than 2015.0 or missing a date (esc)
   \t7 of these were dropped because they were later than 2016.09 or missing a date (esc)

--- a/tests/functional/filter/cram/filter-mismatched-sequences-error.t
+++ b/tests/functional/filter/cram/filter-mismatched-sequences-error.t
@@ -1,53 +1,48 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Try to filter with sequences that don't match any of the metadata.
 This should produce no results because the intersection of metadata and sequences is empty.
 
-  $ echo -e ">something\nATCG" > "$TMP/dummy.fasta"
+  $ echo -e ">something\nATCG" > dummy.fasta
   $ ${AUGUR} filter \
-  >  --sequences "$TMP/dummy.fasta" \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences dummy.fasta \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-length 4 \
   >  --max-date 2020-01-30 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
   ERROR: All samples have been dropped! Check filter rules and metadata file format.
   [2]
-  $ wc -l "$TMP/filtered_strains.txt"
+  $ wc -l filtered_strains.txt
   \s*0 .* (re)
-  $ rm -f "$TMP/filtered_strains.txt"
 
 Repeat with sequence and strain outputs. We should get the same results.
 
   $ ${AUGUR} filter \
-  >  --sequences "$TMP/dummy.fasta" \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences dummy.fasta \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --max-date 2020-01-30 \
-  >  --output-strains "$TMP/filtered_strains.txt" \
-  >  --output-sequences "$TMP/filtered.fasta" > /dev/null
+  >  --output-strains filtered_strains.txt \
+  >  --output-sequences filtered.fasta > /dev/null
   Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
   ERROR: All samples have been dropped! Check filter rules and metadata file format.
   [2]
-  $ wc -l "$TMP/filtered_strains.txt"
+  $ wc -l filtered_strains.txt
   \s*0 .* (re)
-  $ grep "^>" "$TMP/filtered.fasta" | wc -l
+  $ grep "^>" filtered.fasta | wc -l
   \s*0 (re)
-  $ rm -f "$TMP/filtered_strains.txt"
-  $ rm -f "$TMP/filtered.fasta"
 
 Repeat without any sequence-based filters.
 Since we expect metadata to be filtered by presence of strains in input sequences, this should produce no results because the intersection of metadata and sequences is empty.
 
   $ ${AUGUR} filter \
-  >  --sequences "$TMP/dummy.fasta" \
-  >  --metadata filter/data/metadata.tsv \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --sequences dummy.fasta \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
+  >  --output-strains filtered_strains.txt > /dev/null
   Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
   ERROR: All samples have been dropped! Check filter rules and metadata file format.
   [2]
-  $ wc -l "$TMP/filtered_strains.txt"
+  $ wc -l filtered_strains.txt
   \s*0 .* (re)
-  $ rm -f "$TMP/filtered_strains.txt"

--- a/tests/functional/filter/cram/filter-no-outputs-error.t
+++ b/tests/functional/filter/cram/filter-no-outputs-error.t
@@ -1,13 +1,12 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Try to filter without any outputs.
 
   $ ${AUGUR} filter \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-length 10000 > /dev/null
   ERROR: You need to select at least one output.
   [2]

--- a/tests/functional/filter/cram/filter-output-directory-not-found-error.t
+++ b/tests/functional/filter/cram/filter-output-directory-not-found-error.t
@@ -1,12 +1,11 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Try to output to a directory that does not exist.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by year month \
   >  --sequences-per-group 1 \
   >  --output-strains "directory-does-not-exist/filtered_strains.txt" > /dev/null

--- a/tests/functional/filter/cram/filter-output-strains-no-sequence-error.t
+++ b/tests/functional/filter/cram/filter-output-strains-no-sequence-error.t
@@ -1,15 +1,14 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Try to filter with sequence outputs and no sequence inputs.
 This should fail.
 
   $ ${AUGUR} filter \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-length 10000 \
-  >  --output "$TMP/filtered.fasta" > /dev/null
+  >  --output filtered.fasta > /dev/null
   ERROR: You need to provide sequences to output sequences.
   [2]

--- a/tests/functional/filter/cram/filter-query-errors.t
+++ b/tests/functional/filter/cram/filter-query-errors.t
@@ -1,14 +1,13 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Using a pandas query with a nonexistent column results in a specific error.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "invalid == 'value'" \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   ERROR: Query contains a column that does not exist in metadata.
   [2]
 
@@ -18,17 +17,17 @@ Using pandas queries with bad syntax results in a generic errors.
 This raises a ValueError internally (https://github.com/nextstrain/augur/issues/940):
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "invalid = 'value'" \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   ERROR: Error when applying query. Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
   [2]
 
 This raises a SyntaxError internally (https://github.com/nextstrain/augur/issues/941):
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "some bad syntax" \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   ERROR: Error when applying query. Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
   [2]

--- a/tests/functional/filter/cram/filter-query-example.t
+++ b/tests/functional/filter/cram/filter-query-example.t
@@ -1,68 +1,63 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter into two separate sets and then select sequences from the union of those sets.
 First, select strains from Brazil (there should be 1).
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "country == 'Brazil'" \
-  >  --output-strains "$TMP/filtered_strains.brazil.txt" > /dev/null
-  $ wc -l "$TMP/filtered_strains.brazil.txt"
+  >  --output-strains filtered_strains.brazil.txt > /dev/null
+  $ wc -l filtered_strains.brazil.txt
   \s*1 .* (re)
 
 Then, select strains from Colombia (there should be 3).
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "country == 'Colombia'" \
-  >  --output-strains "$TMP/filtered_strains.colombia.txt" > /dev/null
-  $ wc -l "$TMP/filtered_strains.colombia.txt"
+  >  --output-strains filtered_strains.colombia.txt > /dev/null
+  $ wc -l filtered_strains.colombia.txt
   \s*3 .* (re)
 
 Finally, exclude all sequences except those from the two sets of strains (there should be 4).
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/sequences.fasta \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences "$TESTDIR/../data/sequences.fasta" \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --exclude-all \
-  >  --include "$TMP/filtered_strains.brazil.txt" "$TMP/filtered_strains.colombia.txt" \
-  >  --output "$TMP/filtered.fasta" > /dev/null
-  $ grep "^>" "$TMP/filtered.fasta" | wc -l
+  >  --include filtered_strains.brazil.txt filtered_strains.colombia.txt \
+  >  --output filtered.fasta > /dev/null
+  $ grep "^>" filtered.fasta | wc -l
   \s*4 (re)
-  $ rm -f "$TMP/filtered.fasta"
 
 Repeat this filter without a sequence index.
 We should get the same outputs without building a sequence index on the fly, because the exclude-all flag tells us we only want to force-include strains and skip all other filters.
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/sequences.fasta \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences "$TESTDIR/../data/sequences.fasta" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --exclude-all \
-  >  --include "$TMP/filtered_strains.brazil.txt" "$TMP/filtered_strains.colombia.txt" \
-  >  --output "$TMP/filtered.fasta" \
-  >  --output-metadata "$TMP/filtered.tsv" > /dev/null
-  $ grep "^>" "$TMP/filtered.fasta" | wc -l
+  >  --include filtered_strains.brazil.txt filtered_strains.colombia.txt \
+  >  --output filtered.fasta \
+  >  --output-metadata filtered.tsv > /dev/null
+  $ grep "^>" filtered.fasta | wc -l
   \s*4 (re)
-  $ rm -f "$TMP/filtered.fasta"
 
 Metadata should have the same number of records as the sequences plus a header.
 
-  $ wc -l "$TMP/filtered.tsv"
+  $ wc -l filtered.tsv
   \s*5 .* (re)
-  $ rm -f "$TMP/filtered.tsv"
 
 Alternately, exclude the sequences from Brazil and Colombia (N=4) and records without sequences (N=1) or metadata (N=1).
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/sequences.fasta \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
-  >  --exclude "$TMP/filtered_strains.brazil.txt" "$TMP/filtered_strains.colombia.txt" \
-  >  --output "$TMP/filtered.fasta" > /dev/null
-  $ grep "^>" "$TMP/filtered.fasta" | wc -l
+  >  --sequences "$TESTDIR/../data/sequences.fasta" \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
+  >  --exclude filtered_strains.brazil.txt filtered_strains.colombia.txt \
+  >  --output filtered.fasta > /dev/null
+  $ grep "^>" filtered.fasta | wc -l
   \s*7 (re)
-  $ rm -f "$TMP/filtered.fasta"

--- a/tests/functional/filter/cram/filter-sequences-vcf.t
+++ b/tests/functional/filter/cram/filter-sequences-vcf.t
@@ -1,16 +1,14 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter TB strains from VCF and save as a list of filtered strains.
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/tb.vcf.gz \
-  >  --metadata filter/data/tb_metadata.tsv \
+  >  --sequences "$TESTDIR/../data/tb.vcf.gz" \
+  >  --metadata "$TESTDIR/../data/tb_metadata.tsv" \
   >  --min-date 2012 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
-  $ wc -l "$TMP/filtered_strains.txt"
+  $ wc -l filtered_strains.txt
   \s*3 .* (re)
-  $ rm -f "$TMP/filtered_strains.txt"

--- a/tests/functional/filter/cram/subsample-5-sequences-without-group-by-no-probabilistic-sampling.t
+++ b/tests/functional/filter/cram/subsample-5-sequences-without-group-by-no-probabilistic-sampling.t
@@ -1,20 +1,18 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter with subsampling where no more than 5 sequences are requested and no groups are specified.
 This generates a dummy category and subsamples from there. With no-probabilistic-sampling we expect exactly 5 sequences.
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/sequences.fasta \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences "$TESTDIR/../data/sequences.fasta" \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2012 \
   >  --subsample-max-sequences 5 \
   >  --subsample-seed 314159 \
   >  --no-probabilistic-sampling \
-  >  --output "$TMP/filtered.fasta" > /dev/null
-  $ grep ">" "$TMP/filtered.fasta" | wc -l
+  >  --output filtered.fasta > /dev/null
+  $ grep ">" filtered.fasta | wc -l
   \s*5 (re)
-  $ rm -f "$TMP/filtered.fasta"

--- a/tests/functional/filter/cram/subsample-8-sequences-no-probabilistic-sampling.t
+++ b/tests/functional/filter/cram/subsample-8-sequences-no-probabilistic-sampling.t
@@ -1,21 +1,19 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter with subsampling, requesting no more than 8 sequences.
 With 8 groups to subsample from (after filtering), this should produce one sequence per group.
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/sequences.fasta \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences "$TESTDIR/../data/sequences.fasta" \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2012 \
   >  --group-by country year month \
   >  --subsample-max-sequences 8 \
   >  --subsample-seed 314159 \
   >  --no-probabilistic-sampling \
-  >  --output "$TMP/filtered.fasta" > /dev/null
-  $ grep ">" "$TMP/filtered.fasta" | wc -l
+  >  --output filtered.fasta > /dev/null
+  $ grep ">" filtered.fasta | wc -l
   \s*8 (re)
-  $ rm -f "$TMP/filtered.fasta"

--- a/tests/functional/filter/cram/subsample-ambiguous-dates-error.t
+++ b/tests/functional/filter/cram/subsample-ambiguous-dates-error.t
@@ -1,11 +1,10 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Metadata with ambiguous days on all strains should error when grouping by week.
 
-  $ cat >$TMP/metadata.tsv <<~~
+  $ cat >metadata.tsv <<~~
   > strain	date
   > SEQ1	2000-01-XX
   > SEQ2	2000-02-XX
@@ -14,26 +13,25 @@ Metadata with ambiguous days on all strains should error when grouping by week.
   > ~~
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata.tsv \
+  >   --metadata metadata.tsv \
   >   --group-by week \
   >   --sequences-per-group 1 \
   >   --subsample-seed 0 \
-  >   --output-metadata $TMP/metadata-filtered.tsv \
-  >   --output-log $TMP/filtered_log.tsv
+  >   --output-metadata metadata-filtered.tsv \
+  >   --output-log filtered_log.tsv
   ERROR: All samples have been dropped! Check filter rules and metadata file format.
   4 strains were dropped during filtering
   \t4 were dropped during grouping due to ambiguous day information (esc)
   \t0 of these were dropped because of subsampling criteria (esc)
   [2]
-  $ cat $TMP/filtered_log.tsv | grep "skip_group_by_with_ambiguous_day" | wc -l
+  $ cat filtered_log.tsv | grep "skip_group_by_with_ambiguous_day" | wc -l
   \s*4 (re)
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   strain	date
-  $ rm -f $TMP/filtered_log.tsv $TMP/metadata-filtered.tsv
 
 Metadata with ambiguous months on all strains should error when grouping by month.
 
-  $ cat >$TMP/metadata.tsv <<~~
+  $ cat >metadata.tsv <<~~
   > strain	date
   > SEQ1	2000-XX-XX
   > SEQ2	2000-XX-XX
@@ -42,26 +40,25 @@ Metadata with ambiguous months on all strains should error when grouping by mont
   > ~~
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata.tsv \
+  >   --metadata metadata.tsv \
   >   --group-by month \
   >   --sequences-per-group 1 \
   >   --subsample-seed 0 \
-  >   --output-metadata $TMP/metadata-filtered.tsv \
-  >   --output-log $TMP/filtered_log.tsv
+  >   --output-metadata metadata-filtered.tsv \
+  >   --output-log filtered_log.tsv
   ERROR: All samples have been dropped! Check filter rules and metadata file format.
   4 strains were dropped during filtering
   \t4 were dropped during grouping due to ambiguous month information (esc)
   \t0 of these were dropped because of subsampling criteria (esc)
   [2]
-  $ cat $TMP/filtered_log.tsv | grep "skip_group_by_with_ambiguous_month" | wc -l
+  $ cat filtered_log.tsv | grep "skip_group_by_with_ambiguous_month" | wc -l
   \s*4 (re)
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   strain	date
-  $ rm -f $TMP/filtered_log.tsv $TMP/metadata-filtered.tsv
 
 Metadata with ambiguous years on all strains should error when grouping by year.
 
-  $ cat >$TMP/metadata.tsv <<~~
+  $ cat >metadata.tsv <<~~
   > strain	date
   > SEQ1	XXXX-XX-XX
   > SEQ2	XXXX-XX-XX
@@ -70,19 +67,18 @@ Metadata with ambiguous years on all strains should error when grouping by year.
   > ~~
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata.tsv \
+  >   --metadata metadata.tsv \
   >   --group-by year \
   >   --sequences-per-group 1 \
   >   --subsample-seed 0 \
-  >   --output-metadata $TMP/metadata-filtered.tsv \
-  >   --output-log $TMP/filtered_log.tsv
+  >   --output-metadata metadata-filtered.tsv \
+  >   --output-log filtered_log.tsv
   ERROR: All samples have been dropped! Check filter rules and metadata file format.
   4 strains were dropped during filtering
   \t4 were dropped during grouping due to ambiguous year information (esc)
   \t0 of these were dropped because of subsampling criteria (esc)
   [2]
-  $ cat $TMP/filtered_log.tsv | grep "skip_group_by_with_ambiguous_year" | wc -l
+  $ cat filtered_log.tsv | grep "skip_group_by_with_ambiguous_year" | wc -l
   \s*4 (re)
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   strain	date
-  $ rm -f $TMP/filtered_log.tsv $TMP/metadata-filtered.tsv

--- a/tests/functional/filter/cram/subsample-group-by-missing-error.t
+++ b/tests/functional/filter/cram/subsample-group-by-missing-error.t
@@ -1,34 +1,33 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Error on missing group-by columns.
 
-  $ cat >$TMP/metadata-no-date.tsv <<~~
+  $ cat >metadata-no-date.tsv <<~~
   > strain	col
   > SEQ1	a
   > SEQ2	b
   > ~~
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata-no-date.tsv \
+  >   --metadata metadata-no-date.tsv \
   >   --group-by year \
   >   --sequences-per-group 1 \
-  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
+  >   --output-metadata metadata-filtered.tsv > /dev/null
   ERROR: The specified group-by categories (['year']) were not found. Note that using any of ['month', 'week', 'year'] requires a column called 'date'.
   [2]
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   cat: .*: No such file or directory (re)
   [1]
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata-no-date.tsv \
+  >   --metadata metadata-no-date.tsv \
   >   --group-by invalid \
   >   --sequences-per-group 1 \
-  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
+  >   --output-metadata metadata-filtered.tsv > /dev/null
   ERROR: The specified group-by categories (['invalid']) were not found.
   [2]
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   cat: .*: No such file or directory (re)
   [1]

--- a/tests/functional/filter/cram/subsample-group-by-region-1-sequence-per-group-seed.t
+++ b/tests/functional/filter/cram/subsample-group-by-region-1-sequence-per-group-seed.t
@@ -1,27 +1,25 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Filter with subsampling, requesting 1 sequence per group (for a group with 4 distinct values).
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by region \
   >  --sequences-per-group 1 \
   >  --subsample-seed 314159 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
-  $ wc -l "$TMP/filtered_strains.txt"
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ wc -l filtered_strains.txt
   \s*4 .* (re)
 
 By setting the subsample seed above, we should guarantee that we get the same "random" strains as another run with the same command.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by region \
   >  --sequences-per-group 1 \
   >  --subsample-seed 314159 \
-  >  --output-strains "$TMP/filtered_strains_repeated.txt" > /dev/null
+  >  --output-strains filtered_strains_repeated.txt > /dev/null
 
-  $ diff -u <(sort "$TMP/filtered_strains.txt") <(sort "$TMP/filtered_strains_repeated.txt")
-  $ rm -f "$TMP/filtered_strains.txt" "$TMP/filtered_strains_repeated.txt"
+  $ diff -u <(sort filtered_strains.txt) <(sort filtered_strains_repeated.txt)

--- a/tests/functional/filter/cram/subsample-group-by-week.t
+++ b/tests/functional/filter/cram/subsample-group-by-week.t
@@ -1,13 +1,12 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 SEQ1 and SEQ2 translate to week=(2003, 1).
 SEQ3 and SEQ4 translate to week=(2004, 1).
 These should be in separate groups.
 
-  $ cat >$TMP/metadata.tsv <<~~
+  $ cat >metadata.tsv <<~~
   > strain	date
   > SEQ1	2003-01-01
   > SEQ2	2003-01-02
@@ -16,22 +15,22 @@ These should be in separate groups.
   > ~~
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata.tsv \
+  >   --metadata metadata.tsv \
   >   --group-by week \
   >   --sequences-per-group 1 \
   >   --subsample-seed 0 \
-  >   --output-metadata $TMP/metadata-filtered.tsv
+  >   --output-metadata metadata-filtered.tsv
   2 strains were dropped during filtering
   \t2 of these were dropped because of subsampling criteria (esc)
   2 strains passed all filters
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   strain	date
   SEQ1	2003-01-01
   SEQ3	2003-12-30
 
 ISO year from 'week' takes precedence over 'year'.
 
-  $ cat >$TMP/metadata.tsv <<~~
+  $ cat >metadata.tsv <<~~
   > strain	date
   > SEQ1	2003-12-30
   > SEQ2	2003-12-31
@@ -40,15 +39,15 @@ ISO year from 'week' takes precedence over 'year'.
   > ~~
 
   $ ${AUGUR} filter \
-  >   --metadata $TMP/metadata.tsv \
+  >   --metadata metadata.tsv \
   >   --group-by year week \
   >   --sequences-per-group 1 \
   >   --subsample-seed 0 \
-  >   --output-metadata $TMP/metadata-filtered.tsv
+  >   --output-metadata metadata-filtered.tsv
   WARNING: 'year' grouping will be ignored since 'week' includes ISO year.
   3 strains were dropped during filtering
   \t3 of these were dropped because of subsampling criteria (esc)
   1 strains passed all filters
-  $ cat $TMP/metadata-filtered.tsv
+  $ cat metadata-filtered.tsv
   strain	date
   SEQ1	2003-12-30

--- a/tests/functional/filter/cram/subsample-group-by-with-custom-year-column.t
+++ b/tests/functional/filter/cram/subsample-group-by-with-custom-year-column.t
@@ -1,11 +1,10 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Create a metadata file with a custom year column
 
-  $ cat >$TMP/metadata-year-column.tsv <<~~
+  $ cat >metadata-year-column.tsv <<~~
   > strain	date	year	month
   > SEQ1	2021-01-01	odd	January
   > SEQ2	2021-01-02	odd	January
@@ -17,13 +16,13 @@ Create a metadata file with a custom year column
 Group by generated year column, and ensure all original columns are still in the final output.
 
   $ ${AUGUR} filter \
-  >  --metadata $TMP/metadata-year-column.tsv \
+  >  --metadata metadata-year-column.tsv \
   >  --group-by year \
   >  --sequences-per-group 1 \
   >  --subsample-seed 0 \
-  >  --output-metadata "$TMP/filtered_metadata.tsv" > /dev/null
+  >  --output-metadata filtered_metadata.tsv > /dev/null
   WARNING: `--group-by year` uses a generated year value from the 'date' column. The custom 'year' column in the metadata is ignored for grouping purposes.
-  $ cat "$TMP/filtered_metadata.tsv"
+  $ cat filtered_metadata.tsv
   strain\tdate\tyear\tmonth (esc)
   SEQ1\t2021-01-01\todd\tJanuary (esc)
   SEQ5\t2022-02-02\teven\tFebruary (esc)
@@ -31,14 +30,14 @@ Group by generated year column, and ensure all original columns are still in the
 Group by generated year and month columns, and ensure all original columns are still in the final output.
 
   $ ${AUGUR} filter \
-  >  --metadata $TMP/metadata-year-column.tsv \
+  >  --metadata metadata-year-column.tsv \
   >  --group-by year month \
   >  --sequences-per-group 1 \
   >  --subsample-seed 0 \
-  >  --output-metadata "$TMP/filtered_metadata.tsv" > /dev/null
+  >  --output-metadata filtered_metadata.tsv > /dev/null
   WARNING: `--group-by month` uses a generated month value from the 'date' column. The custom 'month' column in the metadata is ignored for grouping purposes.
   WARNING: `--group-by year` uses a generated year value from the 'date' column. The custom 'year' column in the metadata is ignored for grouping purposes.
-  $ cat "$TMP/filtered_metadata.tsv"
+  $ cat filtered_metadata.tsv
   strain\tdate\tyear\tmonth (esc)
   SEQ1\t2021-01-01\todd\tJanuary (esc)
   SEQ3\t2022-01-01\teven\tJanuary (esc)

--- a/tests/functional/filter/cram/subsample-group-by-without-force-included-strains.t
+++ b/tests/functional/filter/cram/subsample-group-by-without-force-included-strains.t
@@ -1,21 +1,19 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Do not consider force-included strains for subsampling.
 In this test, we force-include two old strains that are the only representatives of their month/year date group (December 2015).
 We don't filter these strains, so they could be considered for subsampling, but Augur removes them from consideration because they have been force-included.
 
-  $ cat >$TMP/include_old_strains.txt <<~~
+  $ cat >include_old_strains.txt <<~~
   > PRVABC59
   > COL/FLR_00008/2015
   > ~~
 
   $ ${AUGUR} filter \
-  >   --metadata filter/data/metadata.tsv \
-  >   --include $TMP/include_old_strains.txt \
+  >   --metadata "$TESTDIR/../data/metadata.tsv" \
+  >   --include include_old_strains.txt \
   >   --group-by month year \
   >   --subsample-max-sequences 10 \
-  >   --output-metadata $TMP/metadata-filtered.tsv > /dev/null
-  $ rm -f $TMP/metadata-filtered.tsv
+  >   --output-metadata metadata-filtered.tsv > /dev/null

--- a/tests/functional/filter/cram/subsample-max-sequences-no-probabilistic-sampling-error.t
+++ b/tests/functional/filter/cram/subsample-max-sequences-no-probabilistic-sampling-error.t
@@ -1,20 +1,18 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 This should fail, as probabilistic sampling is explicitly disabled.
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/sequences.fasta \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences "$TESTDIR/../data/sequences.fasta" \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2012 \
   >  --group-by country year month \
   >  --subsample-max-sequences 5 \
   >  --subsample-seed 314159 \
   >  --no-probabilistic-sampling \
-  >  --output "$TMP/filtered.fasta"
+  >  --output filtered.fasta
   ERROR: Asked to provide at most 5 sequences, but there are 8 groups.
   [2]
-  $ rm -f "$TMP/filtered.fasta"

--- a/tests/functional/filter/cram/subsample-max-sequences-with-probabilistic-sampling-warning.t
+++ b/tests/functional/filter/cram/subsample-max-sequences-with-probabilistic-sampling-warning.t
@@ -1,36 +1,34 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Explicitly use probabilistic subsampling to handle the case when there are more available groups than requested sequences.
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/sequences.fasta \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences "$TESTDIR/../data/sequences.fasta" \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2012 \
   >  --group-by country year month \
   >  --subsample-max-sequences 5 \
   >  --subsample-seed 314159 \
   >  --probabilistic-sampling \
-  >  --output-strains "$TMP/filtered_strains_probabilistic.txt" > /dev/null
+  >  --output-strains filtered_strains_probabilistic.txt > /dev/null
   WARNING: Asked to provide at most 5 sequences, but there are 8 groups.
 
 Using the default probabilistic subsampling, should work the same as the previous case.
 
   $ ${AUGUR} filter \
-  >  --sequences filter/data/sequences.fasta \
-  >  --sequence-index filter/data/sequence_index.tsv \
-  >  --metadata filter/data/metadata.tsv \
+  >  --sequences "$TESTDIR/../data/sequences.fasta" \
+  >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-date 2012 \
   >  --group-by country year month \
   >  --subsample-max-sequences 5 \
   >  --subsample-seed 314159 \
-  >  --output-strains "$TMP/filtered_strains_default.txt" > /dev/null
+  >  --output-strains filtered_strains_default.txt > /dev/null
   WARNING: Asked to provide at most 5 sequences, but there are 8 groups.
 
 By setting the subsample seed above, we should get the same results for both runs.
 
-  $ diff -u <(sort "$TMP/filtered_strains_probabilistic.txt") <(sort "$TMP/filtered_strains_default.txt")
-  $ rm -f "$TMP/filtered_strains_probabilistic.txt" "$TMP/filtered_strains_default.txt"
+  $ diff -u <(sort filtered_strains_probabilistic.txt) <(sort filtered_strains_default.txt)

--- a/tests/functional/filter/cram/subsample-no-sequences-quantity-error.t
+++ b/tests/functional/filter/cram/subsample-no-sequences-quantity-error.t
@@ -1,14 +1,13 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Try to group data without any grouping arguments.
 This should fail with a helpful error message.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by year month \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   ERROR: You must specify a number of sequences per group or maximum sequences to subsample.
   [2]

--- a/tests/functional/filter/cram/subsample-priority-file.t
+++ b/tests/functional/filter/cram/subsample-priority-file.t
@@ -1,18 +1,16 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Subsample one strain per year with priorities.
 There are two years (2015 and 2016) represented in the metadata.
 The two highest priority strains are in these two years.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by year \
-  >  --priority filter/data/priorities.tsv \
+  >  --priority "$TESTDIR/../data/priorities.tsv" \
   >  --sequences-per-group 1 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
 
-  $ diff -u <(sort -k 2,2rn -k 1,1 filter/data/priorities.tsv | head -n 2 | cut -f 1) <(sort -k 1,1 "$TMP/filtered_strains.txt")
-  $ rm -f "$TMP/filtered_strains.txt"
+  $ diff -u <(sort -k 2,2rn -k 1,1 "$TESTDIR/../data/priorities.tsv" | head -n 2 | cut -f 1) <(sort -k 1,1 filtered_strains.txt)

--- a/tests/functional/filter/cram/subsample-probabilistic-sampling-not-always-used.t
+++ b/tests/functional/filter/cram/subsample-probabilistic-sampling-not-always-used.t
@@ -1,17 +1,16 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Ensure probabilistic sampling is not used when unnecessary.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by region year month \
   >  --subsample-max-sequences 10 \
   >  --probabilistic-sampling \
   >  --subsample-seed 314159 \
-  >  --output-metadata "$TMP/filtered_metadata.tsv"
+  >  --output-metadata filtered_metadata.tsv
   Sampling at 10 per group.
   2 strains were dropped during filtering
   \t1 were dropped during grouping due to ambiguous year information (esc)

--- a/tests/functional/filter/cram/subsample-probabilistic-sampling-output.t
+++ b/tests/functional/filter/cram/subsample-probabilistic-sampling-output.t
@@ -1,17 +1,16 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Check output of probabilistic sampling.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by region year month \
   >  --subsample-max-sequences 3 \
   >  --probabilistic-sampling \
   >  --subsample-seed 314159 \
-  >  --output-metadata "$TMP/filtered_metadata.tsv"
+  >  --output-metadata filtered_metadata.tsv
   WARNING: Asked to provide at most 3 sequences, but there are 8 groups.
   Sampling probabilistically at 0.3633 sequences per group, meaning it is possible to have more than the requested maximum of 3 sequences after filtering.
   10 strains were dropped during filtering

--- a/tests/functional/filter/cram/subsample-skip-ambiguous-dates.t
+++ b/tests/functional/filter/cram/subsample-skip-ambiguous-dates.t
@@ -1,30 +1,29 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ source _setup.sh
+  $ source "$TESTDIR"/_setup.sh
 
 Try to subsample a maximum number of sequences by year and month, given metadata with ambiguous year and month values.
 Strains with ambiguous years or months should be dropped and logged.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by year month \
   >  --subsample-max-sequences 5 \
-  >  --output-strains "$TMP/filtered_strains.txt" \
-  >  --output-log "$TMP/filtered_log.tsv" > /dev/null
+  >  --output-strains filtered_strains.txt \
+  >  --output-log filtered_log.tsv > /dev/null
   WARNING: Asked to provide at most 5 sequences, but there are 6 groups.
-  $ grep "SG_018" "$TMP/filtered_log.tsv" | cut -f 1-2
+  $ grep "SG_018" filtered_log.tsv | cut -f 1-2
   SG_018\tskip_group_by_with_ambiguous_month (esc)
-  $ grep "COL/FLR_00024/2015" "$TMP/filtered_log.tsv" | cut -f 1-2
+  $ grep "COL/FLR_00024/2015" filtered_log.tsv | cut -f 1-2
   COL/FLR_00024/2015\tskip_group_by_with_ambiguous_year (esc)
 
 Group by 'year month week'. Using 'week' has some restrictions - 'year' should warn and 'month' should error.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by year month week \
   >  --sequences-per-group 1 \
-  >  --output-strains "$TMP/filtered_strains.txt" > /dev/null
+  >  --output-strains filtered_strains.txt > /dev/null
   WARNING: 'year' grouping will be ignored since 'week' includes ISO year.
   ERROR: 'month' and 'week' grouping cannot be used together.
   [2]
@@ -32,15 +31,15 @@ Group by 'year month week'. Using 'week' has some restrictions - 'year' should w
 Group by 'week'. Check the number of strains that have been dropped due to ambiguous day.
 
   $ ${AUGUR} filter \
-  >  --metadata filter/data/metadata.tsv \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --group-by week \
   >  --sequences-per-group 1 \
   >  --subsample-seed 0 \
-  >  --output-strains "$TMP/filtered_strains.txt" \
-  >  --output-log "$TMP/filtered_log.tsv" > /dev/null
-  $ grep "skip_group_by_with_ambiguous_year" "$TMP/filtered_log.tsv" | wc -l
+  >  --output-strains filtered_strains.txt \
+  >  --output-log filtered_log.tsv > /dev/null
+  $ grep "skip_group_by_with_ambiguous_year" filtered_log.tsv | wc -l
   \s*1 (re)
-  $ grep "skip_group_by_with_ambiguous_month" "$TMP/filtered_log.tsv" | wc -l
+  $ grep "skip_group_by_with_ambiguous_month" filtered_log.tsv | wc -l
   \s*1 (re)
-  $ grep "skip_group_by_with_ambiguous_day" "$TMP/filtered_log.tsv" | wc -l
+  $ grep "skip_group_by_with_ambiguous_day" filtered_log.tsv | wc -l
   \s*3 (re)

--- a/tests/functional/filter/data/filtered_log.tsv
+++ b/tests/functional/filter/data/filtered_log.tsv
@@ -1,6 +1,0 @@
-strain	filter	kwargs
-HND/2016/HU_ME59	filter_by_sequence_index	[]
-COL/FLR_00008/2015	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
-Colombia/2016/ZC204Se	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
-COL/FLR_00024/2015	filter_by_query	"[[""query"", ""country != 'Colombia'""]]"
-COL/FLR_00008/2015	force_include_strains	"[[""include_file"", ""filter/data/include.txt""]]"


### PR DESCRIPTION
### Description of proposed changes

`$TMP` is the test runner's temp directory, which is [shared across all individual tests](https://github.com/brodie/cram/blob/61212ab78a88ce4a18eee4e26c89bfe086b28e78/cram/_main.py#L185). This means files must be removed before running the next test to ensure a clean slate.

On the other hand, [the initial working directory of each test](https://github.com/brodie/cram/blob/61212ab78a88ce4a18eee4e26c89bfe086b28e78/cram/_run.py#L67-L70) is a directory within `$TMP` which is truly temporary per test file.

I updated all tests to use this initial working directory as a temporary directory. A summary of the changes:

1. Change the working directory from `$TESTDIR/../../` (`tests/functional/`) to the default initial working directory.
2. Update references to files in `tests/functional/filter/data`, since those had relied on the parent folder as the working directory.
3. Remove directory changes in the "setup" section, simplifying that to one command creating the `AUGUR` alias relative to `$TESTDIR`.
4. Remove rm commands used to clean up output files, since the working directory is a per-test temporary directory.
5. `filter-metadata-sequence-strains-mismatch.t`: Update the diff check to a direct check of file contents, since the resolved `$TESTDIR` must be matched by regex.

Note that if this approach is applied to other cram tests, issues/workarounds such as #863 and #1077 can be avoided.

### Related issue(s)

N/A

### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

- [x] Updated tests are successful in CI

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, dev change
