### PR TITLE
Cram-ify "functional" pytests

### DIFF
--- a/tests/filter/test_relative_dates.py
+++ b/tests/filter/test_relative_dates.py
@@ -1,3 +1,9 @@
+# This file contains functional tests that would normally be written as
+# Cram-style tests. However, pytest is nice here since it is easy to use with
+# parameterized inputs/outputs and mocked system time (things that are not
+# straightforward to set up for Cram tests¹).
+# ¹ https://github.com/nextstrain/augur/pull/1183#discussion_r1142687476
+
 import argparse
 from freezegun import freeze_time
 import pytest

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -1,5 +1,4 @@
 import argparse
-from textwrap import dedent
 import numpy as np
 import random
 import shlex

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -45,21 +45,6 @@ def write_metadata(tmpdir, metadata):
 
 
 class TestFilter:
-    def test_filter_run_with_query_and_include(self, tmpdir, fasta_fn, argparser):
-        """Test that --include still works with filtering on query"""
-        out_fn = str(tmpdir / "out.fasta")
-        meta_fn = write_metadata(tmpdir, (("strain","location","quality"),
-                                          ("SEQ_1","colorado","good"),
-                                          ("SEQ_2","colorado","bad"),
-                                          ("SEQ_3","nevada","good")))
-        include_fn = str(tmpdir / "include")
-        open(include_fn, "w").write("SEQ_3")
-        args = argparser('-s %s --metadata %s -o %s --query "quality==\'good\' & location==\'colorado\'" --include %s'
-                         % (fasta_fn, meta_fn, out_fn, include_fn))
-        augur.filter._run.run(args)
-        output = SeqIO.to_dict(SeqIO.parse(out_fn, "fasta"))
-        assert list(output.keys()) == ["SEQ_1", "SEQ_3"]
-
     def test_filter_run_with_query_and_include_where(self, tmpdir, fasta_fn, argparser):
         """Test that --include_where still works with filtering on query"""
         out_fn = str(tmpdir / "out.fasta")

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -1,12 +1,7 @@
 import argparse
-import random
 import shlex
 
 import pytest
-
-from Bio import SeqIO
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
 
 from freezegun import freeze_time
 
@@ -20,22 +15,6 @@ def argparser():
     def parse(args):
         return parser.parse_args(shlex.split(args))
     return parse
-
-@pytest.fixture
-def sequences():
-    def random_seq(k):
-        return "".join(random.choices(("A","T","G","C"), k=k))
-    return {
-        "SEQ_1": SeqRecord(Seq(random_seq(10)), id="SEQ_1"),
-        "SEQ_2": SeqRecord(Seq(random_seq(10)), id="SEQ_2"),
-        "SEQ_3": SeqRecord(Seq(random_seq(10)), id="SEQ_3"),
-    }
-
-@pytest.fixture
-def fasta_fn(tmpdir, sequences):
-    fn = str(tmpdir / "sequences.fasta")
-    SeqIO.write(sequences.values(), fn, "fasta")
-    return fn
 
 def write_metadata(tmpdir, metadata):
     fn = str(tmpdir / "metadata.tsv")

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -45,19 +45,6 @@ def write_metadata(tmpdir, metadata):
 
 
 class TestFilter:
-    def test_filter_run_with_query_and_include_where(self, tmpdir, fasta_fn, argparser):
-        """Test that --include_where still works with filtering on query"""
-        out_fn = str(tmpdir / "out.fasta")
-        meta_fn = write_metadata(tmpdir, (("strain","location","quality"),
-                                          ("SEQ_1","colorado","good"),
-                                          ("SEQ_2","colorado","bad"),
-                                          ("SEQ_3","nevada","good")))
-        args = argparser('-s %s --metadata %s -o %s --query "quality==\'good\' & location==\'colorado\'" --include-where "location=nevada"'
-                         % (fasta_fn, meta_fn, out_fn))
-        augur.filter._run.run(args)
-        output = SeqIO.to_dict(SeqIO.parse(out_fn, "fasta"))
-        assert list(output.keys()) == ["SEQ_1", "SEQ_3"]
-
     def test_filter_run_min_date(self, tmpdir, fasta_fn, argparser):
         """Test that filter --min-date is inclusive"""
         out_fn = str(tmpdir / "out.fasta")

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -45,20 +45,6 @@ def write_metadata(tmpdir, metadata):
 
 
 class TestFilter:
