### PR TITLE
Remove extra TreeTime version check

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -180,13 +180,6 @@ def run(args):
     else:
         aln = args.alignment
 
-    # Enforce treetime 0.7 or later
-    from distutils.version import StrictVersion
-    import treetime
-    if StrictVersion(treetime.version) < StrictVersion('0.7.0'):
-        print("ERROR: this version of augur requires TreeTime 0.7 or later.", file=sys.stderr)
-        return 1
-
     # Infer ambiguous bases if the user has requested that we infer them (either
     # explicitly or by default) and the user has not explicitly requested that
     # we keep them.


### PR DESCRIPTION
### Description of proposed changes

The TreeTime version is enforced upon installation¹ by definition of setup.py. Thus, any checks during runtime are unnecessary.

¹ https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#declaring-required-dependency

### Related issue(s)

Closes #1271 

### Testing

N/A

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ N/A, no functional changes