### PR TITLE
CI: Remove mamba list

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,6 @@ jobs:
           channels: nextstrain,conda-forge,bioconda
           cache-env: true
       - run: pip install .
-      - run: mamba list
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### Description of proposed changes

mamba used to get pulled in by nextstrain-base, but no longer is as of 20230731T202813Z hb0f4dca_0_locked¹.

This change is a combination of bdfc6003bef1adc1444eaba2562ce67b070f19a0 + 73e3cdd1817ce611ea42c0f7be9700d5d1699e41.

¹ https://github.com/nextstrain/conda-base/actions/runs/5719328680/attempts/1#summary-15496995544

### Related issue(s)

Replaces 9bde4757fc0d354d3b7bd4a088bb6f3cff3c64f4...73e3cdd1817ce611ea42c0f7be9700d5d1699e41

### Testing

- [ ] CI passes

### Checklist

- [x] ~Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.~ No functional changes
