### PR TITLE
chore/remove unused imports

### DIFF
--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -25,7 +25,7 @@ nucleotide sequences, please use `augur translate`.
 from augur.errors import AugurError
 import sys
 import numpy as np
-from Bio import Phylo, SeqIO
+from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from .utils import read_tree, InvalidTreeError, write_json, get_json_name

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -23,7 +23,7 @@ nucleotide sequences, please use `augur translate`.
     The mutation positions in the node-data JSON are one-based.
 """
 from augur.errors import AugurError
-import os, shutil, time, json, sys
+import sys
 import numpy as np
 from Bio import Phylo, SeqIO
 from Bio.Seq import Seq

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -182,7 +182,6 @@ from collections import defaultdict
 import copy
 from itertools import chain
 import json
-import numpy as np
 import pandas as pd
 import sys
 

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -2,8 +2,7 @@
 Export version 1 JSON schema (separate meta and tree JSONs) for visualization with Auspice
 """
 
-import os, sys
-import re
+import sys
 from textwrap import dedent
 import time
 import numpy as np

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -2,7 +2,7 @@
 Export version 2 JSON schema for visualization with Auspice
 """
 from pathlib import Path
-import os, sys
+import sys
 import time
 from collections import defaultdict, deque, OrderedDict
 import warnings

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from typing import Any, Callable, Dict, List, Set, Tuple
 
-from augur.dates import numeric_date, is_date_ambiguous, get_numerical_dates
+from augur.dates import get_numerical_dates, is_date_ambiguous
 from augur.errors import AugurError
 from augur.io.metadata import METADATA_DATE_COLUMN
 from augur.io.print import print_err
@@ -261,6 +261,7 @@ def filter_by_min_date(metadata, date_column, min_date) -> FilterFunctionReturn:
 
     Examples
     --------
+    >>> from augur.dates import numeric_date
     >>> metadata = pd.DataFrame([{"region": "Africa", "date": "2020-01-01"}, {"region": "Europe", "date": "2020-01-02"}], index=["strain1", "strain2"])
     >>> filter_by_min_date(metadata, date_column="date", min_date=numeric_date("2020-01-02"))
     {'strain2'}
@@ -301,6 +302,7 @@ def filter_by_max_date(metadata, date_column, max_date) -> FilterFunctionReturn:
 
     Examples
     --------
+    >>> from augur.dates import numeric_date
     >>> metadata = pd.DataFrame([{"region": "Africa", "date": "2020-01-01"}, {"region": "Europe", "date": "2020-01-02"}], index=["strain1", "strain2"])
     >>> filter_by_max_date(metadata, date_column="date", max_date=numeric_date("2020-01-01"))
     {'strain1'}
@@ -664,6 +666,7 @@ def apply_filters(metadata, exclude_by: List[FilterOption], include_by: List[Fil
 
     Examples
     --------
+    >>> from augur.dates import numeric_date
     >>> metadata = pd.DataFrame([{"region": "Africa", "date": "2020-01-01"}, {"region": "Europe", "date": "2020-10-02"}, {"region": "North America", "date": "2020-01-01"}], index=["strain1", "strain2", "strain3"])
     >>> exclude_by = [(filter_by_min_date, {"date_column": "date", "min_date": numeric_date("2020-04-01")})]
     >>> include_by = [(force_include_where, {"include_where": "region=Africa"})]

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -3,7 +3,6 @@ infer frequencies of mutations or clades
 """
 import json, os, sys
 import numpy as np
-from collections import defaultdict
 from Bio import Phylo, AlignIO
 from Bio.Align import MultipleSeqAlignment
 

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -11,7 +11,7 @@ from .frequency_estimators import get_pivots, alignment_frequencies, tree_freque
 from .frequency_estimators import AlignmentKdeFrequencies, TreeKdeFrequencies, TreeKdeFrequenciesError
 from .dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT, get_numerical_dates
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
-from .utils import read_node_data, write_json
+from .utils import write_json
 
 
 def register_parser(parent_subparsers):

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -1,6 +1,6 @@
 # estimates clade frequencies
 from __future__ import division, print_function
-from collections import defaultdict, deque
+from collections import deque
 import datetime
 import isodate
 import numpy as np
@@ -8,7 +8,6 @@ import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.stats import norm
 import sys
-import time
 
 from .dates import numeric_date
 

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -4,7 +4,6 @@ from collections import deque
 import datetime
 import isodate
 import numpy as np
-import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.stats import norm
 import sys

--- a/augur/index.py
+++ b/augur/index.py
@@ -1,10 +1,7 @@
 """Count occurrence of bases in a set of sequences.
 """
 
-from Bio import SeqIO
 from itertools import combinations
-import Bio.Seq
-import Bio.SeqRecord
 import sys
 import csv
 
