### PR TITLE
Don't fail CI if codecov errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   build-docs:
     uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master


### PR DESCRIPTION
Stop gap for #1111 
Codecov keeps failing for upstream reasons unrelated to our code Now that we run Augur CI every day, transient failures are more painful Not failing CI on false positive seems like a reasonable workaround for now