### PR TITLE
utils.write_json: Serialize Pandas Series

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* utils: Serialize pandas Series in `write_json`. [#1213][] (@victorlin)
+
+[#1213]: https://github.com/nextstrain/augur/pull/1213
 
 ## 22.0.0 (9 May 2023)
 

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -127,11 +127,14 @@ def write_json(data, file_name, indent=(None if os.environ.get("AUGUR_MINIFY_JSO
         data["generated_by"] = {"program": "augur", "version": get_augur_version()}
     with open(file_name, 'w', encoding='utf-8') as handle:
         sort_keys = False if isinstance(data, OrderedDict) else True
-        json.dump(data, handle, indent=indent, sort_keys=sort_keys, cls=NumpyJSONEncoder)
+        json.dump(data, handle, indent=indent, sort_keys=sort_keys, cls=AugurJSONEncoder)
 
 
-class NumpyJSONEncoder(json.JSONEncoder):
-    """A custom JSONEncoder subclass to serialize additional numpy data types."""
+class AugurJSONEncoder(json.JSONEncoder):
+    """
+    A custom JSONEncoder subclass to serialize data types used for various data
+    stored in dictionary format.
+    """
     def default(self, obj):
         if isinstance(obj, np.integer):
             return int(obj)

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -142,6 +142,8 @@ class AugurJSONEncoder(json.JSONEncoder):
             return float(obj)
         if isinstance(obj, np.ndarray):
             return obj.tolist()
+        if isinstance(obj, pd.Series):
+            return obj.tolist()
         return super().default(obj)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import json
 import numpy as np
 from pathlib import Path
 from unittest.mock import patch
+import pandas as pd
 
 import pytest
 
@@ -93,12 +94,13 @@ class TestUtils:
         assert len(strains) == 3
         assert "strain1" in strains
 
-    def test_write_json_numpy_types(self, tmpdir):
-        """write_json should be able to serialize numpy data types."""
+    def test_write_json_data_types(self, tmpdir):
+        """write_json should be able to serialize various data types."""
         data = {
             'int': np.int64(1),
             'float': np.float64(2.0),
-            'array': np.array([3,4,5])
+            'array': np.array([3,4,5]),
+            'series': pd.Series([6,7,8])
         }
         file = Path(tmpdir) / Path("data.json")
         utils.write_json(data, file, include_version=False)
@@ -106,5 +108,6 @@ class TestUtils:
             assert json.load(f) == {
                 'int': 1,
                 'float': 2.0,
-                'array': [3,4,5]
+                'array': [3,4,5],
+                'series': [6,7,8]
             }


### PR DESCRIPTION
### Description of proposed changes

There is a possibility that data to be written by this function contains a pandas Series which was un-serializable prior to this change.

Note: I did some digging to see what other possible data types could be in `node_data` and when they would be used, but didn't get too far. It has to do with modifications on the tree from TreeTime. This investigation should be continued to ensure all possible data types are serialized, so we can avoid similar bugs in the future.

### Related issue(s)
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #1209

Similar to #1119

### Testing

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

- [x] Added a test
- [x] Checks pass

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
