### PR TITLE
Proof-of-concept: warn that only last --exclude-where used when user passes multiple

### DIFF
--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -33,7 +33,7 @@ def register_arguments(parser):
     metadata_filter_group.add_argument('--exclude-ambiguous-dates-by', choices=['any', 'day', 'month', 'year'],
                                 help='Exclude ambiguous dates by day (e.g., 2020-09-XX), month (e.g., 2020-XX-XX), year (e.g., 200X-10-01), or any date fields. An ambiguous year makes the corresponding month and day ambiguous, too, even if those fields have unambiguous values (e.g., "201X-10-01"). Similarly, an ambiguous month makes the corresponding day ambiguous (e.g., "2010-XX-01").')
     metadata_filter_group.add_argument('--exclude', type=str, nargs="+", help="file(s) with list of strains to exclude")
-    metadata_filter_group.add_argument('--exclude-where', nargs='+',
+    metadata_filter_group.add_argument('--exclude-where', nargs='+', action="append",
                                 help="Exclude samples matching these conditions. Ex: \"host=rat\" or \"host!=rat\". Multiple values are processed as OR (matching any of those specified will be excluded), not AND")
     metadata_filter_group.add_argument('--exclude-all', action="store_true", help="exclude all strains by default. Use this with the include arguments to select a specific subset of strains.")
     metadata_filter_group.add_argument('--include', type=str, nargs="+", help="file(s) with list of strains to include regardless of priorities or subsampling")

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -536,7 +536,9 @@ def construct_filters(args, sequence_index) -> Tuple[List[FilterOption], List[Fi
 
     # Exclude strain my metadata field like 'host=camel'.
     if args.exclude_where:
-        for exclude_where in args.exclude_where:
+        # Use only last exclude_where argument for backward compatibility.
+        # User warned in validate_arguments.py
+        for exclude_where in args.exclude_where[-1]:
             exclude_by.append((
                 filter_by_exclude_where,
                 {"exclude_where": exclude_where}

--- a/augur/filter/validate_arguments.py
+++ b/augur/filter/validate_arguments.py
@@ -1,4 +1,5 @@
 from augur.errors import AugurError
+from augur.io.print import print_err
 from augur.io.vcf import is_vcf as filename_is_vcf
 
 
@@ -42,3 +43,9 @@ def validate_arguments(args):
     # If user requested grouping, confirm that other required inputs are provided, too.
     if args.group_by and not any((args.sequences_per_group, args.subsample_max_sequences)):
         raise AugurError("You must specify a number of sequences per group or maximum sequences to subsample.")
+    
+    # If user passes same optional argument twice (e.g. --exclude and --exclude), raise warning
+    # sum(args.exclude,[]) flattens the list of lists, see https://stackoverflow.com/a/952946/7483211
+    if args.exclude_where and len(args.exclude_where) > 1:
+        print_err(f"WARNING: You passed `--exclude-where` {len(args.exclude_where)} times. Only the last argument {args.exclude_where[-1]} will be used.\n"
+                  f"The following arguments {set(sum(args.exclude_where,[])).difference(set(args.exclude_where[-1]))} will be ignored.")


### PR DESCRIPTION
See https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1684360772513889
for discussion leading up to this

This change is entirely backwards compatible. All it does is add a helpful warning

### Description of proposed changes
Warn users that only last `--exclude-where` is used when user passes the same optional arg multiple times.

This is a proof of concept. It would make sense to roll this out more systematically to all arguments where we have `nargs="+"`

The warning looks as follows:

```bash
$ augur filter             --sequences data/sequences.fasta.zst             --metadata results/metadata.tsv             --exclude config/exclude_accessions_mpxv.txt             --output-sequences results/hmpxv1/good_sequences.fasta.zst             --output-metadata results/hmpxv1/good_metadata.tsv             --min-date 2017             --min-length 180000             --exclude-where outbreak!='hMPXV-1' clade!='IIb' --exclude-where 'coverage<0.95' --exclude-where 'divergence<550' --exclude-where 'missing_data>10000' --exclude-where 'divergence>650' --exclude-where 'QC_rare_mutations!=good'             --output-log results/hmpxv1/good_filter.log

WARNING: You passed `--exclude-where` 6 times. Only the last argument ['QC_rare_mutations!=good'] will be used.
The following arguments {'divergence>650', 'divergence<550', 'coverage<0.95', 'outbreak!=hMPXV-1', 'clade!=IIb', 'missing_data>10000'} will be ignored.
Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
519 strains were dropped during filtering
        42 of these were dropped because of 'QC_rare_mutations!=good'
        113 of these were dropped because they were earlier than 2017.0 or missing a date
        364 of these were dropped because they were shorter than minimum length of 180000bp
6553 strains passed all filters
```

### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
