### PR TITLE
Allow multiple thresholds for measurements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## __NEXT__
 
+### Major Changes
+
+* measurements export: Supports exporting multiple thresholds per collection via the measurements config and the `--thresholds` option. This change is backwards compatible with previous uses of the `--threshold` option. However, due to the updates to the JSON schema, users will need to update to Auspice v2.43.0 for thresholds to be displayed properly in the measurements panel. [#1148][] (@joverlee521)
+
 ### Features
 
 * export v2: Add `--validation-mode={error,warn,skip}` option for more nuanced control of validation.  The new "warn" mode performs validation and emits messages about potential problems, but it does not cause the export command to fail even if there are problems. [#1135][] (@tsibley)
@@ -14,6 +18,7 @@
 [#1134]: https://github.com/nextstrain/augur/pull/1134
 [#1135]: https://github.com/nextstrain/augur/pull/1135
 [#1140]: https://github.com/nextstrain/augur/pull/1140
+[#1148]: https://github.com/nextstrain/augur/pull/1148
 
 ## 20.0.0 (20 January 2023)
 

--- a/augur/data/schema-measurements-collection-config.json
+++ b/augur/data/schema-measurements-collection-config.json
@@ -74,8 +74,18 @@
             "description": "The short label to display for the x-axis that describes the `value` of the measurements in a collection",
             "type": "string"
         },
+        "thresholds": {
+            "description": "Numeric measurement thresholds to be displayed as solid grey lines across subplots. Optional -- if not provided, no threshold will be displayed.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "description": "A numeric measurement threshold value.",
+                "type": "number"
+            }
+        },
         "threshold": {
-            "description": "A numeric measurement threshold to be displayed as a single grey line shared across subplots. Optional -- if not provided, no threshold will be displayed",
+            "deprecated": true,
+            "description": "DEPRECATED - A numeric measurement threshold to be displayed as a single grey line shared across subplots. Will be ignored if 'thresholds' is provided.",
             "type": "number"
         },
         "display_defaults": {

--- a/augur/data/schema-measurements.json
+++ b/augur/data/schema-measurements.json
@@ -89,8 +89,18 @@
                         "description": "The short label to display for the x-axis that describes the `value` of the measurements in a collection",
                         "type": "string"
                     },
+                    "thresholds": {
+                        "description": "Numeric measurement thresholds to be displayed as solid grey lines across subplots. Optional -- if not provided, no threshold will be displayed.",
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "description": "A numeric measurement threshold value.",
+                            "type": "number"
+                        }
+                    },
                     "threshold": {
-                        "description": "A numeric measurement threshold to be displayed as a single grey line shared across subplots. Optional -- if not provided, no threshold will be displayed",
+                        "deprecated": true,
+                        "description": "DEPRECATED - A numeric measurement threshold to be displayed as a single grey line shared across subplots. Will be ignored if 'thresholds' is provided.",
                         "type": "number"
                     },
                     "display_defaults": {

--- a/augur/measurements/export.py
+++ b/augur/measurements/export.py
@@ -68,8 +68,8 @@ def register_parser(parent_subparsers):
         help="The short label to display for the x-axis that describles the value of the measurements. " +
              "If not provided via config or command line option, the panel's default " +
              f"x-axis label is {DEFAULT_ARGS['x_axis_label']!r}.")
-    config.add_argument("--threshold", type=float,
-        help="A measurements value threshold to be displayed in the measurements panel.")
+    config.add_argument("--threshold", type=float, nargs="+", dest="thresholds",
+        help="Measurements value threshold(s) to be displayed in the measurements panel.")
     config.add_argument("--filters", nargs="+",
         help="The columns that are to be used a filters for measurements. " +
              "If not provided, all columns will be available as filters.")
@@ -207,8 +207,13 @@ def run(args):
         print("ERROR: Cannot create measurements JSON without valid groupings", file=sys.stderr)
         sys.exit(1)
 
+    # Convert deprecated single threshold value to list if "thresholds" not provided
+    single_threshold = collection_config.pop("threshold", None)
+    if single_threshold is not None and "thresholds" not in collection_config:
+        collection_config["thresholds"] = [single_threshold]
+
     # Combine collection config with command line args
-    config_key_args = ['key', 'title', 'filters', 'x_axis_label', 'threshold']
+    config_key_args = ['key', 'title', 'filters', 'x_axis_label', 'thresholds']
     display_default_args = ['group_by', 'measurements_display', 'show_overall_mean', 'show_threshold']
 
     for key_arg in config_key_args:

--- a/augur/measurements/export.py
+++ b/augur/measurements/export.py
@@ -83,7 +83,7 @@ def register_parser(parent_subparsers):
         help="Show or hide the overall mean per group by default")
     config.add_argument("--show-threshold", "--hide-threshold",
         dest="show_threshold", action=HideAsFalseAction, nargs=0,
-        help="Show or hide the threshold by default. This will be ignored if no threshold is provided.")
+        help="Show or hide the threshold(s) by default. This will be ignored if no threshold(s) are provided.")
 
     optional = parser.add_argument_group(
         title="OPTIONAL SETTINGS"

--- a/augur/measurements/export.py
+++ b/augur/measurements/export.py
@@ -68,7 +68,7 @@ def register_parser(parent_subparsers):
         help="The short label to display for the x-axis that describles the value of the measurements. " +
              "If not provided via config or command line option, the panel's default " +
              f"x-axis label is {DEFAULT_ARGS['x_axis_label']!r}.")
-    config.add_argument("--threshold", type=float, nargs="+", dest="thresholds",
+    config.add_argument("--thresholds", type=float, nargs="+",
         help="Measurements value threshold(s) to be displayed in the measurements panel.")
     config.add_argument("--filters", nargs="+",
         help="The columns that are to be used a filters for measurements. " +

--- a/tests/functional/measurements_export.t
+++ b/tests/functional/measurements_export.t
@@ -145,7 +145,7 @@ Measurements export for a single collection using a collection config and comman
   >   --key override-collection \
   >   --title override-collection-display-title \
   >   --x-axis-label override-label \
-  >   --threshold 2.0 0.0 \
+  >   --thresholds 2.0 0.0 \
   >   --filters field_3 \
   >   --group-by field_3 \
   >   --measurements-display raw \

--- a/tests/functional/measurements_export.t
+++ b/tests/functional/measurements_export.t
@@ -135,3 +135,23 @@ Measurements export for a single collection using a collection config and comman
 
   $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/single_collection_with_overrides_measurements.json "$TMP/single_collection_with_overrides_measurements.json"
   {}
+
+Measurements export for a single collection using a collection config and command-line overrides with multiple thresholds.
+
+  $ ${AUGUR} measurements export \
+  >   --collection measurements_export/collection.tsv \
+  >   --collection-config measurements_export/collection_config.json \
+  >   --grouping-column field_3 \
+  >   --key override-collection \
+  >   --title override-collection-display-title \
+  >   --x-axis-label override-label \
+  >   --threshold 2.0 0.0 \
+  >   --filters field_3 \
+  >   --group-by field_3 \
+  >   --measurements-display raw \
+  >   --hide-overall-mean \
+  >   --hide-threshold \
+  >   --output-json "$TMP/single_collection_with_multiple_thresholds.json" &>/dev/null
+
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/single_collection_with_multiple_thresholds.json "$TMP/single_collection_with_multiple_thresholds.json"
+  {}

--- a/tests/functional/measurements_export/single_collection_with_args_measurements.json
+++ b/tests/functional/measurements_export/single_collection_with_args_measurements.json
@@ -43,7 +43,7 @@
           "value": 3.0
         }
       ],
-      "threshold": 2.0,
+      "thresholds": [2.0],
       "title": "collection-display-title",
       "x_axis_label": "label"
     }

--- a/tests/functional/measurements_export/single_collection_with_config_measurements.json
+++ b/tests/functional/measurements_export/single_collection_with_config_measurements.json
@@ -67,7 +67,7 @@
           "value": 3.0
         }
       ],
-      "threshold": 2.0,
+      "thresholds": [2.0],
       "title": "collection-display-title",
       "x_axis_label": "label"
     }

--- a/tests/functional/measurements_export/single_collection_with_multiple_thresholds.json
+++ b/tests/functional/measurements_export/single_collection_with_multiple_thresholds.json
@@ -53,7 +53,7 @@
           "value": 3.0
         }
       ],
-      "thresholds": [10.0],
+      "thresholds": [2.0, 0.0],
       "title": "override-collection-display-title",
       "x_axis_label": "override-label"
     }


### PR DESCRIPTION
### Description of proposed changes
Adds the ability to export multiple thresholds for the measurements JSON. 

Note that this will produce measurements JSONs that will only have the
"thresholds" array but not the deprecated single "threshold" value. This
means the thresholds will **not** be displayed in Auspice v2.42.0 or lower
because Auspice still expects the single "threshold" value.

### Testing
Added additional Cram test for multiple threshold values. 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