-    def test_filter_run_max_date(self, tmpdir, fasta_fn, argparser):
-        """Test that filter --max-date is inclusive"""
-        out_fn = str(tmpdir / "out.fasta")
-        max_date = "2020-03-01"
-        meta_fn = write_metadata(tmpdir, (("strain","date"),
-                                          ("SEQ_1","2020-03-XX"),
-                                          ("SEQ_2","2020-03-01"),
-                                          ("SEQ_3","2020-03-02")))
-        args = argparser('-s %s --metadata %s -o %s --max-date %s'
-                         % (fasta_fn, meta_fn, out_fn, max_date))
-        augur.filter._run.run(args)
-        output = SeqIO.to_dict(SeqIO.parse(out_fn, "fasta"))
-        assert list(output.keys()) == ["SEQ_1", "SEQ_2"]
-
     def test_filter_incomplete_year(self, tmpdir, fasta_fn, argparser):
         """Test that 2020 is evaluated as 2020-XX-XX"""
         out_fn = str(tmpdir / "out.fasta")

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -12,8 +12,6 @@ from freezegun import freeze_time
 
 import augur.filter
 import augur.filter._run
-import augur.filter.include_exclude_rules
-from augur.io.metadata import read_metadata
 
 @pytest.fixture
 def argparser():
@@ -47,29 +45,6 @@ def write_metadata(tmpdir, metadata):
 
 
 class TestFilter:
-    def test_filter_on_query_good(self, tmpdir, sequences):
-        """Basic filter_on_query test"""
-        meta_fn = write_metadata(tmpdir, (("strain","location","quality"),
-                                          ("SEQ_1","colorado","good"),
-                                          ("SEQ_2","colorado","bad"),
-                                          ("SEQ_3","nevada","good")))
-        metadata = read_metadata(meta_fn)
-        filtered = augur.filter.include_exclude_rules.filter_by_query(metadata, 'quality=="good"')
-        assert sorted(filtered) == ["SEQ_1", "SEQ_3"]
-
-    def test_filter_run_with_query(self, tmpdir, fasta_fn, argparser):
-        """Test that filter --query works as expected"""
-        out_fn = str(tmpdir / "out.fasta")
-        meta_fn = write_metadata(tmpdir, (("strain","location","quality"),
-                                          ("SEQ_1","colorado","good"),
-                                          ("SEQ_2","colorado","bad"),
-                                          ("SEQ_3","nevada","good")))
-        args = argparser('-s %s --metadata %s -o %s --query "location==\'colorado\'"'
-                         % (fasta_fn, meta_fn, out_fn))
-        augur.filter._run.run(args)
-        output = SeqIO.to_dict(SeqIO.parse(out_fn, "fasta"))
-        assert list(output.keys()) == ["SEQ_1", "SEQ_2"]
-
     def test_filter_run_with_query_and_include(self, tmpdir, fasta_fn, argparser):
         """Test that --include still works with filtering on query"""
         out_fn = str(tmpdir / "out.fasta")

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -45,20 +45,6 @@ def write_metadata(tmpdir, metadata):
 
 
 class TestFilter:
-    def test_filter_run_min_date(self, tmpdir, fasta_fn, argparser):
-        """Test that filter --min-date is inclusive"""
-        out_fn = str(tmpdir / "out.fasta")
-        min_date = "2020-02-26"
-        meta_fn = write_metadata(tmpdir, (("strain","date"),
-                                          ("SEQ_1","2020-02-XX"),
-                                          ("SEQ_2","2020-02-26"),
-                                          ("SEQ_3","2020-02-25")))
-        args = argparser('-s %s --metadata %s -o %s --min-date %s'
-                         % (fasta_fn, meta_fn, out_fn, min_date))
-        augur.filter._run.run(args)
-        output = SeqIO.to_dict(SeqIO.parse(out_fn, "fasta"))
-        assert list(output.keys()) == ["SEQ_1", "SEQ_2"]
-
     def test_filter_run_max_date(self, tmpdir, fasta_fn, argparser):
         """Test that filter --max-date is inclusive"""
         out_fn = str(tmpdir / "out.fasta")

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -1,17 +1,17 @@
 import argparse
