### PR TITLE
deps: unpin biopython, pin bcbio-gff to 0.7*

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## __NEXT__
 
+### Features
+
+* Constrain `bcbio-gff` to >=0.7.0 and allow `Biopython` >=1.81 again. We had to introduce the `Biopython` constraint in v21.0.1 (see [#1152][]) due to `bcbio-gff` <0.7.0 relying on the removed `Biopython` feature `UnknownSeq`. [#1178][] (@corneliusroemer)
+
+[#1152]: https://github.com/nextstrain/augur/pull/1152
+[#1178]: https://github.com/nextstrain/augur/pull/1178
 
 ## 21.1.0 (14 March 2023)
 

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,8 @@ setuptools.setup(
     package_data = {'augur': ['data/*']},
     python_requires = '>={}'.format('.'.join(str(n) for n in py_min_version)),
     install_requires = [
-        "bcbio-gff >=0.6.0, ==0.6.*",
-        # TODO: Remove biopython <=1.80 pin when 1.81/higher is supported by a
-        # new version of bcbio-gff¹ and that is also pinned, or when bcbio-gff
-        # is no longer a dependency.
-        # ¹ https://github.com/chapmanb/bcbb/issues/136
-        "biopython >=1.67, !=1.77, !=1.78, <=1.80",
+        "bcbio-gff >=0.7.0, ==0.7.*",
+        "biopython >=1.67, !=1.77, !=1.78",
         "cvxopt >=1.1.9, ==1.*",
         "isodate ==0.6.*",
         "jsonschema >=3.0.0, ==3.*",


### PR DESCRIPTION
Biopython was pinned to <=1.80 in https://github.com/nextstrain/augur/pull/1152 because bcbio-gff <=0.6.9 requires deprecated Biopython functionality that was removed in 1.81

A fix to bcbio-gff was released as 0.7.0, see https://github.com/chapmanb/bcbb/pull/137 https://github.com/chapmanb/bcbb/issues/136 So now we can pin bcbio-gff to >=0.7.0 and remove the pin of Biopython

Note added in https://github.com/nextstrain/augur/pull/1170 can hence be removed

### Testing

We need to check that bcbio-gff actually works without problems

I think the error with `bcbio-gff` occured in translate, so we should test that part in particular, to make sure there are no regressions in `bcbio-gff==0.7.0`

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
