### PR TITLE
Set `date` column to be `string`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,12 @@
 * CI: Add a Github action to test augur on 8 Nextstrain pathogen workflows using example data. [#1217][] (@corneliusroemer)
 * parse: Denote required arguments including `--fields`, `--output-sequences`, and `--output-metadata`. [#1228][] (@huddlej)
 * Fix export of the `strand` attribute of gene annotations. Previously, features on the negative strand were not annotated as such since the code assumed that the `strand` attribute was boolean instead of `[-1, +1]`. [#1211] @rneher and @j23414.
+* augur.io.read_metadata: explicitly set `date` column as `string` type to prevent year only dates from being inferred as integers. [#1235][] (@joverlee521)
 
 [#1211]: https://github.com/nextstrain/augur/pull/1211
 [#1217]: https://github.com/nextstrain/augur/pull/1217
 [#1228]: https://github.com/nextstrain/augur/pull/1228
+[#1235]: https://github.com/nextstrain/augur/pull/1235
 
 ## 22.0.1 (16 May 2023)
 

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -2,7 +2,7 @@
 Filter and subsample a sequence set.
 """
 from augur.dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT
-from augur.io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS
+from augur.io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, METADATA_DATE_COLUMN
 from augur.types import EmptyOutputReportingMethod
 from . import constants
 
@@ -48,7 +48,7 @@ def register_arguments(parser):
     subsample_group.add_argument('--group-by', nargs='+', help=f"""
         categories with respect to subsample.
         Notes:
-        (1) Grouping by {sorted(constants.GROUP_BY_GENERATED_COLUMNS)} is only supported when there is a {constants.METADATA_DATE_COLUMN!r} column in the metadata.
+        (1) Grouping by {sorted(constants.GROUP_BY_GENERATED_COLUMNS)} is only supported when there is a {METADATA_DATE_COLUMN!r} column in the metadata.
         (2) 'week' uses the ISO week numbering system, where a week starts on a Monday and ends on a Sunday.
         (3) 'month' and 'week' grouping cannot be used together.
         (4) Custom columns {sorted(constants.GROUP_BY_GENERATED_COLUMNS)} in the metadata are ignored for grouping. Please rename them if you want to use their values for grouping.""")

--- a/augur/filter/constants.py
+++ b/augur/filter/constants.py
@@ -1,5 +1,3 @@
-METADATA_DATE_COLUMN = 'date'
-
 # Generated date columns.
 DATE_YEAR_COLUMN = 'year'
 DATE_MONTH_COLUMN = 'month'

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Set, Tuple
 
 from augur.dates import numeric_date, is_date_ambiguous, get_numerical_dates
 from augur.errors import AugurError
+from augur.io.metadata import METADATA_DATE_COLUMN
 from augur.io.print import print_err
 from augur.io.vcf import is_vcf as filename_is_vcf
 from augur.utils import read_strains
@@ -554,7 +555,7 @@ def construct_filters(args, sequence_index) -> Tuple[List[FilterOption], List[Fi
         exclude_by.append((
             filter_by_ambiguous_date,
             {
-                "date_column": constants.METADATA_DATE_COLUMN,
+                "date_column": METADATA_DATE_COLUMN,
                 "ambiguity": args.exclude_ambiguous_dates_by,
             }
         ))
@@ -565,7 +566,7 @@ def construct_filters(args, sequence_index) -> Tuple[List[FilterOption], List[Fi
             filter_by_min_date,
             {
                 "min_date": args.min_date,
-                "date_column": constants.METADATA_DATE_COLUMN,
+                "date_column": METADATA_DATE_COLUMN,
             }
         ))
     if args.max_date:
@@ -573,7 +574,7 @@ def construct_filters(args, sequence_index) -> Tuple[List[FilterOption], List[Fi
             filter_by_max_date,
             {
                 "max_date": args.max_date,
-                "date_column": constants.METADATA_DATE_COLUMN,
+                "date_column": METADATA_DATE_COLUMN,
             }
         ))
 
@@ -610,17 +611,17 @@ def construct_filters(args, sequence_index) -> Tuple[List[FilterOption], List[Fi
         if {constants.DATE_YEAR_COLUMN, constants.DATE_MONTH_COLUMN, constants.DATE_WEEK_COLUMN} & set(args.group_by):
             exclude_by.append((
                 skip_group_by_with_ambiguous_year,
-                {"date_column": constants.METADATA_DATE_COLUMN}
+                {"date_column": METADATA_DATE_COLUMN}
             ))
         if {constants.DATE_MONTH_COLUMN, constants.DATE_WEEK_COLUMN} & set(args.group_by):
             exclude_by.append((
                 skip_group_by_with_ambiguous_month,
-                {"date_column": constants.METADATA_DATE_COLUMN}
+                {"date_column": METADATA_DATE_COLUMN}
             ))
         if constants.DATE_WEEK_COLUMN in args.group_by:
             exclude_by.append((
                 skip_group_by_with_ambiguous_day,
-                {"date_column": constants.METADATA_DATE_COLUMN}
+                {"date_column": METADATA_DATE_COLUMN}
             ))
 
     return exclude_by, include_by

--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -7,6 +7,7 @@ from typing import Collection
 
 from augur.dates import get_iso_year_week
 from augur.errors import AugurError
+from augur.io.metadata import METADATA_DATE_COLUMN
 from augur.io.print import print_err
 from . import constants
 
@@ -82,8 +83,8 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     generated_columns_requested = constants.GROUP_BY_GENERATED_COLUMNS & group_by_set
 
     # If we could not find any requested categories, we cannot complete subsampling.
-    if constants.METADATA_DATE_COLUMN not in metadata and group_by_set <= constants.GROUP_BY_GENERATED_COLUMNS:
-        raise AugurError(f"The specified group-by categories ({group_by}) were not found. Note that using any of {sorted(constants.GROUP_BY_GENERATED_COLUMNS)} requires a column called {constants.METADATA_DATE_COLUMN!r}.")
+    if METADATA_DATE_COLUMN not in metadata and group_by_set <= constants.GROUP_BY_GENERATED_COLUMNS:
+        raise AugurError(f"The specified group-by categories ({group_by}) were not found. Note that using any of {sorted(constants.GROUP_BY_GENERATED_COLUMNS)} requires a column called {METADATA_DATE_COLUMN!r}.")
     if not group_by_set & (set(metadata.columns) | constants.GROUP_BY_GENERATED_COLUMNS):
         raise AugurError(f"The specified group-by categories ({group_by}) were not found.")
 
@@ -101,12 +102,12 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
 
         for col in sorted(generated_columns_requested):
             if col in metadata.columns:
-                print_err(f"WARNING: `--group-by {col}` uses a generated {col} value from the {constants.METADATA_DATE_COLUMN!r} column. The custom '{col}' column in the metadata is ignored for grouping purposes.")
+                print_err(f"WARNING: `--group-by {col}` uses a generated {col} value from the {METADATA_DATE_COLUMN!r} column. The custom '{col}' column in the metadata is ignored for grouping purposes.")
                 metadata.drop(col, axis=1, inplace=True)
 
-        if constants.METADATA_DATE_COLUMN not in metadata:
+        if METADATA_DATE_COLUMN not in metadata:
             # Set generated columns to 'unknown'.
-            print_err(f"WARNING: A {constants.METADATA_DATE_COLUMN!r} column could not be found to group-by {sorted(generated_columns_requested)}.")
+            print_err(f"WARNING: A {METADATA_DATE_COLUMN!r} column could not be found to group-by {sorted(generated_columns_requested)}.")
             print_err(f"Filtering by group may behave differently than expected!")
             df_dates = pd.DataFrame({col: 'unknown' for col in constants.GROUP_BY_GENERATED_COLUMNS}, index=metadata.index)
             metadata = pd.concat([metadata, df_dates], axis=1)
@@ -116,7 +117,7 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
             # to generate other columns, and will be discarded at the end.
             temp_prefix = str(uuid.uuid4())
             temp_date_cols = [f'{temp_prefix}year', f'{temp_prefix}month', f'{temp_prefix}day']
-            df_dates = metadata[constants.METADATA_DATE_COLUMN].str.split('-', n=2, expand=True)
+            df_dates = metadata[METADATA_DATE_COLUMN].str.split('-', n=2, expand=True)
             df_dates = df_dates.set_axis(temp_date_cols[:len(df_dates.columns)], axis=1)
             missing_date_cols = set(temp_date_cols) - set(df_dates.columns)
             for col in missing_date_cols:
@@ -126,7 +127,7 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
 
             # Extend metadata with generated date columns
             # Drop the date column since it should not be used for grouping.
-            metadata = pd.concat([metadata.drop(constants.METADATA_DATE_COLUMN, axis=1), df_dates], axis=1)
+            metadata = pd.concat([metadata.drop(METADATA_DATE_COLUMN, axis=1), df_dates], axis=1)
 
             # Check again if metadata is empty after dropping ambiguous dates.
             if metadata.empty:

--- a/augur/io/metadata.py
+++ b/augur/io/metadata.py
@@ -17,6 +17,8 @@ DEFAULT_DELIMITERS = (',', '\t')
 
 DEFAULT_ID_COLUMNS = ("strain", "name")
 
+METADATA_DATE_COLUMN = 'date'
+
 
 class InvalidDelimiter(Exception):
     pass

--- a/augur/io/metadata.py
+++ b/augur/io/metadata.py
@@ -111,7 +111,10 @@ def read_metadata(metadata_file, delimiters=DEFAULT_DELIMITERS, id_columns=DEFAU
     # of having its type inferred. This latter argument allows users to provide
     # numerical ids that don't get converted to numbers by pandas.
     kwargs["index_col"] = index_col
-    kwargs["dtype"] = {index_col: "string"}
+    kwargs["dtype"] = {
+        index_col: "string",
+        METADATA_DATE_COLUMN: "string"
+    }
 
     return pd.read_csv(
         metadata_file,

--- a/tests/functional/filter/cram/filter-exclude-ambiguous-dates-by.t
+++ b/tests/functional/filter/cram/filter-exclude-ambiguous-dates-by.t
@@ -1,0 +1,23 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata TSV file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	date
+  > SEQ_1	2020
+  > SEQ_2	2020
+  > SEQ_3	2020
+  > ~~
+
+Confirm that `--exclude-ambiguous-dates-by` works for all year only ambiguous dates.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --exclude-ambiguous-dates-by any \
+  >  --empty-output-reporting silent \
+  >  --output-strains filtered_strains.txt
+  3 strains were dropped during filtering
+  \t3 of these were dropped because of their ambiguous date in any (esc)
+  0 strains passed all filters


### PR DESCRIPTION
### Description of proposed changes
Set the dtype for the `date` column to be `string` within `read_metadata` so that we don't run into unexpected errors due to Panda's type inference in any downstream uses of the metadata.

Motivated by recent error in ncov workflow ([Slack thread](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1685083351913909))


### Testing
Added new functional test for `filter` where we initially saw the type error. 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
