### PR TITLE
Remove check for BCBio ImportError

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,10 @@
 ### Bug fixes
 
 * translate: Fix error handling when features cannot be read from reference sequence file. [#1168][] (@victorlin)
+* translate: Remove an unnecessary check which allowed for inaccurate error messages to be shown. [#1169][] (@victorlin)
 
 [#1168]: https://github.com/nextstrain/augur/pull/1168
+[#1169]: https://github.com/nextstrain/augur/pull/1169
 
 ## 21.0.1 (17 February 2023)
 

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -152,11 +152,7 @@ def load_features(reference, feature_names=None):
     features = {}
     if '.gff' in reference.lower():
         #looks for 'gene' and 'gene' as best for TB
-        try:
-            from BCBio import GFF #Package name is confusing - tell user exactly what they need!
-        except ImportError:
-            print("ERROR: Package BCBio.GFF not found! Please install using \'pip install bcbio-gff\' before re-running.")
-            return None
+        from BCBio import GFF
         limit_info = dict( gff_type = ['gene', 'source'] )
 
         with open(reference, encoding='utf-8') as in_handle:


### PR DESCRIPTION
### Description of proposed changes

This made sense when it was added (in c6a9b24be7214b6b9dbc6d2fc665cd85e98a66c4) but is not necessary now since all installation options (pip, Bioconda) should automatically install bcbio-gff as a dependency of Augur.

The check gave potential for inaccurate error messages such as when an ImportError within the BCBio package is raised¹.

¹ https://github.com/nextstrain/augur/issues/1151#issuecomment-1434744483

### Related issue(s)

Addresses inaccurate error handling mentioned in #1151.

### Testing

N/A

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
