### PR TITLE
Update TreeTime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 
 * clades, export v2: Clade labels + coloring keys are now definable via arguments to augur clades allowing pipelines to use multiple invocations of augur clades resulting in multiple sets of colors and branch labels. How labels are stored in the (intermediate) node-data JSON files has changed. This should be fully backwards compatible for pipelines using augur commands, however custom scripts may need updating. PR [#728][] (@jameshadfield)
 
+ * Updated to use TreeTime 0.10.0, which changes the random seeding method used in `augur refine --seed`. [#1207][] (@rneher)
+
 
 ### Bug fixes
 
@@ -34,6 +36,7 @@
 [#1200]: https://github.com/nextstrain/augur/pull/1200
 [#1203]: https://github.com/nextstrain/augur/pull/1203
 [#1206]: https://github.com/nextstrain/augur/pull/1206
+[#1207]: https://github.com/nextstrain/augur/pull/1207
 [`pandas.read_csv()`]: https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.read_csv.html
 
 ## 21.1.0 (14 March 2023)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -120,8 +120,12 @@ def register_parser(parent_subparsers):
                                 "rates and/or rerooting. "
                                 "Use --no-covariance to turn off.")
     parser.add_argument('--no-covariance', dest='covariance', action='store_false')  #If you set help here, it displays 'default: True' - which is confusing!
+
+    # the following three flags should be mutually exclusive
     parser.add_argument('--keep-polytomies', action='store_true', help='Do not attempt to resolve polytomies')
     parser.add_argument('--stochastic-resolve', action='store_true', help='Resolve polytomies via stochastic subtree building rather than greedy optimization')
+    parser.add_argument('--greedy-resolve', action='store_false', dest='stochastic_resolve') # inverse of `--stochastic-resolve` to facilitate changing defaults in the future
+
     parser.add_argument('--precision', type=int, choices=[0,1,2,3], help="precision used by TreeTime to determine the number of grid points that are used for the evaluation of the branch length interpolation objects. Values range from 0 (rough) to 3 (ultra fine) and default to 'auto'.")
     parser.add_argument('--date-format', default="%Y-%m-%d", help="date format")
     parser.add_argument('--date-confidence', action="store_true", help="calculate confidence intervals for node dates")

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -15,7 +15,7 @@ from treetime.seq_utils import profile_maps
 def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='auto',
              confidence=False, resolve_polytomies=True, stochastic_resolve=False, max_iter=2, precision='auto',
              infer_gtr=True, Tc=0.01, reroot=None, use_marginal='always', fixed_pi=None, use_fft=True,
-             clock_rate=None, clock_std=None, clock_filter_iqd=None, verbosity=1, covariance=True, **kwarks):
+             clock_rate=None, clock_std=None, clock_filter_iqd=None, verbosity=1, covariance=True, rng_seed=None, **kwarks):
     from treetime import TreeTime
 
     try: #Tc could be a number or  'opt' or 'skyline'. TreeTime expects a float or int if a number.
@@ -38,7 +38,7 @@ def refine(tree=None, aln=None, ref=None, dates=None, branch_length_inference='a
 
     #send ref, if is None, does no harm
     tt = TreeTime(tree=tree, aln=aln, ref=ref, dates=dates, use_fft=use_fft,
-                  verbose=verbosity, gtr='JC69', precision=precision)
+                  verbose=verbosity, gtr='JC69', precision=precision, rng_seed=rng_seed)
 
     # conditionally run clock-filter and remove bad tips
     if clock_filter_iqd:
@@ -142,8 +142,6 @@ def register_parser(parent_subparsers):
 
 
 def run(args):
-    if args.seed is not None:
-        np.random.seed(args.seed)
 
     # check alignment type, set flags, read in if VCF
     is_vcf = False
@@ -242,7 +240,7 @@ def run(args):
                     clock_rate=args.clock_rate, clock_std=args.clock_std_dev,
                     clock_filter_iqd=args.clock_filter_iqd, max_iter=args.max_iter,
                     covariance=args.covariance, resolve_polytomies=(not args.keep_polytomies),
-                    stochastic_resolve=args.stochastic_resolve, verbosity=args.verbosity)
+                    stochastic_resolve=args.stochastic_resolve, verbosity=args.verbosity, rng_seed=args.seed)
 
         node_data['clock'] = {'rate': tt.date2dist.clock_rate,
                               'intercept': tt.date2dist.intercept,
@@ -278,7 +276,7 @@ def run(args):
                 except ValueError as err:
                     raise ValueError(f"HINT: This error may be because your specified root with name '{args.root}' was not found in your alignment file") from err
 
-        tt = TreeAnc(tree=T, aln=aln, ref=ref, gtr='JC69', verbose=args.verbosity)
+        tt = TreeAnc(tree=T, aln=aln, ref=ref, gtr='JC69', verbose=args.verbosity, rng_seed=args.seed)
 
     node_data['nodes'] = collect_node_data(T, attributes)
     if args.divergence_units=='mutations-per-site': #default

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -121,10 +121,10 @@ def register_parser(parent_subparsers):
                                 "Use --no-covariance to turn off.")
     parser.add_argument('--no-covariance', dest='covariance', action='store_false')  #If you set help here, it displays 'default: True' - which is confusing!
 
-    # the following three flags should be mutually exclusive
-    parser.add_argument('--keep-polytomies', action='store_true', help='Do not attempt to resolve polytomies')
-    parser.add_argument('--stochastic-resolve', action='store_true', help='Resolve polytomies via stochastic subtree building rather than greedy optimization')
-    parser.add_argument('--greedy-resolve', action='store_false', dest='stochastic_resolve') # inverse of `--stochastic-resolve` to facilitate changing defaults in the future
+    resolve_group = parser.add_mutually_exclusive_group()
+    resolve_group.add_argument('--keep-polytomies', action='store_true', help='Do not attempt to resolve polytomies')
+    resolve_group.add_argument('--stochastic-resolve', action='store_true', help='Resolve polytomies via stochastic subtree building rather than greedy optimization')
+    resolve_group.add_argument('--greedy-resolve', action='store_false', dest='stochastic_resolve') # inverse of `--stochastic-resolve` to facilitate changing defaults in the future
 
     parser.add_argument('--precision', type=int, choices=[0,1,2,3], help="precision used by TreeTime to determine the number of grid points that are used for the evaluation of the branch length interpolation objects. Values range from 0 (rough) to 3 (ultra fine) and default to 'auto'.")
     parser.add_argument('--date-format', default="%Y-%m-%d", help="date format")

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setuptools.setup(
         "numpy ==1.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",
-        "phylo-treetime >=0.9.6, ==0.9.*",
+        "phylo-treetime >=0.10.0, ==0.10.*",
         "pyfastx >=0.8.4, ==0.8.*",
         "scipy ==1.*",
         "xopen[zstd] >=1.7.0, ==1.*"


### PR DESCRIPTION
This PR updates the required TreeTime version to 0.10.0 or later. This version of TT handles random number generator state differently, which requires slight changes how the `augur refine` argument `--seed` is handled. Instead of setting the default numpy RNG, this argument is now passed to the TreeTime constructor. 

In addition, this PR adds a flag `--greedy-resolve` to `augur refine`. This is the default atm. But adding the flag will enable changing the default in the future.   