### PR TITLE
ci: trigger conda-base update after augur release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,10 +35,13 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
           TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
-  rebuild-docker-image:
+  rebuild-docker-and-conda-base-update:
     needs: [run]
     runs-on: ubuntu-latest
     steps:
     - run: gh workflow run ci.yml --repo nextstrain/docker-base
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
+    - run: gh workflow run ci.yaml --repo nextstrain/conda-base
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}


### PR DESCRIPTION
We currently only trigger a docker-base update.
There's no reason we shouldn't also trigger conda-base CI: https://github.com/nextstrain/conda-base/blob/main/.github/workflows/ci.yaml
The code here predates the existence of conda-base.