### PR TITLE
export v1: Add deprecation warning, remove `--metadata-id-columns`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,12 @@
 ### Bug fixes
 
 * export v2: Previously, when `strain` was not used as the metadata ID column, node attributes might have gone missing from the final Auspice JSON. This has been fixed. [#1260][], [#1262][] (@victorlin, @joverlee521)
+* export v1: Added a deprecation warning for this command. [#1265][] (@victorlin)
+* export v1: The recently introduced flag `--metadata-id-columns` did not work properly due to the same `export v2` bug that was fixed in this release. Instead of fixing it in `export v1`, drop the broken feature since this command is no longer being maintained. [#1265][] (@victorlin)
 
 [#1260]: https://github.com/nextstrain/augur/issues/1260
 [#1262]: https://github.com/nextstrain/augur/issues/1262
+[#1265]: https://github.com/nextstrain/augur/pull/1265
 
 ## 22.1.0 (10 July 2023)
 

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -4,6 +4,7 @@ Export version 1 JSON schema (separate meta and tree JSONs) for visualization wi
 
 import os, sys
 import re
+from textwrap import dedent
 import time
 import numpy as np
 from Bio import Phylo
@@ -345,6 +346,10 @@ def register_parser(parent_subparsers):
 
 
 def run(args):
+    print(dedent("""\
+        DEPRECATION WARNING: augur export v1 is no longer maintained and will be removed in a future release.
+        Read more on how to migrate to export v2: <https://docs.nextstrain.org/projects/augur/en/stable/releases/migrating-v5-v6.html>"""),file=sys.stderr)
+
     T = Phylo.read(args.tree, 'newick')
     node_data = read_node_data(args.node_data) # args.node_data is an array of multiple files (or a single file)
     nodes = node_data["nodes"] # this is the per-node metadata produced by various augur modules

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -12,7 +12,7 @@ from argparse import SUPPRESS
 from collections import defaultdict
 from .errors import AugurError
 from .argparse_ import ExtendAction
-from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
+from .io.metadata import DEFAULT_DELIMITERS, InvalidDelimiter, read_metadata
 from .utils import read_node_data, write_json, read_config, read_lat_longs, read_colors
 
 def convert_tree_to_json_structure(node, metadata, div=0, strains=None):
@@ -316,8 +316,6 @@ def add_core_args(parser):
     core.add_argument('--metadata', required=True, metavar="FILE", help="sequence metadata")
     core.add_argument('--metadata-delimiters', default=DEFAULT_DELIMITERS, nargs="+",
                       help="delimiters to accept when reading a metadata file. Only one delimiter will be inferred.")
-    core.add_argument('--metadata-id-columns', default=DEFAULT_ID_COLUMNS, nargs="+",
-                                 help="names of possible metadata columns containing identifier information, ordered by priority. Only one ID column will be inferred.")
     core.add_argument('--node-data', required=True, nargs='+', action=ExtendAction, help="JSON files with meta data for each node")
     core.add_argument('--output-tree', help="JSON file name that is passed on to auspice (e.g., zika_tree.json).")
     core.add_argument('--output-meta', help="JSON file name that is passed on to auspice (e.g., zika_meta.json).")
@@ -377,8 +375,7 @@ def run(args):
     try:
         meta_tsv = read_metadata(
             args.metadata,
-            delimiters=args.metadata_delimiters,
-            id_columns=args.metadata_id_columns)
+            delimiters=args.metadata_delimiters)
     except InvalidDelimiter:
         raise AugurError(
             f"Could not determine the delimiter of {args.metadata!r}. "

--- a/tests/builds/zika.t
+++ b/tests/builds/zika.t
@@ -164,6 +164,8 @@ Export JSON files as v1 auspice outputs.
   >  --output-tree "$TMP/out/v1_zika_tree.json" \
   >  --output-meta "$TMP/out/v1_zika_meta.json" \
   >  --output-sequence "$TMP/out/v1_zika_seq.json" > /dev/null
+  DEPRECATION WARNING: augur export v1 is no longer maintained and will be removed in a future release.
+  Read more on how to migrate to export v2: <https://docs.nextstrain.org/projects/augur/en/stable/releases/migrating-v5-v6.html>
 
   $ ${AUGUR} validate export-v1 "$TMP/out/v1_zika_meta.json" "$TMP/out/v1_zika_tree.json" > /dev/null
 


### PR DESCRIPTION
### Description of proposed changes

Start the process of removing `export v1`.

### Related issue(s)

#1266

### Testing

- [x] Test updated with deprecation warning
- [ ] Checks pass

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
