### PR TITLE
filter: Try converting all queried columns to numerical type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,13 @@
 * export v1: Added a deprecation warning for this command. [#1265][] (@victorlin)
 * export v1: The recently introduced flag `--metadata-id-columns` did not work properly due to the same `export v2` bug that was fixed in this release. Instead of fixing it in `export v1`, drop the broken feature since this command is no longer being maintained. [#1265][] (@victorlin)
 * filter: Expose internal Pandas errors from `--query` which may be useful to users. [#1267][] (@victorlin)
+* filter: Previously, `--query` would fail when numerical comparisons were used on columns with missing values. This has been fixed. [#1269][] (@victorlin)
 
 [#1260]: https://github.com/nextstrain/augur/issues/1260
 [#1262]: https://github.com/nextstrain/augur/issues/1262
 [#1265]: https://github.com/nextstrain/augur/pull/1265
 [#1267]: https://github.com/nextstrain/augur/pull/1267
+[#1269]: https://github.com/nextstrain/augur/issues/1269
 
 ## 22.1.0 (10 July 2023)
 

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -178,6 +178,10 @@ def filter_by_query(metadata, query) -> FilterFunctionReturn:
     set()
 
     """
+    # Try converting all columns to numeric.
+    for column in metadata.columns:
+        metadata[column] = pd.to_numeric(metadata[column], errors='ignore')
+
     return set(metadata.query(query).index.values)
 
 

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -13,6 +13,12 @@ from augur.io.vcf import is_vcf as filename_is_vcf
 from augur.utils import read_strains
 from . import constants
 
+try:
+    # python ≥3.8 only
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
+
 
 # The strains to keep as a result of applying a filter function.
 FilterFunctionReturn = Set[str]
@@ -178,8 +184,8 @@ def filter_by_query(metadata, query) -> FilterFunctionReturn:
     set()
 
     """
-    # Try converting all columns to numeric.
-    for column in metadata.columns:
+    # Try converting all queried columns to numeric.
+    for column in extract_variables(query).intersection(metadata.columns):
         metadata[column] = pd.to_numeric(metadata[column], errors='ignore')
 
     return set(metadata.query(query).index.values)
@@ -803,3 +809,29 @@ def _filter_kwargs_to_str(kwargs: FilterFunctionKwargs):
         kwarg_list.append((key, value))
 
     return json.dumps(kwarg_list)
+
+
+# From https://stackoverflow.com/a/76536356
+def extract_variables(pandas_query: str):
+    """Extract variable names used in a pandas query string."""
+
+    # Track variables in a dictionary to be used as a dictionary of globals.
+    variables: Dict[str, Literal[None]] = {}
+
+    while True:
+        try:
+            # Try creating a Expr object with the query string and dictionary of globals.
+            # This will raise an error as long as the dictionary of globals is incomplete.
+            env = pd.core.computation.scope.ensure_scope(level=0, global_dict=variables)
+            pd.core.computation.expr.Expr(pandas_query, env=env)
+
+            # Exit the loop when evaluation is successful.
+            break
+        except pd.errors.UndefinedVariableError as e:
+            # This relies on the format defined here: https://github.com/pandas-dev/pandas/blob/965ceca9fd796940050d6fc817707bba1c4f9bff/pandas/errors/__init__.py#L401
+            name = re.findall("name '(.+?)' is not defined", str(e))[0]
+
+            # Add the name to the globals dictionary with a dummy value.
+            variables[name] = None
+
+    return set(variables.keys())

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setuptools.setup(
             "sphinx-autodoc-typehints >=1.21.4",
             "types-jsonschema >=3.0.0, ==3.*",
             "types-setuptools",
+            "typing_extensions; python_version <'3.8'",
             "wheel >=0.32.3",
             "ipdb >=0.10.1"
         ]

--- a/tests/functional/filter/cram/filter-query-numerical.t
+++ b/tests/functional/filter/cram/filter-query-numerical.t
@@ -1,0 +1,26 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	coverage
+  > SEQ_1	0.94
+  > SEQ_2	0.95
+  > SEQ_3	0.96
+  > SEQ_4	
+  > ~~
+
+Ideally, the 'coverage' column should be query-able by numerical comparisons.
+This does not currently work since the empty string is causing that column to be
+parsed as a non-numerical type.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "coverage >= 0.95" \
+  >  --output-strains filtered_strains.txt > /dev/null
+  ERROR: Internal Pandas error when applying query:
+  	'>=' not supported between instances of 'str' and 'float'
+  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  [2]

--- a/tests/functional/filter/cram/filter-query-numerical.t
+++ b/tests/functional/filter/cram/filter-query-numerical.t
@@ -12,15 +12,13 @@ Create metadata file for testing.
   > SEQ_4	
   > ~~
 
-Ideally, the 'coverage' column should be query-able by numerical comparisons.
-This does not currently work since the empty string is causing that column to be
-parsed as a non-numerical type.
+The 'coverage' column should be query-able by numerical comparisons.
 
   $ ${AUGUR} filter \
   >  --metadata metadata.tsv \
   >  --query "coverage >= 0.95" \
   >  --output-strains filtered_strains.txt > /dev/null
-  ERROR: Internal Pandas error when applying query:
-  	'>=' not supported between instances of 'str' and 'float'
-  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
-  [2]
+
+  $ sort filtered_strains.txt
+  SEQ_2
+  SEQ_3


### PR DESCRIPTION
### Description of proposed changes

The dtype inference in augur.io.read_metadata does not support numerical columns with empty values (because it calls pandas.read_csv with na_filter=False¹). This gets around that limitation by converting columns before querying.

I also considered infer_objects and convert_dtypes, but those are not useful here since they only support soft (not hard) conversions².

¹ a1bfce484097fb3e1638b3c507793f3b8c6270c1
² https://stackoverflow.com/a/60278450

### Related issue(s)

Fixes #1269

Addresses https://github.com/nextstrain/augur/pull/1252#discussion_r1256657083

Prompted by in-lab discussion with a user.

### Testing

- [x] Test added and updated to show change in behavior
- [x] Checks pass

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
