### PR TITLE
feat(mask): allow empty mask file, warn not error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Features
 
 * mask: Add `--mask-gaps` option to `augur mask` to allow masking of gaps at terminals via `--mask-gaps terminals` or all gaps via `--mask-gaps all`. [#1286][] (@corneliusroemer)
+* mask: Warn on empty mask file instead of error. Introduced to allow empty stub files when setting up builds and to prevent necessary workflow changes when all mask sites are removed. [#1287][] (@corneliusroemer)
 
 ### Bug fixes
 
@@ -12,6 +13,7 @@
 
 [#1285]: https://github.com/nextstrain/augur/pull/1285
 [#1286]: https://github.com/nextstrain/augur/pull/1286
+[#1287]: https://github.com/nextstrain/augur/pull/1286
 
 ## 22.3.0 (14 August 2023)
 

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -231,8 +231,7 @@ def run(args):
             print("ERROR: File {} does not exist!".format(args.mask_file))
             sys.exit(1)
         if os.path.getsize(args.mask_file) == 0:
-            print("ERROR: {} is an empty file.".format(args.mask_file))
-            sys.exit(1)
+            print(f"WARN: The mask file {args.mask_file} is an empty file.")
     if not any((args.mask_file, args.mask_gaps, args.mask_from_beginning, args.mask_from_end, args.mask_sites, args.mask_invalid)):
         print("No masking sites provided. Must include one of --mask, --mask-gaps, --mask-from-beginning, --mask-from-end, --mask-invalid, or --mask-sites")
         sys.exit(1)


### PR DESCRIPTION
### Description of proposed changes
This commit adds a warning message when encountering an empty mask file. Now, instead of throwing an error, a warning is printed with the name of the empty mask file.

Reason: When stubbing out a build, one may want to add an empty mask file to future proof the repo even if that list of sites is empty

Also: When one just has one masked site, removes it from the file, one generally doesn't want the workflow to error

Config file changes, e.g. removing mask sites, shouldn't cause workflows to error. This is arguably a bug.

### Testing

Minimal changes, no testing necessary

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
