### PR TITLE
Automatically check for new GitHub actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot configuration file
+# Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Each ecosystem is checked on a scheduled interval defined below.
+# To trigger a check manually, go to https://github.com/nextstrain/augur/network/updates
+# and click "Last checked …" then "Check for updates".
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Description of proposed changes

Configure dependabot to do this for us.

More info: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

### Related issue(s)

Ported from https://github.com/nextstrain/docker-base/pull/113, but any Dependabot secrets configuration since no secrets are used in the PR checks.

### Testing

- [x] Pushed changes to a fork repo, enabled dependabot, and observed new dependabot PRs as expected. ([evidence](https://github.com/victorlin/augur/pulls))
- [x] Checks pass, though these changes shouldn't affect anything there

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, dev change
