### PR TITLE
titer_model: Remove top-level entrypoint

### DIFF
--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -1,6 +1,3 @@
-# Prevent mypy from erroring on "flu" not being defined.
-# mypy: disable-error-code="name-defined"
-
 import os
 import logging
 import numpy as np
@@ -1159,16 +1156,3 @@ class SubstitutionModel(TiterModel):
                 child.cTiterSub = node.cTiterSub + child.dTiterSub
 
         return tree
-
-
-if __name__=="__main__":
-    # test tree model (assumes there is a tree called flu in memory...)
-    ttm = TreeModel(flu.tree.tree, flu.titers)
-    ttm.prepare(training_fraction=0.8)
-    ttm.train(method='nnl1reg')
-    ttm.validate(plot=True)
-
-    tsm = SubstitutionModel(flu.tree.tree, flu.titers)
-    tsm.prepare(training_fraction=0.8)
-    tsm.train(method='nnl1reg')
-    tsm.validate(plot=True)


### PR DESCRIPTION
### Description of proposed changes

Once upon a time, this Python file might have been used as a standalone program. Nowadays, it is only used by titers.py. This means the code removed in this commit should be unused.

Removal of the entrypoint code allows the removal of a Mypy exception that applied to the entire file, but was only meant to target this block of code.

### Related issue(s)

- Prompted by https://github.com/nextstrain/augur/pull/1244#discussion_r1248116345

### Testing

N/A

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, no functional changes