### PR TITLE
fix: don't error if node data file is empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* export: In version 22.0.0, validation of `augur.utils.read_node_data` was changed to error when a node data JSON did not contain any actual data. This causes export to error when an empty node data JSON is passed, as for example in ncov's pathogen-ci. This is now fixed by warning instead. The bug was originally introduced in PR [#728][]. [#1214][] (@corneliusroemer)
+
+[#1214]: https://github.com/nextstrain/augur/pull/1214
 
 ## 22.0.0 (9 May 2023)
 

--- a/augur/util_support/node_data_file.py
+++ b/augur/util_support/node_data_file.py
@@ -80,12 +80,13 @@ class NodeDataFile:
 
         if not isinstance(self.branches, dict):
             raise AugurError(
-                f"`branches` value in {self.fname} is not a dictionary. Please check the formatting of this JSON!"            )
+                f"`branches` value in {self.fname} is not a dictionary. Please check the formatting of this JSON!"
+            )
 
         if not self.nodes and not self.branches:
-            raise AugurError(
-                f"{self.fname} did not contain either `nodes` or `branches`. Please check the formatting of this JSON!"
-        )
+            print_err(
+                f"WARNING: {self.fname} has empty or nonexistent `nodes` and `branches`. Please check the formatting of this JSON!"
+            )
 
         if self.validation_mode is not ValidationMode.SKIP and self.is_generated_by_incompatible_augur:
             msg = (


### PR DESCRIPTION
Resolves #1215 

Partial revert of (over) eager validation introduced recently through PR #728

### Description of proposed changes

In PR #728, extra node data validation was introduced. In particular, files without information for either `nodes` or `branches` caused erroring.

This is problematic for test scripts that may produce empty node data in test cases.

This PR removes the eager validation. In the future we could reintroduce it as a warning.
And possibly an error but with opt-out.

This type of node data json was previously errored on by augur export, it is now accepted again:

```json
{
  "nodes": {},
  "rbd_level_details": {}
}
```

### Related issue(s)
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes the ncov pathogen-CI issue: https://github.com/nextstrain/conda-base/pull/27#issuecomment-1547937744

### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

- [x] https://github.com/nextstrain/conda-base/pull/27#issuecomment-1547937744 is fixed, export now accepts empty nodes dicts again

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
