### PR TITLE
Add DEFAULT_AUGUR_RECURSION_LIMIT=10000

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 * Constrain `bcbio-gff` to >=0.7.0 and allow `Biopython` >=1.81 again. We had to introduce the `Biopython` constraint in v21.0.1 (see [#1152][]) due to `bcbio-gff` <0.7.0 relying on the removed `Biopython` feature `UnknownSeq`. [#1178][] (@corneliusroemer)
 * `augur.io.read_metadata` (used by export, filter, frequencies, refine, and traits): Previously, this used the Python parser engine for [`pandas.read_csv()`][]. Updated to use the C engine for faster reading of metadata. [#812][] (@victorlin)
 * curate: Allow custom metadata delimiters with the new `--metadata-delimiters` flag. [#1196][] (@victorlin)
+* Bump the default recursion limit to 10,000. Users can continue to override this limit with the environment variable `AUGUR_RECURSION_LIMIT`. [#1200][] (@joverlee521)
 
 ### Bug fixes
 
@@ -24,6 +25,7 @@
 [#1171]: https://github.com/nextstrain/augur/issues/1171
 [#1178]: https://github.com/nextstrain/augur/pull/1178
 [#1196]: https://github.com/nextstrain/augur/pull/1196
+[#1200]: https://github.com/nextstrain/augur/pull/1200
 [`pandas.read_csv()`]: https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.read_csv.html
 
 ## 21.1.0 (14 March 2023)

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -77,7 +77,7 @@ def run(argv):
     except TreeTimeUnknownError as e:
         print_err(dedent("""\
             ERROR from TreeTime: An error occurred in TreeTime (see above). This may be due to an issue with TreeTime or Augur.
-            Please report you are calling TreeTime via Augur. 
+            Please report you are calling TreeTime via Augur.
             """))
         sys.exit(2)
     except TreeTimeError as e:

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -15,9 +15,8 @@ from .errors import AugurError
 from .io.print import print_err
 from .argparse_ import add_command_subparsers, add_default_command
 
-recursion_limit = os.environ.get("AUGUR_RECURSION_LIMIT")
-if recursion_limit:
-    sys.setrecursionlimit(int(recursion_limit))
+DEFAULT_AUGUR_RECURSION_LIMIT = 10000
+sys.setrecursionlimit(int(os.environ.get("AUGUR_RECURSION_LIMIT") or DEFAULT_AUGUR_RECURSION_LIMIT))
 
 command_strings = [
     "parse",


### PR DESCRIPTION
### Description of proposed changes
We've had to use the `AUGUR_RECURSION_LIMIT` environment variable to
bump the recursion limit for SARS-CoV-2 builds¹, mpox builds², and
our `nextstrain-jobs` definition in AWS Batch. From a general search of
the envvar across GitHub³, 10,000 looks like the default that others use
as well (although this may be influenced by our discussions⁴).

¹ https://github.com/nextstrain/ncov/pull/690
² https://github.com/nextstrain/monkeypox/pull/150
³ https://cs.github.com/?scopeName=All+repos&scope=&q=AUGUR_RECURSION_LIMIT%3D
⁴ https://github.com/nextstrain/augur/issues/328

### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
