### PR TITLE
Run pathogen-ci as part of Augur's CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  pytest-cram:
     name: test (python=${{ matrix.python-version }} biopython=${{ matrix.biopython-version || 'latest' }})
     runs-on: ubuntu-latest
     strategy:
@@ -86,7 +86,6 @@ jobs:
     env:
       repodata_use_zst: true
     strategy:
-      max-parallel: 4
       matrix:
         include:
           - { pathogen: avian-flu, build-args: auspice/flu_avian_h5n1_ha.json }
@@ -144,7 +143,7 @@ jobs:
 
   codecov:
     if: github.repository == 'nextstrain/augur'
-    needs: [test, pathogen-ci]
+    needs: [pytest-cram]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,9 +80,71 @@ jobs:
         name: coverage
         path: "${{ env.COVERAGE_FILE }}"
 
+  pathogen-ci:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      repodata_use_zst: true
+    strategy:
+      max-parallel: 4
+      matrix:
+        include:
+          - { pathogen: avian-flu, build-args: auspice/flu_avian_h5n1_ha.json }
+          - { pathogen: ebola }
+          - { pathogen: lassa }
+          - { pathogen: monkeypox }
+          - { pathogen: mumps }
+          - {
+              pathogen: ncov,
+              build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci,
+            }
+          - {
+              pathogen: seasonal-flu,
+              build-args: --configfile profiles/ci/builds.yaml -p,
+            }
+          - { pathogen: zika }
+    name: test-pathogen-repo-ci (${{ matrix.pathogen }})
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mamba-org/provision-with-micromamba@v15
+        with:
+          environment-file: false
+          environment-name: augur
+          extra-specs: nextstrain-base
+          channels: nextstrain,conda-forge,bioconda
+          cache-env: true
+      - run: pip install .
+      - run: mamba list
+
+      - uses: actions/checkout@v3
+        with:
+          repository: nextstrain/${{ matrix.pathogen }}
+      - name: Copy example data
+        run: |
+          if [[ -d example_data ]]; then
+            mkdir -p data/
+            cp -v example_data/* data/
+          else
+            echo No example data to copy.
+          fi
+      - run: snakemake -c all ${{ matrix.build-args }}
+      - if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: output-${{ matrix.pathogen }}
+          path: |
+            auspice/
+            results/
+            benchmarks/
+            logs/
+            .snakemake/log/
+
   codecov:
     if: github.repository == 'nextstrain/augur'
-    needs: [test]
+    needs: [test, pathogen-ci]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## __NEXT__
 
+### Internal
+
+* CI: Add a Github action to test augur on 8 Nextstrain pathogen workflows using example data. [#1217][] (@corneliusroemer)
+
+[#1217]: https://github.com/nextstrain/augur/pull/1217
+
 
 ## 22.0.1 (16 May 2023)
 


### PR DESCRIPTION
Inspired by this bug #1215 which we only noticed after release but which could have been noticed had we run pathogen ci for ncov within Augur's CI.

### Description of proposed changes
Add pathogen CI runs for every commit of Augur.

With some changes to our reusable pathogen ci workflow this could be made DRYer, but not sure it's worth the effort as this is probably the only repo where we'd want to have this pattern. Augur is the most widely used tool in the workflows, all the other nextstrain ones are much less used. A bit of Nextclade/align, but not worth adding to Nextclade CI (I think). 

### Related issue(s)
Fixes #1216 

### Testing
- [x] CI still works

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file. => N/A
