### PR TITLE
export and validate: Substantially improve validation errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,9 @@
 ### Bug Fixes
 
 * filter, frequencies, refine, parse: Properly handle invalid date errors and output the bad date. [#1140][] (@victorlin)
+* export, validate: Validation errors are now much more human-readable and actually pinpoint the problems. [#1134][] (@tsibley)
 
+[#1134]: https://github.com/nextstrain/augur/pull/1134
 [#1140]: https://github.com/nextstrain/augur/pull/1140
 
 ## 20.0.0 (20 January 2023)

--- a/augur/io/json.py
+++ b/augur/io/json.py
@@ -166,8 +166,14 @@ class JSONDecodeError(json.JSONDecodeError):
 
 def shorten_left(text, length, placeholder):
     """
-    A variant of :py:func:`shorten` which shortens from the left end of *text*
-    instead of the right.
+    Truncate the left end of *text* to a maximum *length* (if necessary),
+    indicating truncation with the given *placeholder*.
+
+    The maximum *length* must be longer than the length of the *placeholder*.
+
+    Behaviour is slightly different than :py:func:`textwrap.shorten` which is
+    intended for shortening sentences and works at the word, not character,
+    level.
 
     >>> shorten_left("foobar", 6, "...")
     'foobar'

--- a/augur/io/json.py
+++ b/augur/io/json.py
@@ -117,6 +117,7 @@ class JSONDecodeError(json.JSONDecodeError):
     Typically you won't need to ever reference this class directly.  It will be
     raised by :func:`load_json` and be caught by except blocks which catch the
     standard :class:`json.JSONDecodeError`.
+
     >>> load_json('{foo: "bar"}')
     Traceback (most recent call last):
         ...

--- a/augur/io/json.py
+++ b/augur/io/json.py
@@ -1,30 +1,35 @@
 """
-A copy of id3c/lib/id3c/json.py and the additional util functions from
-id3c/lib/id3c/utils.py of the seattleflu/id3c repo as of commit 911e7d7 and
-licensed under the MIT License. The License file included in the repo is
-copied below verbatim.
+This file, augur/io/json.py, started as a copy of lib/id3c/json.py and the
+functions shorten_left(), contextualize_char(), and mark_char() from
+lib/id3c/utils.py in the https://github.com/seattleflu/id3c repo as of commit
+911e7d7bfccc4d050e63e6f73d7a7e59fa1a80e8, licensed under the MIT License.
 
-MIT License
+Subsequent modifications (as recorded in Augur's own version control history)
+are licensed under the same terms as the rest of Augur, the GNU AGPL 3.0.
 
-Copyright (c) 2018 Brotman Baty Institute
+The LICENSE file included in ID3C's repo is copied below verbatim::
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+    MIT License
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+    Copyright (c) 2018 Brotman Baty Institute
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 """
 import json
 from datetime import datetime

--- a/augur/io/json.py
+++ b/augur/io/json.py
@@ -165,6 +165,48 @@ class JSONDecodeError(json.JSONDecodeError):
         return f"{error}: {context}"
 
 
+def shorten_as_json(value, length, placeholder) -> str:
+    """
+    Converts *value* to JSON with :py:func:`as_json` and then truncates it to a
+    maximum *length* (if necessary), indicating truncation with the given
+    *placeholder*.
+
+    >>> shorten_as_json({'hello': 'world', 'x': 42}, 100, '…')
+    '{"hello": "world", "x": 42}'
+    >>> shorten_as_json({'hello': 'world', 'x': 42}, 21, '…')
+    '{"hello": "world", …}'
+
+    For readability, the outermost JSON value delimiter at the right hand side,
+    i.e. ``}``, ``]``, or ``"``, is preserved, such that *placeholder* will put
+    placed "inside" *value*'s JSON representation.
+
+    >>> shorten_as_json([1,2,3,'four',5,6], 20, '…')
+    '[1, 2, 3, "four", …]'
+    >>> shorten_as_json([1,2,3,'four',5,6], 15, '…')
+    '[1, 2, 3, "fo…]'
+
+    The maximum *length* must be at least two characters longer than the length
+    of the *placeholder*.
+
+    >>> shorten_as_json({'foo': 'bar'}, 4, '...')
+    Traceback (most recent call last):
+        ...
+    ValueError: maximum length (4) must be two greater than length of placeholder (3), i.e. at least 5
+    >>> shorten_as_json({'foo': 'bar'}, 5, '...')
+    '{...}'
+    """
+    min_length = len(placeholder) + 2
+    if length < min_length:
+        raise ValueError(f"maximum length ({length}) must be two greater than length of placeholder ({len(placeholder)}), i.e. at least {min_length}")
+
+    json_value = as_json(value)
+
+    if len(json_value) > length:
+        return json_value[0:length - len(placeholder) - 1] + placeholder + json_value[-1:]
+    else:
+        return json_value
+
+
 def shorten_left(text, length, placeholder):
     """
     Truncate the left end of *text* to a maximum *length* (if necessary),

--- a/docs/api/developer/augur.io.json.rst
+++ b/docs/api/developer/augur.io.json.rst
@@ -1,0 +1,7 @@
+augur.io.json
+=============
+
+.. automodule:: augur.io.json
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/developer/augur.io.rst
+++ b/docs/api/developer/augur.io.rst
@@ -9,6 +9,7 @@ augur.io
 .. toctree::
 
    augur.io.file
+   augur.io.json
    augur.io.metadata
    augur.io.print
    augur.io.sequences


### PR DESCRIPTION
All errors are reported in the case of subschemas inside a "oneOf" validator, such as used by our "tree" property.  Previously only the top-level error was reported and it was worse than useless as it was incredibly long and contained no actionable .

Suberrors are grouped by the validator arm they failed, making it clear why each element of a "oneOf" failed.

Errors avoid being overly long by consistently shortening output that might be long.  Different shortening strategies are used for different values in an attempt to preserve the most useful information.

Paths in error messages now index into the given JSON being validated, not the JSON Schema.  This disconnect was confusing as the schema path refers to properties that don't exist in the JSON being validated.

Resolves <https://github.com/nextstrain/augur/issues/1044>.

### Testing

- [x] Manually tested various error message situations
- [x] Added doctests
- [x] CI passes

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
