### PR TITLE
refine: Re-implement --year-bounds with error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,14 @@
 
 * Constrain `bcbio-gff` to >=0.7.0 and allow `Biopython` >=1.81 again. We had to introduce the `Biopython` constraint in v21.0.1 (see [#1152][]) due to `bcbio-gff` <0.7.0 relying on the removed `Biopython` feature `UnknownSeq`. [#1178][] (@corneliusroemer)
 
+### Bug fixes
+
+* filter, frequencies, refine, parse: Previously, ambiguous dates in the future had a limit of today's date imposed on the upper value but not the lower value. It is now imposed on the lower value as well. [#1171][] (@victorlin)
+* refine: `--year-bounds` was ignored in versions 9.0.0 through 20.0.0. It now works. [#1136][] (@victorlin)
+
+[#1136]: https://github.com/nextstrain/augur/issues/1136
 [#1152]: https://github.com/nextstrain/augur/pull/1152
+[#1171]: https://github.com/nextstrain/augur/issues/1171
 [#1178]: https://github.com/nextstrain/augur/pull/1178
 
 ## 21.1.0 (14 March 2023)

--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -117,7 +117,7 @@ def get_numerical_date_from_value(value, fmt=None, min_max_year=None):
         value = fmt.replace('%Y', value).replace('%m', 'XX').replace('%d', 'XX')
     if 'XX' in value:
         try:
-            ambig_date = AmbiguousDate(value, fmt=fmt, min_max_year=min_max_year).range()
+            ambig_date = AmbiguousDate(value, fmt=fmt).range(min_max_year=min_max_year)
         except InvalidDate as error:
             raise AugurError(str(error)) from error
         if ambig_date is None or None in ambig_date:

--- a/augur/dates/ambiguous_date.py
+++ b/augur/dates/ambiguous_date.py
@@ -65,7 +65,8 @@ class AmbiguousDate:
             resolve_uncertain_int(self.uncertain_date_components["d"], "max"),
         )
 
-        # Limit the max date to be no later than today's date.
+        # Limit the min and max dates to be no later than today's date.
+        min_date = min(min_date, datetime.date.today())
         max_date = min(max_date, datetime.date.today())
 
         return (min_date, max_date)

--- a/augur/dates/ambiguous_date.py
+++ b/augur/dates/ambiguous_date.py
@@ -49,6 +49,10 @@ class AmbiguousDate:
         self.assert_only_less_significant_uncertainty()
 
     def range(self):
+        """Return the range of possible dates defined by the ambiguous date.
+
+        Impose an upper limit of today's date.
+        """
         min_date = tuple_to_date(
             resolve_uncertain_int(self.uncertain_date_components["Y"], "min"),
             resolve_uncertain_int(self.uncertain_date_components["m"], "min"),
@@ -60,6 +64,8 @@ class AmbiguousDate:
             resolve_uncertain_int(self.uncertain_date_components["m"], "max"),
             resolve_uncertain_int(self.uncertain_date_components["d"], "max"),
         )
+
+        # Limit the max date to be no later than today's date.
         max_date = min(max_date, datetime.date.today())
 
         return (min_date, max_date)

--- a/augur/dates/errors.py
+++ b/augur/dates/errors.py
@@ -9,3 +9,6 @@ class InvalidDate(Exception):
     def __str__(self):
         """Return a human-readable summary of the error."""
         return f"Invalid date {self.date!r}: {self.message}"
+
+class InvalidYearBounds(Exception):
+    """Custom exception class to handle year bounds in unsupported formats."""

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -5,6 +5,7 @@ import numpy as np
 import sys
 from Bio import Phylo
 from .dates import get_numerical_dates
+from .dates.errors import InvalidYearBounds
 from .io.metadata import read_metadata
 from .utils import read_tree, write_json, InvalidTreeError
 from .errors import AugurError
@@ -206,8 +207,11 @@ def run(args):
         metadata = read_metadata(args.metadata)
         if args.year_bounds:
             args.year_bounds.sort()
-        dates = get_numerical_dates(metadata, fmt=args.date_format,
-                                    min_max_year=args.year_bounds)
+        try:
+            dates = get_numerical_dates(metadata, fmt=args.date_format,
+                                        min_max_year=args.year_bounds)
+        except InvalidYearBounds as error:
+            raise AugurError(f"Invalid value for --year-bounds: {error}")
 
         # save input state string for later export
         for n in T.get_terminals():

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -205,8 +205,6 @@ def run(args):
             print("ERROR: meta data with dates is required for time tree reconstruction", file=sys.stderr)
             return 1
         metadata = read_metadata(args.metadata)
-        if args.year_bounds:
-            args.year_bounds.sort()
         try:
             dates = get_numerical_dates(metadata, fmt=args.date_format,
                                         min_max_year=args.year_bounds)

--- a/tests/dates/test_dates.py
+++ b/tests/dates/test_dates.py
@@ -50,10 +50,11 @@ class TestDates:
 
     @freeze_time("2000-02-20")
     def test_get_numerical_date_from_value_current_day_limit(self):
-        min_date, max_date = dates.get_numerical_date_from_value("2000-02-XX", "%Y-%m-%d")
+        min_date, max_date = dates.get_numerical_date_from_value("2000-03-XX", "%Y-%m-%d")
+        # min_date is not subject to the upper limit
         assert (min_date
-            == pytest.approx(dates.numeric_date(datetime.date(year=2000, month=2, day=1)), abs=1e-3)
-            == pytest.approx(2000.086, abs=1e-3)
+            == pytest.approx(dates.numeric_date(datetime.date(year=2000, month=3, day=1)), abs=1e-3)
+            == pytest.approx(2000.165, abs=1e-3)
         )
         assert (max_date
             == pytest.approx(dates.numeric_date(datetime.date(year=2000, month=2, day=20)), abs=1e-3)

--- a/tests/dates/test_dates.py
+++ b/tests/dates/test_dates.py
@@ -51,10 +51,9 @@ class TestDates:
     @freeze_time("2000-02-20")
     def test_get_numerical_date_from_value_current_day_limit(self):
         min_date, max_date = dates.get_numerical_date_from_value("2000-03-XX", "%Y-%m-%d")
-        # min_date is not subject to the upper limit
         assert (min_date
-            == pytest.approx(dates.numeric_date(datetime.date(year=2000, month=3, day=1)), abs=1e-3)
-            == pytest.approx(2000.165, abs=1e-3)
+            == pytest.approx(dates.numeric_date(datetime.date(year=2000, month=2, day=20)), abs=1e-3)
+            == pytest.approx(2000.138, abs=1e-3)
         )
         assert (max_date
             == pytest.approx(dates.numeric_date(datetime.date(year=2000, month=2, day=20)), abs=1e-3)

--- a/tests/functional/refine/cram/year-bounds-error.t
+++ b/tests/functional/refine/cram/year-bounds-error.t
@@ -1,0 +1,50 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata with a strain that has partial ambiguity on the century-level
+(20XX) so that --year-bounds is applied.
+
+  $ cat >metadata.tsv <<~~
+  > strain	date
+  > PAN/CDC_259359_V1_V3/2015	20XX-XX-XX
+  > ~~
+
+
+Check that invalid --year-bounds provides useful error messages.
+
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" \
+  >  --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --metadata metadata.tsv \
+  >  --output-tree tree.nwk \
+  >  --output-node-data branch_lengths.json \
+  >  --timetree \
+  >  --year-bounds 1950 1960 1970 \
+  >  --divergence-units mutations > /dev/null
+  ERROR: Invalid value for --year-bounds: The year bounds [1950, 1960, 1970] must have only one (lower) or two (lower, upper) bounds.
+  [2]
+
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" \
+  >  --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --metadata metadata.tsv \
+  >  --output-tree tree.nwk \
+  >  --output-node-data branch_lengths.json \
+  >  --timetree \
+  >  --year-bounds 0 1000 \
+  >  --divergence-units mutations > /dev/null
+  ERROR: Invalid value for --year-bounds: 0 is not a valid year.
+  [2]
+
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" \
+  >  --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --metadata metadata.tsv \
+  >  --output-tree tree.nwk \
+  >  --output-node-data branch_lengths.json \
+  >  --timetree \
+  >  --year-bounds -2000 -3000 \
+  >  --divergence-units mutations > /dev/null
+  ERROR: Invalid value for --year-bounds: -3000 is not a valid year.
+  [2]

--- a/tests/functional/refine/cram/year-bounds.t
+++ b/tests/functional/refine/cram/year-bounds.t
@@ -1,0 +1,66 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create a copy of tests/functional/refine/data/metadata.tsv, adding partial ambiguity on the century-level (20XX) for the first strain PAN/CDC_259359_V1_V3/2015.
+
+  $ cat >metadata.tsv <<~~
+  > strain	date
+  > PAN/CDC_259359_V1_V3/2015	20XX-XX-XX
+  > COL/FLR_00024/2015	2015-12-XX
+  > PRVABC59	2015-12-XX
+  > COL/FLR_00008/2015	2015-12-XX
+  > Colombia/2016/ZC204Se	2016-01-06
+  > ZKC2/2016	2016-02-16
+  > VEN/UF_1/2016	2016-03-25
+  > DOM/2016/BB_0059	2016-04-04
+  > BRA/2016/FC_6706	2016-04-08
+  > DOM/2016/BB_0183	2016-04-18
+  > EcEs062_16	2016-04-XX
+  > HND/2016/HU_ME59	2016-05-13
+  > ~~
+
+Limit ambiguous dates to be within (2000, 2020).
+
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" \
+  >  --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --metadata metadata.tsv \
+  >  --output-tree tree.nwk \
+  >  --output-node-data branch_lengths.json \
+  >  --timetree \
+  >  --year-bounds 2000 2020 \
+  >  --coalescent opt \
+  >  --date-confidence \
+  >  --date-inference marginal \
+  >  --clock-filter-iqd 4 \
+  >  --seed 314159 \
+  >  --divergence-units mutations &> /dev/null
+
+Check that the inferred date is 2020-12-31.
+TODO: Using jq woud be cleaner, but requires an extra dev dependency.
+
+  $ python3 -c 'import json, sys; print(json.load(sys.stdin)["nodes"]["PAN/CDC_259359_V1_V3/2015"]["date"])' < branch_lengths.json
+  2020-12-31
+
+Reverse the order to check that order does not matter.
+
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" \
+  >  --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --metadata metadata.tsv \
+  >  --output-tree tree.nwk \
+  >  --output-node-data branch_lengths.json \
+  >  --timetree \
+  >  --year-bounds 2020 2000 \
+  >  --coalescent opt \
+  >  --date-confidence \
+  >  --date-inference marginal \
+  >  --clock-filter-iqd 4 \
+  >  --seed 314159 \
+  >  --divergence-units mutations &> /dev/null
+
+Run the same check as above.
+
+  $ python3 -c 'import json, sys; print(json.load(sys.stdin)["nodes"]["PAN/CDC_259359_V1_V3/2015"]["date"])' < branch_lengths.json
+  2020-12-31


### PR DESCRIPTION
### Description of proposed changes

See commit messages.

### Related issue(s)

- Fixes #1136
- Fixes #1171

### Testing

- [x] Updated and added pytests
- [x] Added a functional test for `augur refine` with `--year-bounds`
- [x] Checks pass

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
