### PR TITLE
ci: post release, wait 10min before docker update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,11 @@ jobs:
     needs: [run]
     runs-on: ubuntu-latest
     steps:
+    # Delay for 10 minutes to allow the PyPI package to be available.
+    # See https://github.com/nextstrain/docker-base/issues/128
+    - name: Sleep for 10 minutes
+      run: sleep 600
+      shell: bash
     - run: gh workflow run ci.yml --repo nextstrain/docker-base
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}


### PR DESCRIPTION
Mitigates https://github.com/nextstrain/docker-base/issues/128

It seems to take a few minutes for Pypi to return the newest release. So we should delay triggering the automatic docker build. 10min seems like a reasonable wait time. The update happened around 2min when we last did the release.