### PR TITLE
feat: add mid-point rooting to refine

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,9 @@
 
 * ancestral: add functionality to reconstruct ancestral amino acid sequences and add inferred mutations to the `node_data_json` with output equivalent to `augur translate`. `ancestral` now takes an annotation (`--annotation`), a list of genes (`--genes`), and a file name pattern for amino acid alignments (`--translations`). Mutations for each of these genes will be inferred and added to the output JSON to each node as a list at `['aa_muts'][gene]`. The annotations will be added to the `annotation` field in the output JSON. Inferred amino acids sequences can be saved with the new `--output-translations` argument. [#1258][] (@rneher, @huddlej)
 * ancestral: add the ability to report mutations relative to a sequence other than the inferred root of the tree. This sequence can be specified via `--root-sequence` and difference between this sequence and the inferred root of the tree will be added as mutations to the root node for nucleotides and amino acids. All differences between the specified `root-sequence` and the inferred sequence of the root node of the tree will be added as mutations to the root node. This was previously already possible for `vcf` input via `--vcf-reference`. [#1258][] (@rneher)
+* refine: add `mid_point` as rooting option to `refine`. [#1257][] (@rneher)
 
+[#1257]: https://github.com/nextstrain/augur/pull/1257
 [#1258]: https://github.com/nextstrain/augur/pull/1258
 
 ## 22.2.0 (31 July 2023)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -113,7 +113,7 @@ def register_parser(parent_subparsers):
     parser.add_argument('--gen-per-year', default=50, type=float, help="number of generations per year, relevant for skyline output('skyline')")
     parser.add_argument('--clock-rate', type=float, help="fixed clock rate")
     parser.add_argument('--clock-std-dev', type=float, help="standard deviation of the fixed clock_rate estimate")
-    parser.add_argument('--root', nargs="+", default='best', help="rooting mechanism ('best', least-squares', 'min_dev', 'oldest') "
+    parser.add_argument('--root', nargs="+", default='best', help="rooting mechanism ('best', least-squares', 'min_dev', 'oldest', 'mid_point') "
                                 "OR node to root by OR two nodes indicating a monophyletic group to root by. "
                                 "Run treetime -h for definitions of rooting methods.")
     parser.add_argument('--keep-root', action="store_true", help="do not reroot the tree; use it as-is. "
@@ -240,6 +240,11 @@ def run(args):
         else:
             time_inference_mode = 'always' if args.date_inference=='marginal' else 'never'
 
+        if args.root == 'mid_point':
+            # root at midpoint and disable downstream rerooting in TreeTime
+            T.root_at_midpoint()
+            args.root = None
+
         tt = refine(tree=T, aln=aln, ref=ref, dates=dates, confidence=args.date_confidence,
                     reroot=args.root, # or 'best', # We now have a default in param spec - this just adds confusion.
                     Tc=0.01 if args.coalescent is None else args.coalescent, #use 0.01 as default coalescent time scale
@@ -277,8 +282,10 @@ def run(args):
             if args.root == 'best':
                 print("Warning: To root without inferring a timetree, you must specify an explicit outgroup.")
                 print("\tProceeding without re-rooting. To suppress this message, use '--keep-root'.\n")
-            elif args.root in ['least-squares', 'min_dev', 'oldest']:
+            elif args.root in ['least-squares', 'oldest', 'min_dev']:
                 raise TypeError("The rooting option '%s' is only available when inferring a timetree. Please specify an explicit outgroup."%args.root)
+            elif args.root=="mid_point":
+                T.root_at_midpoint()
             else:
                 try:
                     T.root_with_outgroup(args.root)


### PR DESCRIPTION
### Description of proposed changes
Add option to mid-point root to refine, both with and without timetree. 

### Checklist

- [X] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
