### PR TITLE
Report helpful error if filter query string malformed

### DIFF
--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -97,10 +97,11 @@ def _parse_filter_query(query):
     ('property', <built-in function ne>, 'value')
 
     """
-    column, value = re.split(r'!?=', query)
-    op = operator.eq
-    if "!=" in query:
-        op = operator.ne
+    split_query = re.split(r'!?=', query)
+    if len(split_query) != 2:
+        raise AugurError(f"Invalid query `{query}`. Hint: Queries must follow the pattern of `property=value` or `property!=value`.")
+    column, value = split_query
+    op = operator.ne if "!=" in query else operator.eq
 
     return column, op, value
 


### PR DESCRIPTION
Resolves #1230
filter: Improperly handled `ValueError: not enough values to unpack (expected 2, got 1)` in ` _parse_filter_query`

### Description of proposed changes
Validate, and raise error with helpful warning if the query string is malformed, rather than raising unhelpful Value Error

New error output:

```bash
❌1 ❯ augur filter --exclude-where "coverage<0.95"   --sequences data/sequences.fasta.zst   --metadata results/metadata.tsv   --exclude config/exclude_accessions_mpxv.txt  --output-sequences results/hmpxv1/good_sequences.fasta.zst  --output-metadata results/hmpxv1/good_metadata.tsv   --min-length 180000   
Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
ERROR: Invalid query `coverage<0.95`. Hint: Queries must follow the pattern of `property=value` or `property!=value`.
```

### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

- [ ] Checks pass

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
