### PR TITLE
filter: Remove attempt at extracting variables from `--query`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,13 @@
 * ancestral: add the ability to report mutations relative to a sequence other than the inferred root of the tree. This sequence can be specified via `--root-sequence` and difference between this sequence and the inferred root of the tree will be added as mutations to the root node for nucleotides and amino acids. All differences between the specified `root-sequence` and the inferred sequence of the root node of the tree will be added as mutations to the root node. This was previously already possible for `vcf` input via `--vcf-reference`. [#1258][] (@rneher)
 * refine: add `mid_point` as rooting option to `refine`. [#1257][] (@rneher)
 
+### Bug fixes
+
+* filter: In version 22.2.0, `--query` would fail when the `.str` accessor was used on a column. This has been fixed. [#1277][] (@victorlin)
+
 [#1257]: https://github.com/nextstrain/augur/pull/1257
 [#1258]: https://github.com/nextstrain/augur/pull/1258
+[#1277]: https://github.com/nextstrain/augur/issues/1277
 
 ## 22.2.0 (31 July 2023)
 

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -184,11 +184,14 @@ def filter_by_query(metadata, query) -> FilterFunctionReturn:
     set()
 
     """
-    # Try converting all columns to numeric.
-    for column in metadata.columns:
-        metadata[column] = pd.to_numeric(metadata[column], errors='ignore')
+    # Create a copy to prevent modification of the original DataFrame.
+    metadata_copy = metadata.copy()
 
-    return set(metadata.query(query).index.values)
+    # Try converting all columns to numeric.
+    for column in metadata_copy.columns:
+        metadata_copy[column] = pd.to_numeric(metadata_copy[column], errors='ignore')
+
+    return set(metadata_copy.query(query).index.values)
 
 
 def filter_by_ambiguous_date(metadata, date_column, ambiguity) -> FilterFunctionReturn:

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -14,12 +14,6 @@ from augur.utils import read_strains
 from . import constants
 
 try:
-    # python ≥3.8 only
-    from typing import Literal  # type: ignore
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
-
-try:
     # pandas ≥1.5.0 only
     PandasUndefinedVariableError = pd.errors.UndefinedVariableError  # type: ignore
 except AttributeError:
@@ -190,8 +184,8 @@ def filter_by_query(metadata, query) -> FilterFunctionReturn:
     set()
 
     """
-    # Try converting all queried columns to numeric.
-    for column in extract_variables(query).intersection(metadata.columns):
+    # Try converting all columns to numeric.
+    for column in metadata.columns:
         metadata[column] = pd.to_numeric(metadata[column], errors='ignore')
 
     return set(metadata.query(query).index.values)
@@ -810,29 +804,3 @@ def _filter_kwargs_to_str(kwargs: FilterFunctionKwargs):
         kwarg_list.append((key, value))
 
     return json.dumps(kwarg_list)
-
-
-# From https://stackoverflow.com/a/76536356
-def extract_variables(pandas_query: str):
-    """Extract variable names used in a pandas query string."""
-
-    # Track variables in a dictionary to be used as a dictionary of globals.
-    variables: Dict[str, Literal[None]] = {}
-
-    while True:
-        try:
-            # Try creating a Expr object with the query string and dictionary of globals.
-            # This will raise an error as long as the dictionary of globals is incomplete.
-            env = pd.core.computation.scope.ensure_scope(level=0, global_dict=variables)
-            pd.core.computation.expr.Expr(pandas_query, env=env)
-
-            # Exit the loop when evaluation is successful.
-            break
-        except PandasUndefinedVariableError as e:
-            # This relies on the format defined here: https://github.com/pandas-dev/pandas/blob/965ceca9fd796940050d6fc817707bba1c4f9bff/pandas/errors/__init__.py#L401
-            name = re.findall("name '(.+?)' is not defined", str(e))[0]
-
-            # Add the name to the globals dictionary with a dummy value.
-            variables[name] = None
-
-    return set(variables.keys())

--- a/tests/functional/filter/cram/filter-query-and-exclude-ambiguous-dates-by.t
+++ b/tests/functional/filter/cram/filter-query-and-exclude-ambiguous-dates-by.t
@@ -13,12 +13,14 @@ Create metadata TSV file for testing.
   > ~~
 
 Confirm that `--exclude-ambiguous-dates-by` works for all year only ambiguous dates.
-This currently fails because the metadata DataFrame is modified in-place.
 
   $ ${AUGUR} filter \
   >  --metadata metadata.tsv \
   >  --query 'region=="Asia"' \
   >  --exclude-ambiguous-dates-by any \
   >  --empty-output-reporting silent \
-  >  --output-strains filtered_strains.txt > /dev/null 2>&1
-  [2]
+  >  --output-strains filtered_strains.txt
+  4 strains were dropped during filtering
+  \t1 of these were filtered out by the query: "region=="Asia"" (esc)
+  \t3 of these were dropped because of their ambiguous date in any (esc)
+  0 strains passed all filters

--- a/tests/functional/filter/cram/filter-query-and-exclude-ambiguous-dates-by.t
+++ b/tests/functional/filter/cram/filter-query-and-exclude-ambiguous-dates-by.t
@@ -1,0 +1,24 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata TSV file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	date	region
+  > SEQ_1	2020	Asia
+  > SEQ_2	2020	Asia
+  > SEQ_3	2020	Asia
+  > SEQ_4	2020	North America
+  > ~~
+
+Confirm that `--exclude-ambiguous-dates-by` works for all year only ambiguous dates.
+This currently fails because the metadata DataFrame is modified in-place.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query 'region=="Asia"' \
+  >  --exclude-ambiguous-dates-by any \
+  >  --empty-output-reporting silent \
+  >  --output-strains filtered_strains.txt > /dev/null 2>&1
+  [2]

--- a/tests/functional/filter/cram/filter-query-str.t
+++ b/tests/functional/filter/cram/filter-query-str.t
@@ -1,0 +1,24 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	column
+  > SEQ_1	value1
+  > SEQ_2	value2
+  > SEQ_3	value3
+  > ~~
+
+'column' should be query-able using the `.str` accessor.
+Currently, this does not work properly due to a bug.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "column.str.startswith('value')" \
+  >  --output-strains filtered_strains.txt > /dev/null
+  ERROR: Internal Pandas error when applying query:
+  	'NoneType' object has no attribute 'str'
+  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  [2]

--- a/tests/functional/filter/cram/filter-query-str.t
+++ b/tests/functional/filter/cram/filter-query-str.t
@@ -12,13 +12,13 @@ Create metadata file for testing.
   > ~~
 
 'column' should be query-able using the `.str` accessor.
-Currently, this does not work properly due to a bug.
 
   $ ${AUGUR} filter \
   >  --metadata metadata.tsv \
   >  --query "column.str.startswith('value')" \
   >  --output-strains filtered_strains.txt > /dev/null
-  ERROR: Internal Pandas error when applying query:
-  	'NoneType' object has no attribute 'str'
-  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
-  [2]
+
+  $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_2
+  SEQ_3


### PR DESCRIPTION
### Description of proposed changes

The attempt worked under limited testing, but introduced a bug that can only be resolved with further complex Pandas query parsing. I don't think that road is worth pursuing at the moment, so it's better to drop the effort entirely.

This partially reverts commit 2ead5b3e3306dc1100b49eb774287496018122d9 and related changes.

I chose to keep the definition of PandasUndefinedVariableError at the top-level¹ because it keeps external references next to each other, and typing_extensions in the dependency list² because it is bound to be useful at some point, and updating dependencies on Augur's Bioconda recipe is a hassle.

¹ 602e3d5429f26d4625ecaeb7a07b47477f333d37
² 26586595e1b16a8ba77e0ed1bb7b83c766bddcc1

### Related issue(s)

Fixes #1277

### Testing

- [x] Test added to show change in behavior
- [x] Checks pass

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.