### PR TITLE
index: "export" strain column and delimiter

### DIFF
--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -8,7 +8,12 @@ import pandas as pd
 from tempfile import NamedTemporaryFile
 
 from augur.errors import AugurError
-from augur.index import index_sequences, index_vcf
+from augur.index import (
+    index_sequences,
+    index_vcf,
+    ID_COLUMN as SEQUENCE_INDEX_ID_COLUMN,
+    DELIMITER as SEQUENCE_INDEX_DELIMITER,
+)
 from augur.io.file import open_file
 from augur.io.metadata import read_metadata
 from augur.io.sequences import read_sequences, write_sequences
@@ -57,8 +62,8 @@ def run(args):
     if sequence_index_path:
         sequence_index = pd.read_csv(
             sequence_index_path,
-            sep="\t",
-            index_col="strain",
+            sep=SEQUENCE_INDEX_DELIMITER,
+            index_col=SEQUENCE_INDEX_ID_COLUMN,
         )
 
         # Remove temporary index file, if it exists.

--- a/augur/index.py
+++ b/augur/index.py
@@ -12,6 +12,11 @@ from .io.file import open_file
 from .io.sequences import read_sequences
 from .io.vcf import is_vcf, read_vcf
 
+
+DELIMITER = '\t'
+ID_COLUMN = 'strain'
+
+
 def register_parser(parent_subparsers):
     parser = parent_subparsers.add_parser("index", help=__doc__)
     parser.add_argument('--sequences', '-s', required=True, help="sequences in FASTA or VCF formats. Augur will summarize the content of FASTA sequences and only report the names of strains found in a given VCF.")
@@ -42,10 +47,10 @@ def index_vcf(vcf_path, index_path):
     num_of_seqs = 0
 
     with open_file(index_path, 'wt') as out_file:
-        tsv_writer = csv.writer(out_file, delimiter = '\t')
+        tsv_writer = csv.writer(out_file, delimiter = DELIMITER)
 
         #write header i output file
-        header = ['strain']
+        header = [ID_COLUMN]
         tsv_writer.writerow(header)
 
         for record in strains:
@@ -183,7 +188,7 @@ def index_sequences(sequences_path, sequence_index_path):
         tsv_writer = csv.writer(out_file, delimiter = '\t', lineterminator='\n')
 
         #write header i output file
-        header = ['strain', 'length']+labels+['invalid_nucleotides']
+        header = [ID_COLUMN, 'length']+labels+['invalid_nucleotides']
         tsv_writer.writerow(header)
 
         for record in seqs:


### PR DESCRIPTION
### Description of proposed changes

Defining these as top-level constants allows them to be imported where they are used elsewhere.

### Related issue(s)

N/A, this came up while working on `augur filter`.

### Testing

- [x] Checks pass

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, no functional change.