-import shlex
-
-import pytest
-
 from freezegun import freeze_time
+import pytest
+import shlex
 
 from augur.filter import register_arguments
 from augur.filter._run import run
+
 
 def parse_args(args):
     parser = argparse.ArgumentParser()
     register_arguments(parser)
     return parser.parse_args(shlex.split(args))
+
 
 def write_metadata(tmpdir, metadata):
     fn = str(tmpdir / "metadata.tsv")
@@ -20,147 +20,147 @@ def write_metadata(tmpdir, metadata):
     return fn
 
 
-class TestFilter:
-    @freeze_time("2020-03-25")
-    @pytest.mark.parametrize(
-        "argparse_params, metadata_rows, output_sorted_expected",
-        [
+@freeze_time("2020-03-25")
+@pytest.mark.parametrize(
+    "argparse_params, metadata_rows, output_sorted_expected",
+    [
+        (
+            "--min-date 1D",
             (
-                "--min-date 1D",
-                (
-                    ("SEQ_1","2020-03-23"),
-                    ("SEQ_2","2020-03-24"),
-                    ("SEQ_3","2020-03-25"),
-                ),
-                ["SEQ_2", "SEQ_3"],
+                ("SEQ_1","2020-03-23"),
+                ("SEQ_2","2020-03-24"),
+                ("SEQ_3","2020-03-25"),
             ),
+            ["SEQ_2", "SEQ_3"],
+        ),
+        (
+            "--max-date 1D",
             (
-                "--max-date 1D",
-                (
-                    ("SEQ_1","2020-03-23"),
-                    ("SEQ_2","2020-03-24"),
-                    ("SEQ_3","2020-03-25"),
-                ),
-                ["SEQ_1", "SEQ_2"],
+                ("SEQ_1","2020-03-23"),
+                ("SEQ_2","2020-03-24"),
+                ("SEQ_3","2020-03-25"),
             ),
+            ["SEQ_1", "SEQ_2"],
+        ),
+        (
+            "--min-date 4W",
             (
-                "--min-date 4W",
-                (
-                    ("SEQ_1","2020-02-25"),
-                    ("SEQ_2","2020-02-26"),
-                    ("SEQ_3","2020-03-25"),
-                ),
-                ["SEQ_2", "SEQ_3"],
+                ("SEQ_1","2020-02-25"),
+                ("SEQ_2","2020-02-26"),
+                ("SEQ_3","2020-03-25"),
             ),
+            ["SEQ_2", "SEQ_3"],
+        ),
+        (
+            "--max-date 4W",
             (
-                "--max-date 4W",
-                (
-                    ("SEQ_1","2020-02-25"),
-                    ("SEQ_2","2020-02-26"),
-                    ("SEQ_3","2020-03-25"),
-                ),
-                ["SEQ_1", "SEQ_2"],
+                ("SEQ_1","2020-02-25"),
+                ("SEQ_2","2020-02-26"),
+                ("SEQ_3","2020-03-25"),
             ),
+            ["SEQ_1", "SEQ_2"],
+        ),
+        (
+            "--min-date 1M",
             (
-                "--min-date 1M",
-                (
-                    ("SEQ_1","2020-01-25"),
-                    ("SEQ_2","2020-02-25"),
-                    ("SEQ_3","2020-03-25"),
-                ),
-                ["SEQ_2", "SEQ_3"],
+                ("SEQ_1","2020-01-25"),
+                ("SEQ_2","2020-02-25"),
+                ("SEQ_3","2020-03-25"),
             ),
+            ["SEQ_2", "SEQ_3"],
+        ),
+        (
+            "--max-date 1M",
             (
-                "--max-date 1M",
-                (
-                    ("SEQ_1","2020-01-25"),
-                    ("SEQ_2","2020-02-25"),
-                    ("SEQ_3","2020-03-25"),
-                ),
-                ["SEQ_1", "SEQ_2"],
+                ("SEQ_1","2020-01-25"),
+                ("SEQ_2","2020-02-25"),
+                ("SEQ_3","2020-03-25"),
             ),
+            ["SEQ_1", "SEQ_2"],
+        ),
+        (
+            "--min-date P1M",
             (
-                "--min-date P1M",
-                (
-                    ("SEQ_1","2020-01-25"),
-                    ("SEQ_2","2020-02-25"),
-                    ("SEQ_3","2020-03-25"),
-                ),
-                ["SEQ_2", "SEQ_3"],
+                ("SEQ_1","2020-01-25"),
+                ("SEQ_2","2020-02-25"),
+                ("SEQ_3","2020-03-25"),
             ),
+            ["SEQ_2", "SEQ_3"],
+        ),
+        (
+            "--max-date P1M",
             (
-                "--max-date P1M",
-                (
-                    ("SEQ_1","2020-01-25"),
-                    ("SEQ_2","2020-02-25"),
-                    ("SEQ_3","2020-03-25"),
-                ),
-                ["SEQ_1", "SEQ_2"],
+                ("SEQ_1","2020-01-25"),
+                ("SEQ_2","2020-02-25"),
+                ("SEQ_3","2020-03-25"),
             ),
+            ["SEQ_1", "SEQ_2"],
+        ),
+        (
+            "--min-date 2Y",
             (
-                "--min-date 2Y",
-                (
-                    ("SEQ_1","2017-03-25"),
-                    ("SEQ_2","2018-03-25"),
-                    ("SEQ_3","2019-03-25"),
-                ),
-                ["SEQ_2", "SEQ_3"],
+                ("SEQ_1","2017-03-25"),
+                ("SEQ_2","2018-03-25"),
+                ("SEQ_3","2019-03-25"),
             ),
+            ["SEQ_2", "SEQ_3"],
+        ),
+        (
+            "--max-date 2Y",
             (
-                "--max-date 2Y",
-                (
-                    ("SEQ_1","2017-03-25"),
-                    ("SEQ_2","2018-03-25"),
-                    ("SEQ_3","2019-03-25"),
-                ),
-                ["SEQ_1", "SEQ_2"],
+                ("SEQ_1","2017-03-25"),
+                ("SEQ_2","2018-03-25"),
+                ("SEQ_3","2019-03-25"),
             ),
+            ["SEQ_1", "SEQ_2"],
+        ),
+        (
+            "--min-date 1Y2W5D",
             (
-                "--min-date 1Y2W5D",
-                (
-                    ("SEQ_1","2019-03-05"),
-                    ("SEQ_2","2019-03-06"),
-                    ("SEQ_3","2019-03-07"),
-                ),
-                ["SEQ_2", "SEQ_3"],
+                ("SEQ_1","2019-03-05"),
+                ("SEQ_2","2019-03-06"),
+                ("SEQ_3","2019-03-07"),
             ),
+            ["SEQ_2", "SEQ_3"],
+        ),
+        (
+            "--max-date 1Y2W5D",
             (
-                "--max-date 1Y2W5D",
-                (
-                    ("SEQ_1","2019-03-05"),
-                    ("SEQ_2","2019-03-06"),
-                    ("SEQ_3","2019-03-07"),
-                ),
-                ["SEQ_1", "SEQ_2"],
+                ("SEQ_1","2019-03-05"),
+                ("SEQ_2","2019-03-06"),
+                ("SEQ_3","2019-03-07"),
             ),
-        ],
-    )
-    def test_filter_relative_dates(self, tmpdir, argparse_params, metadata_rows, output_sorted_expected):
-        """Test that various relative dates work"""
-        out_fn = str(tmpdir / "filtered.txt")
-        meta_fn = write_metadata(tmpdir, (("strain","date"),
-                                          *metadata_rows))
-        args = parse_args(f'--metadata {meta_fn} --output-strains {out_fn} {argparse_params}')
-        run(args)
-        with open(out_fn) as f:
-            output_sorted = sorted(line.rstrip() for line in f)
-        assert output_sorted == output_sorted_expected
+            ["SEQ_1", "SEQ_2"],
+        ),
+    ],
+)
+def test_filter_relative_dates(tmpdir, argparse_params, metadata_rows, output_sorted_expected):
+    """Test that various relative dates work"""
+    out_fn = str(tmpdir / "filtered.txt")
+    meta_fn = write_metadata(tmpdir, (("strain","date"),
+                                      *metadata_rows))
+    args = parse_args(f'--metadata {meta_fn} --output-strains {out_fn} {argparse_params}')
+    run(args)
+    with open(out_fn) as f:
+        output_sorted = sorted(line.rstrip() for line in f)
+    assert output_sorted == output_sorted_expected
 