@@ -81,6 +78,7 @@ def index_sequence(sequence, values):
 
     Examples
     --------
+    >>> import Bio
     >>> other_IUPAC = {'r', 'y', 's', 'w', 'k', 'm', 'd', 'h', 'b', 'v'}
     >>> values = [{'a'},{'c'},{'g'},{'t'},{'n'}, other_IUPAC, {'-'}, {'?'}]
     >>> sequence_a = Bio.SeqRecord.SeqRecord(seq=Bio.Seq.Seq("ACTGN-?XWN"), id="seq_A")

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -5,9 +5,6 @@ import os
 import sys
 from shutil import copyfile
 
-import numpy as np
-import pandas as pd
-from Bio import SeqIO
 from Bio.Seq import MutableSeq
 
 from .io.file import open_file

--- a/augur/reconstruct_sequences.py
+++ b/augur/reconstruct_sequences.py
@@ -2,9 +2,7 @@
 Reconstruct alignments from mutations inferred on the tree
 """
 
-import os, sys
 import numpy as np
-from collections import defaultdict
 from Bio import SeqIO, Seq, SeqRecord, Phylo
 from .utils import read_node_data, write_json
 from treetime.vcf_utils import read_vcf

--- a/augur/reconstruct_sequences.py
+++ b/augur/reconstruct_sequences.py
@@ -2,10 +2,8 @@
 Reconstruct alignments from mutations inferred on the tree
 """
 
-import numpy as np
 from Bio import SeqIO, Seq, SeqRecord, Phylo
-from .utils import read_node_data, write_json
-from treetime.vcf_utils import read_vcf
+from .utils import read_node_data
 
 
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -330,7 +330,6 @@ def run(args):
         return 1
 
     # Export refined tree and node data
-    import json
     tree_success = Phylo.write(T, tree_fname, 'newick', format_branch_length='%1.8f', branch_length_only=True)
     print("updated tree written to",tree_fname, file=sys.stdout)
 

--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -1,7 +1,5 @@
 import os
-import logging
 import numpy as np
-import time
 from collections import defaultdict
 import pandas as pd
 from pprint import pprint

--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
 from collections import defaultdict
-import pandas as pd
 from pprint import pprint
 import sys
 

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -2,9 +2,8 @@
 Annotate a tree with actual and inferred titer measurements.
 """
 
-import json, os, sys
+import sys
 import numpy as np
-from collections import defaultdict
 from Bio import Phylo
 
 from .reconstruct_sequences import load_alignments

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -3,12 +3,11 @@ Annotate a tree with actual and inferred titer measurements.
 """
 
 import sys
-import numpy as np
 from Bio import Phylo
 
 from .reconstruct_sequences import load_alignments
 from .titer_model import InsufficientDataException
-from .utils import read_node_data, write_json
+from .utils import write_json
 from .argparse_ import add_default_command
 
 

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -5,7 +5,6 @@ Infer ancestral traits based on a tree.
 import numpy as np
 from collections import defaultdict
 import sys
-import pandas as pd
 from .errors import AugurError
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
 from .utils import write_json, get_json_name
