### PR TITLE
Run CI daily

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,12 +3,16 @@ on:
   push:
     branches:
       - master
+
   # Routinely check that tests pass with new versions of dependencies.
   schedule:
     # Every day at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
     - cron: "42 17 * * *"
+
   pull_request:
+
   workflow_dispatch:
+
 jobs:
   test:
     name: test (python=${{ matrix.python-version }} biopython=${{ matrix.biopython-version || 'latest' }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - master
+  # Routinely check that tests pass with new versions of dependencies.
+  schedule:
+    # Every day at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
+    - cron: "42 17 * * *"
   pull_request:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
### Description of proposed changes

Schedule copied from a workflow in nextstrain-cli: https://github.com/nextstrain/cli/commit/9b489c9d035f27bef00a06a182ed324660b45375

### Related issue(s)

Prompted by https://github.com/nextstrain/augur/issues/1151#issuecomment-1434823342:

> [@corneliusroemer] Maybe a case for running CI at least daily to automatically notice if a new package version causes issues? In this case, I spotted it quickly because I happened to manually update my environment and run into the bug in the wild, but would be good not to depend on manual updates or user reports.

### Testing

N/A

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, dev change
