### PR TITLE
translate: Fix error handling of reference sequence features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* translate: Fix error handling when features cannot be read from reference sequence file. [#1168][] (@victorlin)
+
+[#1168]: https://github.com/nextstrain/augur/pull/1168
 
 ## 21.0.1 (17 February 2023)
 

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -351,10 +351,10 @@ def run(args):
 
     ## load features; only requested features if genes given
     features = load_features(args.reference_sequence, genes)
-    print("Read in {} features from reference sequence file".format(len(features)))
     if features is None:
         print("ERROR: could not read features of reference sequence file")
         return 1
+    print("Read in {} features from reference sequence file".format(len(features)))
 
     ### translate every feature - but not 'nuc'!
     translations = {}


### PR DESCRIPTION
### Description of proposed changes

Previously, the error message was never reached because len(features) would raise another error:

    TypeError: object of type 'NoneType' has no len()

Switching the order allows for the intended error handling to happen.

### Related issue(s)

Fixes uncaught error in #1151.

### Testing

No testing as I'm not sure how to reproduce this scenario, but I think this is a trivial change.

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
