### PR TITLE
fix: Pin Biopython to <=1.80

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* Constrain Biopython version to <=1.80 so that `augur translate` is not broken by a deprecation of `UnknownSeq` in 1.81. When running `augur translate` with Biopython 1.81, the user will receive an error starting with `ERROR: Package BCBio.GFF not found!` and ending with `TypeError: object of type 'NoneType' has no len()`. [#1152][] (@corneliusroemer)
+
+[#1152]: https://github.com/nextstrain/augur/pull/1152
 
 ## 21.0.0 (7 February 2023)
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
     python_requires = '>={}'.format('.'.join(str(n) for n in py_min_version)),
     install_requires = [
         "bcbio-gff >=0.6.0, ==0.6.*",
-        "biopython >=1.67, !=1.77, !=1.78",
+        "biopython >=1.67, !=1.77, !=1.78, <=1.80",
         "cvxopt >=1.1.9, ==1.*",
         "isodate ==0.6.*",
         "jsonschema >=3.0.0, ==3.*",


### PR DESCRIPTION
1.81 is incompatible with BCBio.GFF which requires a module
that was removed in 1.81
Partially resolves https://github.com/nextstrain/augur/issues/1151

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
- [x] Tests pass, even for Biopython latest - which is exactly what we need

After release, make sure Bioconda gets the pin mirrored