-    @freeze_time("2020-03-25")
-    @pytest.mark.parametrize(
-        "argparse_flag, argparse_value",
-        [
-            ("--min-date", "3000Y"),
-            ("--max-date", "3000Y"),
-            ("--min-date", "invalid"),
-            ("--max-date", "invalid"),
-        ],
-    )
-    def test_filter_relative_dates_error(self, tmpdir, argparse_flag, argparse_value):
-        """Test that invalid dates fail"""
-        out_fn = str(tmpdir / "filtered.txt")
-        meta_fn = write_metadata(tmpdir, (("strain","date"),
-                                          ("SEQ_1","2020-03-23")))
-        with pytest.raises(SystemExit) as e_info:
-            parse_args(f'--metadata {meta_fn} --output-strains {out_fn} {argparse_flag} {argparse_value}')
-        assert f"Invalid date '{argparse_value}'" in e_info.value.__context__.message
+
+@freeze_time("2020-03-25")
+@pytest.mark.parametrize(
+    "argparse_flag, argparse_value",
+    [
+        ("--min-date", "3000Y"),
+        ("--max-date", "3000Y"),
+        ("--min-date", "invalid"),
+        ("--max-date", "invalid"),
+    ],
+)
+def test_filter_relative_dates_error(tmpdir, argparse_flag, argparse_value):
+    """Test that invalid dates fail"""
+    out_fn = str(tmpdir / "filtered.txt")
+    meta_fn = write_metadata(tmpdir, (("strain","date"),
+                                      ("SEQ_1","2020-03-23")))
+    with pytest.raises(SystemExit) as e_info:
+        parse_args(f'--metadata {meta_fn} --output-strains {out_fn} {argparse_flag} {argparse_value}')
+    assert f"Invalid date '{argparse_value}'" in e_info.value.__context__.message

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -5,12 +5,12 @@ import pytest
 
 from freezegun import freeze_time
 
