### PR TITLE
Use less dtype inference when reading metadata into DataFrames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,17 @@
 
 ## __NEXT__
 
+### Features
+
+* `augur.io.read_metadata`: A new optional `dtype` argument allows custom data types for all columns. Automatic type inference still happens by default, so this is not a breaking change. [#1252][] (@victorlin)
+
+
+### Bug Fixes
+
+* filter, frequencies, refine: Speed up reading of the metadata file. [#1252][] (@victorlin)
+* traits: Previously, columns with only numeric values were treated as numerical data. These are now treated as categorical data for discrete trait analysis. [#1252][] (@victorlin)
+
+[#1252]: https://github.com/nextstrain/augur/pull/1252
 
 ## 24.0.0 (22 January 2024)
 

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -169,6 +169,7 @@ def run(args):
             delimiters=args.metadata_delimiters,
             id_columns=args.metadata_id_columns,
             chunk_size=args.metadata_chunk_size,
+            dtype="string",
         )
     except InvalidDelimiter:
         raise AugurError(
@@ -320,6 +321,7 @@ def run(args):
             delimiters=args.metadata_delimiters,
             id_columns=args.metadata_id_columns,
             chunk_size=args.metadata_chunk_size,
+            dtype="string",
         )
         for metadata in metadata_reader:
             # Recalculate groups for subsampling as we loop through the

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -85,7 +85,14 @@ def format_frequencies(freq):
 
 def run(args):
     try:
-        metadata = read_metadata(args.metadata, delimiters=args.metadata_delimiters, id_columns=args.metadata_id_columns)
+        # TODO: load only the ID, date, and --weights-attribute columns when
+        # read_metadata supports loading a subset of all columns.
+        metadata = read_metadata(
+            args.metadata,
+            delimiters=args.metadata_delimiters,
+            id_columns=args.metadata_id_columns,
+            dtype="string",
+        )
     except InvalidDelimiter:
         raise AugurError(
             f"Could not determine the delimiter of {args.metadata!r}. "

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -214,10 +214,14 @@ def run(args):
             print("ERROR: meta data with dates is required for time tree reconstruction", file=sys.stderr)
             return 1
         try:
+            # TODO: load only the ID and date columns when read_metadata
+            # supports loading a subset of all columns.
             metadata = read_metadata(
                 args.metadata,
                 delimiters=args.metadata_delimiters,
-                id_columns=args.metadata_id_columns)
+                id_columns=args.metadata_id_columns,
+                dtype="string",
+            )
         except InvalidDelimiter:
             raise AugurError(
                 f"Could not determine the delimiter of {args.metadata!r}. "

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -131,7 +131,11 @@ def run(args):
         traits = read_metadata(
             args.metadata,
             delimiters=args.metadata_delimiters,
-            id_columns=args.metadata_id_columns)
+            id_columns=args.metadata_id_columns,
+
+            # Read all columns as string for discrete trait analysis
+            dtype="string",
+        )
     except InvalidDelimiter:
         raise AugurError(
                 f"Could not determine the delimiter of {args.metadata!r}. "

--- a/tests/functional/filter/cram/filter-query-numerical.t
+++ b/tests/functional/filter/cram/filter-query-numerical.t
@@ -33,3 +33,28 @@ The 'category' column will fail when used with a numerical comparison.
   	'>=' not supported between instances of 'str' and 'float'
   Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
   [2]
+
+Create another metadata file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	metric1	metric2
+  > SEQ1	4	5
+  > SEQ2	5	9
+  > SEQ3	6	10
+  > ~~
+
+Use a Pandas query to filter by a numerical value.
+This relies on having proper data types associated with the columns. If < is
+comparing strings, it's likely that SEQ3 will be dropped or errors arise.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "metric1 > 4 & metric1 < metric2" \
+  >  --output-strains filtered_strains.txt
+  1 strains were dropped during filtering
+  \t1 of these were filtered out by the query: "metric1 > 4 & metric1 < metric2" (esc)
+  2 strains passed all filters
+
+  $ sort filtered_strains.txt
+  SEQ2
+  SEQ3


### PR DESCRIPTION
### Description of proposed changes

Support passing the `dtype` parameter to `pandas.read_csv` in `augur.io.read_metadata`, and use it to not infer data types in subcommands that don't need it.

Internal references to `read_metadata` that were not updated due to broad use of data types:

- export v1, v2: These support arbitrary columns for coloring. Data types should be inferred on all columns to ensure they are converted to JSON properly.

### Related issue(s)

- Prompted by https://github.com/nextstrain/augur/pull/1235#discussion_r1207327871

### Testing

- [x] Added a test for numerical queries that rely on dtypes
- [x] Checks pass

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
