### PR TITLE
docs: Update usage docs for `ancestral` and `translate`

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -1,5 +1,16 @@
 """
 Infer ancestral sequences based on a tree.
+
+The ancestral sequences are inferred using `TreeTime <https://academic.oup.com/ve/article/4/1/vex042/4794731>`_.
+Each internal node gets assigned a nucleotide sequence that maximizes a
+likelihood on the tree given its descendants and its parent node.
+Each node then gets assigned a list of nucleotide mutations for any position
+that has a mismatch between its own sequence and its parent's sequence.
+The node sequences and mutations are output to a node-data JSON file.
+
+.. note::
+
+    The mutation positions in the node-data JSON are one-based.
 """
 
 import os, shutil, time, json, sys

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -1,5 +1,16 @@
 """
 Translate gene regions from nucleotides to amino acids.
+
+Translates nucleotide sequences of nodes in a tree to amino acids for gene
+regions of the annotated features of the provided reference sequence.
+Each node then gets assigned a list of amino acid mutations for any position
+that has a mismatch between its own amino acid sequence and its parent's sequence.
+The reference amino acid sequences, genome annotations, and node amino acid
+mutations are output to a node-data JSON file.
+
+.. note::
+
+    The mutation positions in the node-data JSON are one-based.
 """
 
 import os, sys

--- a/docs/usage/cli/ancestral.rst
+++ b/docs/usage/cli/ancestral.rst
@@ -2,9 +2,38 @@
 augur ancestral
 ===============
 
+.. contents::
+    :local:
+
 .. argparse::
     :module: augur
     :func: make_parser
     :prog: augur
     :path: ancestral
-        
+
+Example Node Data JSON
+======================
+
+Here's an example of the output node-data JSON where ``NODE_1`` has no
+mutations compared to it's parent and ``NODE_2`` has multiple mutations.
+
+.. code-block:: json
+
+    {
+        "nodes": {
+            "NODE_1": {
+                "muts": [],
+                "sequence": "TCCAAACAAAGT..."
+            },
+            "NODE_2": {
+                "muts": [
+                  "A4461G",
+                  "A6591G",
+                  "A9184C",
+                  "A10385T",
+                  "T15098C"
+                ],
+                "sequence": "TCCAAACAAAGT..."
+            }
+        }
+    }

--- a/docs/usage/cli/translate.rst
+++ b/docs/usage/cli/translate.rst
@@ -2,9 +2,71 @@
 augur translate
 ===============
 
+.. contents::
+    :local:
+
 .. argparse::
     :module: augur
     :func: make_parser
     :prog: augur
     :path: translate
-        
+
+Example Node Data JSON
+======================
+
+Here's an example of the output node-data JSON where ``NODE_1`` has no
+mutations compared to it's parent and ``NODE_2`` has multiple mutations in
+multiple genes.
+
+.. code-block:: json
+
+    {
+        "annotations": {
+            "GENE_1": {
+                "end": 1685,
+                "seqid": "reference.gb",
+                "start": 108,
+                "strand": "+",
+                "type": "CDS"
+            },
+            "GENE_2": {
+                "end": 2705,
+                "seqid": "reference.gb",
+                "start": 1807,
+                "strand": "+",
+                "type": "CDS"
+            },
+        },
+        "nodes": {
+            "NODE_1": {
+                "aa_muts": []
+            },
+            "NODE_2": {
+                "aa_muts": [
+                    "GENE_1": [
+                        "S139N",
+                        "R213K",
+                        "R439G",
+                        "V440A",
+                        "D474N",
+                        "S479W",
+                        "S481T",
+                        "P485L",
+                        "R521K"
+                    ],
+                    "GENE_2": [
+                        "P43S",
+                        "D46N",
+                        "C64R",
+                        "R98K",
+                        "D136G",
+                        "M175V"
+                    ]
+                ]
+            }
+        },
+        "reference": {
+            "GENE_1": "MATLLRSLAL...",
+            "GENE_2": "MAEEQARHVK..."
+        }
+    }


### PR DESCRIPTION
### Description of proposed changes
Adds a high level explanation based on an email sent by @huddlej for explaining the entropy panel in Auspice. (Visible in the Nextstrain discussion forum¹)

Includes a generic example of the output node-data JSONs so users can produce their own JSONs outside of Augur if desired.

¹ https://discussion.nextstrain.org/t/make-auspice-entropy-panel-show-mutations-with-respect-to-arbitrary-sequence-reference-rather-than-reconstructed-root-of-the-tree/1333/2

### Related issue(s)
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Related to https://github.com/nextstrain/docs.nextstrain.org/pull/153

### Checklist

- ~[ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ Doc updates only. 

---
See docs previews:
- [ancestral](https://nextstrain--1174.org.readthedocs.build/projects/augur/en/1174/usage/cli/ancestral.html)
- [translate](https://nextstrain--1174.org.readthedocs.build/projects/augur/en/1174/usage/cli/translate.html)