-import augur.filter
-import augur.filter._run
+from augur.filter import register_arguments
+from augur.filter._run import run
 
 def parse_args(args):
     parser = argparse.ArgumentParser()
-    augur.filter.register_arguments(parser)
+    register_arguments(parser)
     return parser.parse_args(shlex.split(args))
 
 def write_metadata(tmpdir, metadata):
@@ -141,7 +141,7 @@ class TestFilter:
         meta_fn = write_metadata(tmpdir, (("strain","date"),
                                           *metadata_rows))
         args = parse_args(f'--metadata {meta_fn} --output-strains {out_fn} {argparse_params}')
-        augur.filter._run.run(args)
+        run(args)
         with open(out_fn) as f:
             output_sorted = sorted(line.rstrip() for line in f)
         assert output_sorted == output_sorted_expected

--- a/tests/filter/test_run.py
+++ b/tests/filter/test_run.py
@@ -45,34 +45,6 @@ def write_metadata(tmpdir, metadata):
 
 
 class TestFilter:
-    def test_filter_incomplete_year(self, tmpdir, fasta_fn, argparser):
-        """Test that 2020 is evaluated as 2020-XX-XX"""
-        out_fn = str(tmpdir / "out.fasta")
-        min_date = "2020-02-01"
-        meta_fn = write_metadata(tmpdir, (("strain","date"),
-                                          ("SEQ_1","2020.0"),
-                                          ("SEQ_2","2020"),
-                                          ("SEQ_3","2020-XX-XX")))
-        args = argparser('-s %s --metadata %s -o %s --min-date %s'
-                         % (fasta_fn, meta_fn, out_fn, min_date))
-        augur.filter._run.run(args)
-        output = SeqIO.to_dict(SeqIO.parse(out_fn, "fasta"))
-        assert list(output.keys()) == ["SEQ_2", "SEQ_3"]
-
-    def test_filter_date_formats(self, tmpdir, fasta_fn, argparser):
-        """Test that 2020.0, 2020, and 2020-XX-XX all pass --min-date 2019"""
-        out_fn = str(tmpdir / "out.fasta")
-        min_date = "2019"
-        meta_fn = write_metadata(tmpdir, (("strain","date"),
-                                          ("SEQ_1","2020.0"),
-                                          ("SEQ_2","2020"),
-                                          ("SEQ_3","2020-XX-XX")))
-        args = argparser('-s %s --metadata %s -o %s --min-date %s'
-                         % (fasta_fn, meta_fn, out_fn, min_date))
-        augur.filter._run.run(args)
-        output = SeqIO.to_dict(SeqIO.parse(out_fn, "fasta"))
-        assert list(output.keys()) == ["SEQ_1", "SEQ_2", "SEQ_3"]
-
     @freeze_time("2020-03-25")
     @pytest.mark.parametrize(
         "argparse_params, metadata_rows, output_sorted_expected",

--- a/tests/functional/filter/cram/filter-max-date.t
+++ b/tests/functional/filter/cram/filter-max-date.t
@@ -1,0 +1,22 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata TSV file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	date
+  > SEQ_1	2020-03-XX
+  > SEQ_2	2020-03-01
+  > SEQ_3	2020-03-02
+  > ~~
+
+Test that --max-date is inclusive.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --max-date 2020-03-01 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_2

--- a/tests/functional/filter/cram/filter-metadata-date-formats.t
+++ b/tests/functional/filter/cram/filter-metadata-date-formats.t
@@ -1,0 +1,33 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata TSV file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	date
+  > SEQ_1	2020.0
+  > SEQ_2	2020
+  > SEQ_3	2020-XX-XX
+  > ~~
+
+Test that 2020 is evaluated as 2020-XX-XX.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --min-date 2020-02-01 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_2
+  SEQ_3
+
+Test that 2020.0, 2020, and 2020-XX-XX all pass --min-date 2019
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --min-date 2019 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_2
+  SEQ_3

--- a/tests/functional/filter/cram/filter-min-date.t
+++ b/tests/functional/filter/cram/filter-min-date.t
@@ -2,10 +2,21 @@ Setup
 
   $ source "$TESTDIR"/_setup.sh
 
-Filter using only metadata without a sequence index.
-This should work because the requested filters don't rely on sequence information.
+Create metadata TSV file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	date
+  > SEQ_1	2020-02-XX
+  > SEQ_2	2020-02-26
+  > SEQ_3	2020-02-25
+  > ~~
+
+Test that --min-date is inclusive.
 
   $ ${AUGUR} filter \
-  >  --metadata "$TESTDIR/../data/metadata.tsv" \
-  >  --min-date 2012 \
+  >  --metadata metadata.tsv \
+  >  --min-date 2020-02-26 \
   >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_2

--- a/tests/functional/filter/cram/filter-query-and-include-where.t
+++ b/tests/functional/filter/cram/filter-query-and-include-where.t
@@ -1,0 +1,23 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata TSV file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	location	quality
+  > SEQ_1	colorado	good
+  > SEQ_2	colorado	bad
+  > SEQ_3	nevada	good
+  > ~~
+
+Test that --include_where still works with filtering on query.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "quality=='good' & location=='colorado'" \
+  >  --include-where "location=nevada" \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_3

--- a/tests/functional/filter/cram/filter-query-and-include.t
+++ b/tests/functional/filter/cram/filter-query-and-include.t
@@ -1,0 +1,26 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata TSV file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	location	quality
+  > SEQ_1	colorado	good
+  > SEQ_2	colorado	bad
+  > SEQ_3	nevada	good
+  > ~~
+  $ cat >include.txt <<~~
+  > SEQ_3
+  > ~~
+
+Test that --include_where still works with filtering on query.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "quality=='good' & location=='colorado'" \
+  >  --include include.txt \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_3

--- a/tests/functional/filter/cram/subsample-priority-file-error.t
+++ b/tests/functional/filter/cram/subsample-priority-file-error.t
@@ -1,0 +1,32 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Try running with a priority file that does not exist.
+
+  $ ${AUGUR} filter \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
+  >  --priority does-not-exist.tsv \
+  >  --subsample-max-sequences 5 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  ERROR: missing or malformed priority scores file does-not-exist.tsv
+  [2]
+
+Create a priority file that is not tab-delimited.
+
+  $ cat >priorities.csv <<~~
+  > SEQ_1,5
+  > SEQ_2,6
+  > SEQ_3,8
+  > SEQ_4,-100
+  > ~~
+
+Try running with the above file.
+
+  $ ${AUGUR} filter \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
+  >  --priority priorities.csv \
+  >  --subsample-max-sequences 5 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  ERROR: missing or malformed priority scores file priorities.csv
+  [2]

--- a/tests/functional/filter/cram/subsample-priority-values.t
+++ b/tests/functional/filter/cram/subsample-priority-values.t
@@ -1,0 +1,84 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create files for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	quality
+  > SEQ_1	good
+  > SEQ_2	good
+  > SEQ_3	good
+  > SEQ_4	good
+  > SEQ_5	good
+  > ~~
+
+  $ cat >priorities.tsv <<~~
+  > SEQ_1	5
+  > SEQ_2	6
+  > SEQ_3	8
+  > SEQ_4	-100
+  > ~~
+
+Subsample 5 strains. Note that SEQ_5 should not be dropped even though it does
+not have a priority score.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --priority priorities.tsv \
+  >  --subsample-max-sequences 5 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_2
+  SEQ_3
+  SEQ_4
+  SEQ_5
+
+Subsample 1 less strain. SEQ_5 should be dropped since it does not have a
+priority score, which is effectively lowest priority (even compared to negative
+values).
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --priority priorities.tsv \
+  >  --subsample-max-sequences 4 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_2
+  SEQ_3
+  SEQ_4
+
+Subsample 1 less strain. SEQ_4 should now be dropped.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --priority priorities.tsv \
+  >  --subsample-max-sequences 3 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_2
+  SEQ_3
+
+Subsample 1 less strain. SEQ_1 should now be dropped.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --priority priorities.tsv \
+  >  --subsample-max-sequences 2 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_2
+  SEQ_3
+
+Subsample 1 less strain. SEQ_1 should now be dropped.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --priority priorities.tsv \
+  >  --subsample-max-sequences 1 \
+  >  --output-strains filtered_strains.txt > /dev/null
+  $ sort filtered_strains.txt
+  SEQ_3


### PR DESCRIPTION
_(Note: the squashed changes are not review-friendly – see individual commit messages for a better experience.)_

### Description of proposed changes

Convert "functional" pytests that predated/overlooked the adoption of using Cram to write functional tests in this codebase (except for testing relative dates – see 579c7e3e3b3a75fcdcc38765184a8706dedaa011).

In terms of the logic being tested, I also removed some duplication and increased coverage in a few places.

### Related issue(s)

N/A – this was prompted by work related to #854 where some of these tests are not compatible. Cram-ify-ing fixes that.

### Testing

- [x] Checks pass
- [x] No change in Codecov report

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, no functional changes
