### PR TITLE
refine: Remove `--year-bounds`

### DIFF
--- a/augur/dates.py
+++ b/augur/dates.py
@@ -73,8 +73,8 @@ def numeric_date_type(date):
     except ValueError as e:
         raise argparse.ArgumentTypeError(str(e)) from e
 
-def ambiguous_date_to_date_range(uncertain_date, fmt, min_max_year=None):
-    return DateDisambiguator(uncertain_date, fmt=fmt, min_max_year=min_max_year).range()
+def ambiguous_date_to_date_range(uncertain_date, fmt):
+    return DateDisambiguator(uncertain_date, fmt=fmt).range()
 
 def is_date_ambiguous(date, ambiguous_by="any"):
     """
@@ -107,7 +107,7 @@ def is_date_ambiguous(date, ambiguous_by="any"):
         "X" in day and ambiguous_by in ("any", "day")
     ))
 
-def get_numerical_date_from_value(value, fmt=None, min_max_year=None):
+def get_numerical_date_from_value(value, fmt=None):
     value = str(value)
     if re.match(r'^-*\d+\.\d+$', value):
         # numeric date which can be negative
@@ -116,7 +116,7 @@ def get_numerical_date_from_value(value, fmt=None, min_max_year=None):
         # year-only date is ambiguous
         value = fmt.replace('%Y', value).replace('%m', 'XX').replace('%d', 'XX')
     if 'XX' in value:
-        ambig_date = ambiguous_date_to_date_range(value, fmt, min_max_year)
+        ambig_date = ambiguous_date_to_date_range(value, fmt)
         if ambig_date is None or None in ambig_date:
             return [None, None] #don't send to numeric_date or will be set to today
         return [treetime.utils.numeric_date(d) for d in ambig_date]
@@ -125,7 +125,7 @@ def get_numerical_date_from_value(value, fmt=None, min_max_year=None):
     except:
         return None
 
-def get_numerical_dates(metadata:pd.DataFrame, name_col = None, date_col='date', fmt=None, min_max_year=None):
+def get_numerical_dates(metadata:pd.DataFrame, name_col = None, date_col='date', fmt=None):
     if not isinstance(metadata, pd.DataFrame):
         raise AugurError("Metadata should be a pandas.DataFrame.")
     if fmt:
@@ -133,8 +133,7 @@ def get_numerical_dates(metadata:pd.DataFrame, name_col = None, date_col='date',
         dates = metadata[date_col].apply(
             lambda date: get_numerical_date_from_value(
                 date,
-                fmt,
-                min_max_year
+                fmt
             )
         ).values
     else:

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -126,7 +126,6 @@ def register_parser(parent_subparsers):
     parser.add_argument('--clock-filter-iqd', type=float, help='clock-filter: remove tips that deviate more than n_iqd '
                                 'interquartile ranges from the root-to-tip vs time regression')
     parser.add_argument('--vcf-reference', type=str, help='fasta file of the sequence the VCF was mapped to')
-    parser.add_argument('--year-bounds', type=int, nargs='+', help='specify min or max & min prediction bounds for samples with XX in year')
     parser.add_argument('--divergence-units', type=str, choices=['mutations', 'mutations-per-site'],
                         default='mutations-per-site', help='Units in which sequence divergences is exported.')
     parser.add_argument('--seed', type=int, help='seed for random number generation')
@@ -204,10 +203,7 @@ def run(args):
             print("ERROR: meta data with dates is required for time tree reconstruction", file=sys.stderr)
             return 1
         metadata = read_metadata(args.metadata)
-        if args.year_bounds:
-            args.year_bounds.sort()
-        dates = get_numerical_dates(metadata, fmt=args.date_format,
-                                    min_max_year=args.year_bounds)
+        dates = get_numerical_dates(metadata, fmt=args.date_format)
 
         # save input state string for later export
         for n in T.get_terminals():

--- a/augur/util_support/date_disambiguator.py
+++ b/augur/util_support/date_disambiguator.py
@@ -38,10 +38,9 @@ def resolve_uncertain_int(uncertain_string, min_or_max):
 class DateDisambiguator:
     """Transforms a date string with uncertainty into the range of possible dates."""
 
-    def __init__(self, uncertain_date, fmt="%Y-%m-%d", min_max_year=None):
+    def __init__(self, uncertain_date, fmt="%Y-%m-%d"):
         self.uncertain_date = uncertain_date
         self.fmt = fmt
-        self.min_max_year = min_max_year
 
         self.assert_only_less_significant_uncertainty()
 


### PR DESCRIPTION
### Description of proposed changes

This is the only usage of the `min_max_year` parameter in several internal functions where it is passed around ultimately to `DateDisambiguator`. Upon inspection, the value is set on the object but is actually unused. This is because some old logic got lost in a refactor: 1cf41fb7eb388077aff0ded044d32aab2e4c5590

Since this option is not doing anything and seems to be [unused for the most part](https://github.com/search?q=augur+refine+--year-bounds+NOT+path%3A%2F%5Eaugur%5C%2Frefine.py%2F&type=code), remove it as well as all the supporting code.

### Related issue(s)

Resolves #1136

### Testing

- [ ] Checks pass

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