@@ -43,9 +42,6 @@ def mugration_inference(tree=None, seq_meta=None, field='country', confidence=Tr
         mapping of character states to
     """
     from treetime.wrappers import reconstruct_discrete_traits
-    from Bio.Align import MultipleSeqAlignment
-    from Bio.SeqRecord import SeqRecord
-    from Bio.Seq import Seq
     from Bio import Phylo
 
     T = Phylo.read(tree, 'newick')

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -4,7 +4,7 @@ Infer ancestral traits based on a tree.
 
 import numpy as np
 from collections import defaultdict
-import os, sys
+import sys
 import pandas as pd
 from .errors import AugurError
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -15,7 +15,7 @@ mutations are output to a node-data JSON file.
 
 import os, sys
 import numpy as np
-from Bio import SeqIO, SeqFeature, Seq, SeqRecord, Phylo
+from Bio import Phylo, Seq, SeqIO, SeqRecord
 from .io.vcf import write_VCF_translation
 from .utils import read_node_data, load_features, write_json, get_json_name
 from treetime.vcf_utils import read_vcf

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -498,7 +498,6 @@ def run(args):
     print("\nBuilding original tree took {} seconds".format(str(end-start)))
 
     if T:
-        import json
         tree_success = Phylo.write(T, tree_fname, 'newick', format_branch_length='%1.8f')
     else:
         return 1

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -1,13 +1,9 @@
 import argparse
 import Bio
 import Bio.Phylo
-import gzip
 import numpy as np
 import os, json, sys
 import pandas as pd
-import subprocess
-import shlex
-from contextlib import contextmanager
 from collections import defaultdict, OrderedDict
 from pkg_resources import resource_stream
 from io import TextIOWrapper

--- a/scripts/beast-to-auspice-jsons-proof-of-principle.py
+++ b/scripts/beast-to-auspice-jsons-proof-of-principle.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from Bio import Phylo
 import imp
-from pdb import set_trace
 from StringIO import StringIO
 import json
 

--- a/scripts/json_tree_to_nexus.py
+++ b/scripts/json_tree_to_nexus.py
@@ -1,11 +1,10 @@
 from __future__ import print_function
-import os, sys
+import sys
 sys.path.append('..')
 import json
 from base.io_util import json_to_tree
 from base.utils import save_as_nexus
 import Bio.Phylo
-from pdb import set_trace
 import argparse
 
 def collect_args():

--- a/scripts/plot_msa.py
+++ b/scripts/plot_msa.py
@@ -1,5 +1,4 @@
 import argparse
-import Bio
 from Bio import AlignIO
 from Bio.Align import AlignInfo
 import matplotlib as mpl

--- a/scripts/swap_colors.py
+++ b/scripts/swap_colors.py
@@ -2,7 +2,6 @@ import json
 from re import split
 import argparse
 from glob import glob
-from pprint import pprint
 
 parser = argparse.ArgumentParser(description ="Update color ramps in processed meta.JSON files")
 parser.add_argument('--jsons', '--json', default=None, nargs='+', type=str, help="Path to prepared JSON(s) to edit. If none, will update all files like ./*meta.json")

--- a/scripts/traits_from_json.py
+++ b/scripts/traits_from_json.py
@@ -4,7 +4,6 @@ sys.path.append('..') # this is an assumption and is probably wrong
 from base.utils import parse_date
 import argparse
 import json
-from pdb import set_trace
 from numpy import ndarray
 
 def get_trait(attributes, trait, dateFormat):

--- a/scripts/traits_from_json.py
+++ b/scripts/traits_from_json.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import os, sys
+import sys
 sys.path.append('..') # this is an assumption and is probably wrong
 from base.utils import parse_date
 import argparse

--- a/scripts/verify_meta_json.py
+++ b/scripts/verify_meta_json.py
@@ -3,7 +3,6 @@ import sys
 sys.path.append('..') # this is an assumption and is probably wrong
 import argparse
 import json
-from pdb import set_trace
 
 
 def verify_defaults(defaults):

--- a/scripts/verify_meta_json.py
+++ b/scripts/verify_meta_json.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import os, sys
+import sys
 sys.path.append('..') # this is an assumption and is probably wrong
 import argparse
 import json

--- a/tests/test_clades.py
+++ b/tests/test_clades.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import pytest
-import pathlib
 import networkx as nx
 
 from augur.clades import read_in_clade_definitions

--- a/tests/test_clades.py
+++ b/tests/test_clades.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import pytest
-import networkx as nx
 
 from augur.clades import read_in_clade_definitions
 

--- a/tests/test_frequencies.py
+++ b/tests/test_frequencies.py
@@ -7,7 +7,6 @@ import numpy as np
 from pathlib import Path
 import pytest
 import sys
-import os
 
 # we assume (and assert) that this script is running from the tests/ directory
 sys.path.append(str(Path(__file__).parent.parent.parent))

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -6,7 +6,6 @@ for any function in mask.py, check that it is correctly updated in this file.
 import argparse
 import os
 import pytest
-import random
 import string
 
 from Bio import SeqIO

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,7 +2,6 @@ import Bio.SeqIO
 import Bio.Seq
 import pytest
 from pathlib import Path
-import unittest
 import sys
 
 # make sure we get the local version of parse

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,14 +1,12 @@
 """
 Unit tests for nucleotide to acid translation
 """
-import numpy as np
 from pathlib import Path
 import pytest
 import sys
 
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
-import treetime
 
 # we assume (and assert) that this script is running from the tests/ directory
 sys.path.append(str(Path(__file__).parent.parent.parent))

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,12 +1,10 @@
 """
 Unit tests for nucleotide to acid translation
 """
-import json
 import numpy as np
 from pathlib import Path
 import pytest
 import sys
-import os
 
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation


### PR DESCRIPTION
- chore: remove unused standard-lib imports using autoflake
- chore: remove unused non-standard-lib imports using autoflake

### Description of proposed changes
Remove unused imports as they increase loading time, pollute files and produce false positives when trying to find out where functions are used. 

The command I used (before discarding unwanted changes) was roughly this:
```bash
autoflake --ignore-init-module-imports \
--ignore-pass-after-docstring \
--remove-all-unused-imports \
-ri .
```

### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

- [x] Tests still pass

### Checklist

No end user focused changes, so no changelog entry
