### PR TITLE
Require parse arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,21 +2,20 @@
 
 ## __NEXT__
 
-### Internal
+### Bug fixes
 
 * CI: Add a Github action to test augur on 8 Nextstrain pathogen workflows using example data. [#1217][] (@corneliusroemer)
+* parse: Denote required arguments including `--fields`, `--output-sequences`, and `--output-metadata`. [#1228][] (@huddlej)
 
 [#1217]: https://github.com/nextstrain/augur/pull/1217
-
+[#1228]: https://github.com/nextstrain/augur/pull/1228
 
 ## 22.0.1 (16 May 2023)
 
 ### Bug fixes
 
 * export: No longer export duplicate entries in the colorings array, a bug which has been present in Augur since at least v12 [#719][]. [#1218][] (@jameshadfield)
-
 * export: In version 22.0.0, some configurations of export may have resulted in the clade coloring appearing last in the Auspice dropdown rather than first. This is now fixed. [#1218] (@jameshadfield)
-
 * export: In version 22.0.0, validation of `augur.utils.read_node_data` was changed to error when a node data JSON did not contain any actual data. This causes export to error when an empty node data JSON is passed, as for example in ncov's pathogen-ci. This is now fixed by warning instead. The bug was originally introduced in PR [#728][]. [#1214][] (@corneliusroemer)
 
 [#719]: https://github.com/nextstrain/augur/issues/719

--- a/augur/parse.py
+++ b/augur/parse.py
@@ -141,9 +141,9 @@ def parse_sequence(sequence, fields, strain_key="strain", separator="|", prettif
 def register_parser(parent_subparsers):
     parser = parent_subparsers.add_parser("parse", help=__doc__)
     parser.add_argument('--sequences', '-s', required=True, help="sequences in fasta or VCF format")
-    parser.add_argument('--output-sequences', help="output sequences file")
-    parser.add_argument('--output-metadata', help="output metadata file")
-    parser.add_argument('--fields', nargs='+', help="fields in fasta header")
+    parser.add_argument('--output-sequences', required=True, help="output sequences file")
+    parser.add_argument('--output-metadata', required=True, help="output metadata file")
+    parser.add_argument('--fields', required=True, nargs='+', help="fields in fasta header")
     parser.add_argument('--prettify-fields', nargs='+', help="apply string prettifying operations (underscores to spaces, capitalization, etc) to specified metadata fields")
     parser.add_argument('--separator', default='|', help="separator of fasta header")
     parser.add_argument('--fix-dates', choices=['dayfirst', 'monthfirst'],

--- a/tests/functional/parse.t
+++ b/tests/functional/parse.t
@@ -3,6 +3,21 @@ Integration tests for augur parse.
   $ pushd "$TESTDIR" > /dev/null
   $ export AUGUR="${AUGUR:-../../bin/augur}"
 
+Try to parse Zika sequences without specifying fields.
+This should fail.
+
+  $ ${AUGUR} parse \
+  >   --sequences parse/zika.fasta \
+  >   --output-sequences "$TMP/sequences.fasta" \
+  >   --output-metadata "$TMP/metadata.tsv"
+  usage: .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  augur parse: error: the following arguments are required: --fields
+  [2]
+
 Parse Zika sequences into sequences and metadata.
 
   $ ${AUGUR} parse \


### PR DESCRIPTION
### Description of proposed changes

Require arguments to `augur parse` that are actually required including the list of fields to parse and both output files.

### Related issue(s)

Resolves #1222

### Testing

- [x] Adds a simple functional test to confirm this new behavior.
- [x] Checks pass

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
