### PR TITLE
Add test for export with color by metadata

### DIFF
--- a/tests/functional/export_v2.t
+++ b/tests/functional/export_v2.t
@@ -166,5 +166,22 @@ Run export with metadata and external colors TSV that contains zero values.
   {}
   $ rm -f "$TMP/dataset6.json"
 
+Run export with metadata and color by a metadata column ("custom_trait") in addition to colorings defined in the node data.
+
+  $ ${AUGUR} export v2 \
+  >  --tree export_v2/tree.nwk \
+  >  --metadata export_v2/dataset1_metadata_with_strain.tsv \
+  >  --node-data export_v2/div_node-data.json export_v2/location_node-data.json \
+  >  --auspice-config export_v2/auspice_config1.json \
+  >  --maintainers "Nextstrain Team" \
+  >  --color-by-metadata custom_trait \
+  >  --output "$TMP/dataset_with_color_from_metadata.json" > /dev/null
+  WARNING: [config file] Trait 'custom_trait' is missing type information. We've guessed 'categorical'.
+  \s{0} (re)
+
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" export_v2/dataset_with_color_from_metadata.json "$TMP/dataset_with_color_from_metadata.json" \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+  $ rm -f "$TMP/dataset1.json"
 
   $ popd > /dev/null

--- a/tests/functional/export_v2/dataset1_metadata_with_strain.tsv
+++ b/tests/functional/export_v2/dataset1_metadata_with_strain.tsv
@@ -1,7 +1,7 @@
-strain	div	mutation_length
-tipA	1	1
-tipB	3	1
-tipC	3	1
-tipD	8	3
-tipE	9	4
-tipF	6	1
+strain	div	mutation_length	custom_trait
+tipA	1	1	A
+tipB	3	1	A
+tipC	3	1	B
+tipD	8	3	B
+tipE	9	4	C
+tipF	6	1	D

--- a/tests/functional/export_v2/dataset_with_color_from_metadata.json
+++ b/tests/functional/export_v2/dataset_with_color_from_metadata.json
@@ -1,0 +1,248 @@
+{
+  "meta": {
+    "colorings": [
+      {
+        "key": "location",
+        "legend": [
+          {
+            "display": "\u03b1",
+            "value": "alpha"
+          },
+          {
+            "value": "beta"
+          }
+        ],
+        "scale": [
+          [
+            "beta",
+            "#bd0026"
+          ],
+          [
+            "gamma",
+            "#6a51a3"
+          ]
+        ],
+        "title": "Location",
+        "type": "categorical"
+      },
+      {
+        "key": "mutation_length",
+        "legend": [
+          {
+            "bounds": [
+              -1,
+              2
+            ],
+            "display": "0-2",
+            "value": 1
+          },
+          {
+            "bounds": [
+              2,
+              5
+            ],
+            "display": "3-5",
+            "value": 3
+          },
+          {
+            "bounds": [
+              5,
+              10
+            ],
+            "display": ">5",
+            "value": 5
+          }
+        ],
+        "scale": [
+          [
+            1,
+            "#081d58"
+          ],
+          [
+            3,
+            "#1d91c0"
+          ],
+          [
+            5,
+            "#c7e9b4"
+          ]
+        ],
+        "title": "Mutations per branch",
+        "type": "continuous"
+      },
+      {
+        "key": "location",
+        "legend": [
+          {
+            "display": "\u03b1",
+            "value": "alpha"
+          },
+          {
+            "value": "beta"
+          }
+        ],
+        "scale": [
+          [
+            "beta",
+            "#bd0026"
+          ],
+          [
+            "gamma",
+            "#6a51a3"
+          ]
+        ],
+        "title": "Location",
+        "type": "categorical"
+      },
+      {
+        "key": "custom_trait",
+        "title": "custom_trait",
+        "type": "categorical"
+      }
+    ],
+    "filters": [
+      "location",
+      "custom_trait"
+    ],
+    "panels": [
+      "tree"
+    ],
+    "updated": "2021-06-09"
+  },
+  "tree": {
+    "branch_attrs": {},
+    "children": [
+      {
+        "branch_attrs": {},
+        "name": "tipA",
+        "node_attrs": {
+          "div": 1,
+          "location": {
+            "value": "delta"
+          },
+          "mutation_length": {
+            "value": 1
+          },
+          "custom_trait": {
+            "value": "A"
+          }
+        }
+      },
+      {
+        "branch_attrs": {},
+        "children": [
+          {
+            "branch_attrs": {},
+            "name": "tipB",
+            "node_attrs": {
+              "div": 3,
+              "location": {
+                "value": "gamma"
+              },
+              "mutation_length": {
+                "value": 1
+              },
+              "custom_trait": {
+                "value": "A"
+              }
+            }
+          },
+          {
+            "branch_attrs": {},
+            "name": "tipC",
+            "node_attrs": {
+              "div": 3,
+              "location": {
+                "value": "gamma"
+              },
+              "mutation_length": {
+                "value": 1
+              },
+              "custom_trait": {
+                "value": "B"
+              }
+            }
+          }
+        ],
+        "name": "internalBC",
+        "node_attrs": {
+          "div": 2,
+          "mutation_length": {
+            "value": 2
+          }
+        }
+      },
+      {
+        "branch_attrs": {},
+        "children": [
+          {
+            "branch_attrs": {},
+            "name": "tipD",
+            "node_attrs": {
+              "div": 8,
+              "location": {
+                "value": "alpha"
+              },
+              "mutation_length": {
+                "value": 3
+              },
+              "custom_trait": {
+                "value": "B"
+              }
+            }
+          },
+          {
+            "branch_attrs": {},
+            "name": "tipE",
+            "node_attrs": {
+              "div": 9,
+              "location": {
+                "value": "alpha"
+              },
+              "mutation_length": {
+                "value": 4
+              },
+              "custom_trait": {
+                "value": "C"
+              }
+            }
+          },
+          {
+            "branch_attrs": {},
+            "name": "tipF",
+            "node_attrs": {
+              "div": 6,
+              "location": {
+                "value": "beta"
+              },
+              "mutation_length": {
+                "value": 1
+              },
+              "custom_trait": {
+                "value": "D"
+              }
+            }
+          }
+        ],
+        "name": "internalDEF",
+        "node_attrs": {
+          "div": 5,
+          "location": {
+            "value": "alpha"
+          },
+          "mutation_length": {
+            "value": 5
+          }
+        }
+      }
+    ],
+    "name": "ROOT",
+    "node_attrs": {
+      "div": 0,
+      "mutation_length": {
+        "value": 0
+      }
+    }
+  },
+  "version": "v2"
+}


### PR DESCRIPTION
### Description of proposed changes

Adds a functional test and mock data that should work where augur export includes the `--color-by-metadata` argument with a column named `custom_trait`. The resulting Auspice JSON should include the `custom_trait` as a node attribute for each tip and as a coloring that appears after the colorings explicitly defined in the Auspice config JSON.

The original goal of this test was to confirm that "color by metadata" colorings disrupt the order of all colorings in the Auspice config JSON, but this test also reveals a separate potential bug where one of the node data annotations (`mutation_length`) that also appears in the metadata gets dropped completety from the Auspice JSON when the color by metadata argument is used.

### Testing

 - [x] Adds functional test
 - [ ] CI passes

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
