### PR TITLE
feat(mask): Add `--mask-gaps {all,terminals}` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,16 @@
 
 ## __NEXT__
 
+### Features
+
+* mask: Add `--mask-gaps` option to `augur mask` to allow masking of gaps at terminals via `--mask-gaps terminals` or all gaps via `--mask-gaps all`. [#1286][] (@corneliusroemer)
+
 ### Bug fixes
 
 * distance: Improve documentation by describing how gaps get treated as indels and how users can ignore specific characters in distance calculations. [#1285][] (@huddlej)
 
 [#1285]: https://github.com/nextstrain/augur/pull/1285
+[#1286]: https://github.com/nextstrain/augur/pull/1286
 
 ## 22.3.0 (14 August 2023)
 


### PR DESCRIPTION
This allows`augur mask` to allow masking of gaps at terminals via `--mask-gaps terminals` or all gaps via `--mask-gaps all`.

Masking all gaps symmetrizes treatments of gaps and insertions.
It is useful when gaps are jumpy due to sequencing artefacts and allows
gaps to be entirely ignored

Further discussion: https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1692443660080129

### Testing

I tested all options in a workflow. As this is a new option that is a _noop_ unless the option is explicitly set, it shouldn't break any existing code even if the implementation happens to have a bug.

If this PR gets approved, we might want to add a simple cram test, but it'd be a waste of time to do this now before feedback on whether this PR is at all welcome.

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
- [ ] Add simple cram test (once PR is generally accepted)
