### PR TITLE
Add dev status update to changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,10 @@
 * translate: Fix error handling when features cannot be read from reference sequence file. [#1168][] (@victorlin)
 * translate: Remove an unnecessary check which allowed for inaccurate error messages to be shown. [#1169][] (@victorlin)
 * frequencies: Previously, monthly pivot points calculated from the end of a month may have been shifted by 1-3 days. This is now fixed. [#1150][] (@victorlin)
+* Update development status on PyPI from "3 - Alpha" to "5 - Production/Stable". This should have been done since the beginning of this changelog, but now it is official. [#1160][] (@corneliusroemer)
 
 [#1150]: https://github.com/nextstrain/augur/pull/1150
+[#1160]: https://github.com/nextstrain/augur/pull/1160
 [#1168]: https://github.com/nextstrain/augur/pull/1168
 [#1169]: https://github.com/nextstrain/augur/pull/1169
 


### PR DESCRIPTION
Follow-up to #1160.

I think this is worth adding in the changelog because it is visible on [PyPI](https://pypi.org/project/nextstrain-augur/):

![image](https://user-images.githubusercontent.com/13424970/221266385-9919f474-6807-4869-9e54-ab5120689827.png)
