### PR TITLE
Use flake8 for code quality checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,6 +22,3 @@ extend-ignore =
 
     # allow unused imports
     F401,
-
-    # allow undefined variables
-    F821,

--- a/.flake8
+++ b/.flake8
@@ -19,6 +19,3 @@ extend-ignore =
 
     # allow unused variables
     F841,
-
-    # allow unused imports
-    F401,

--- a/.flake8
+++ b/.flake8
@@ -25,6 +25,3 @@ extend-ignore =
 
     # allow undefined variables
     F821,
-
-    # allow redefining unused variables
-    F811,

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,30 @@
+# Right now we use Flake8 only for a few static checks focusing on runtime
+# safety and correctness.  We don't use it for style checks.
+
+[flake8]
+select =
+    # syntax errors
+    E9,
+
+    # all pyflakes correctness issues
+    F,
+
+# This option requires flake8 >=3.6.0, but if the pin is defined in setup.py, a
+# proper Snakemake version can't be resolved. I'm not sure why, so I've left
+# flake8 unpinned with a note here describing why (on the off chance that an
+# incompatible version of flake8 is installed).
+extend-ignore =
+    # allow f-strings without any placeholders
+    F541,
+
+    # allow unused variables
+    F841,
+
+    # allow unused imports
+    F401,
+
+    # allow undefined variables
+    F821,
+
+    # allow redefining unused variables
+    F811,

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -109,7 +109,7 @@ def add_version_alias(parser):
     class run_version_command(argparse.Action):
         def __call__(self, *args, **kwargs):
             opts = SimpleNamespace()
-            sys.exit( version.run(opts) )
+            sys.exit( version.run(opts) )  # noqa: F821; This is imported from version_file.
 
     return parser.add_argument(
         "--version",

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -23,9 +23,9 @@ nucleotide sequences, please use `augur translate`.
     The mutation positions in the node-data JSON are one-based.
 """
 from augur.errors import AugurError
-import os, shutil, time, json, sys
+import sys
 import numpy as np
-from Bio import Phylo, SeqIO
+from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from .utils import read_tree, InvalidTreeError, write_json, get_json_name

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -182,7 +182,6 @@ from collections import defaultdict
 import copy
 from itertools import chain
 import json
-import numpy as np
 import pandas as pd
 import sys
 

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -2,8 +2,7 @@
 Export version 1 JSON schema (separate meta and tree JSONs) for visualization with Auspice
 """
 
-import os, sys
-import re
+import sys
 from textwrap import dedent
 import time
 import numpy as np

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -2,7 +2,7 @@
 Export version 2 JSON schema for visualization with Auspice
 """
 from pathlib import Path
-import os, sys
+import sys
 import time
 from collections import defaultdict, deque, OrderedDict
 import warnings

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from typing import Any, Callable, Dict, List, Set, Tuple
 
-from augur.dates import numeric_date, is_date_ambiguous, get_numerical_dates
+from augur.dates import is_date_ambiguous, get_numerical_dates
 from augur.errors import AugurError
 from augur.io.metadata import METADATA_DATE_COLUMN
 from augur.io.print import print_err
@@ -274,6 +274,7 @@ def filter_by_min_date(metadata, date_column, min_date) -> FilterFunctionReturn:
 
     Examples
     --------
+    >>> from augur.dates import numeric_date
     >>> metadata = pd.DataFrame([{"region": "Africa", "date": "2020-01-01"}, {"region": "Europe", "date": "2020-01-02"}], index=["strain1", "strain2"])
     >>> filter_by_min_date(metadata, date_column="date", min_date=numeric_date("2020-01-02"))
     {'strain2'}
@@ -314,6 +315,7 @@ def filter_by_max_date(metadata, date_column, max_date) -> FilterFunctionReturn:
 
     Examples
     --------
+    >>> from augur.dates import numeric_date
     >>> metadata = pd.DataFrame([{"region": "Africa", "date": "2020-01-01"}, {"region": "Europe", "date": "2020-01-02"}], index=["strain1", "strain2"])
     >>> filter_by_max_date(metadata, date_column="date", max_date=numeric_date("2020-01-01"))
     {'strain1'}
@@ -677,6 +679,7 @@ def apply_filters(metadata, exclude_by: List[FilterOption], include_by: List[Fil
 
     Examples
     --------
+    >>> from augur.dates import numeric_date
     >>> metadata = pd.DataFrame([{"region": "Africa", "date": "2020-01-01"}, {"region": "Europe", "date": "2020-10-02"}, {"region": "North America", "date": "2020-01-01"}], index=["strain1", "strain2", "strain3"])
     >>> exclude_by = [(filter_by_min_date, {"date_column": "date", "min_date": numeric_date("2020-04-01")})]
     >>> include_by = [(force_include_where, {"include_where": "region=Africa"})]

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -3,7 +3,6 @@ infer frequencies of mutations or clades
 """
 import json, os, sys
 import numpy as np
-from collections import defaultdict
 from Bio import Phylo, AlignIO
 from Bio.Align import MultipleSeqAlignment
 
@@ -12,7 +11,7 @@ from .frequency_estimators import get_pivots, alignment_frequencies, tree_freque
 from .frequency_estimators import AlignmentKdeFrequencies, TreeKdeFrequencies, TreeKdeFrequenciesError
 from .dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT, get_numerical_dates
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
-from .utils import read_node_data, write_json
+from .utils import write_json
 
 
 def register_parser(parent_subparsers):

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -1,10 +1,9 @@
 # estimates clade frequencies
 from __future__ import division, print_function
-from collections import defaultdict, deque
+from collections import deque
 import datetime
 import isodate
 import numpy as np
-import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.stats import norm
 import sys

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -8,7 +8,6 @@ import pandas as pd
 from scipy.interpolate import interp1d
 from scipy.stats import norm
 import sys
-import time
 
 from .dates import numeric_date
 

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -639,7 +639,7 @@ class alignment_frequencies(object):
         self.counts = count_observations(self.pivots, self.tps)
 
 
-    def estimate_genotype_frequency(self, gt):
+    def estimate_genotype_frequency(self, aln, gt, **kwargs):
         '''
         slice an alignment at possibly multiple positions and calculate the
         frequency trajectory of this multi-locus genotype

--- a/augur/index.py
+++ b/augur/index.py
@@ -3,8 +3,6 @@
 
 from Bio import SeqIO
 from itertools import combinations
-import Bio.Seq
-import Bio.SeqRecord
 import sys
 import csv
 
@@ -81,6 +79,7 @@ def index_sequence(sequence, values):
 
     Examples
     --------
+    >>> import Bio
     >>> other_IUPAC = {'r', 'y', 's', 'w', 'k', 'm', 'd', 'h', 'b', 'v'}
     >>> values = [{'a'},{'c'},{'g'},{'t'},{'n'}, other_IUPAC, {'-'}, {'?'}]
     >>> sequence_a = Bio.SeqRecord.SeqRecord(seq=Bio.Seq.Seq("ACTGN-?XWN"), id="seq_A")

--- a/augur/index.py
+++ b/augur/index.py
@@ -1,7 +1,6 @@
 """Count occurrence of bases in a set of sequences.
 """
 
-from Bio import SeqIO
 from itertools import combinations
 import sys
 import csv

--- a/augur/io/__init__.py
+++ b/augur/io/__init__.py
@@ -2,6 +2,6 @@
 """
 # Functions and variables exposed here are part of Augur's public Python API.
 # To use functions internally, import directly from the submodule.
-from .file import open_file
-from .metadata import read_metadata
-from .sequences import read_sequences, write_sequences
+from .file import open_file  # noqa: F401
+from .metadata import read_metadata  # noqa: F401
+from .sequences import read_sequences, write_sequences  # noqa: F401

--- a/augur/mask.py
+++ b/augur/mask.py
@@ -5,9 +5,6 @@ import os
 import sys
 from shutil import copyfile
 
-import numpy as np
-import pandas as pd
-from Bio import SeqIO
 from Bio.Seq import MutableSeq
 
 from .io.file import open_file

--- a/augur/reconstruct_sequences.py
+++ b/augur/reconstruct_sequences.py
@@ -2,12 +2,8 @@
 Reconstruct alignments from mutations inferred on the tree
 """
 
-import os, sys
-import numpy as np
-from collections import defaultdict
 from Bio import SeqIO, Seq, SeqRecord, Phylo
-from .utils import read_node_data, write_json
-from treetime.vcf_utils import read_vcf
+from .utils import read_node_data
 
 
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -336,7 +336,6 @@ def run(args):
         return 1
 
     # Export refined tree and node data
-    import json
     tree_success = Phylo.write(T, tree_fname, 'newick', format_branch_length='%1.8f', branch_length_only=True)
     print("updated tree written to",tree_fname, file=sys.stdout)
 

--- a/augur/sequence_traits.py
+++ b/augur/sequence_traits.py
@@ -51,8 +51,13 @@ def read_in_translate_vcf(vcf_file, ref_file):
     opn = gzip.open if vcf_file.endswith(('.gz', '.GZ')) else open
 
     with opn(vcf_file, mode='rt') as f:
+        samps = []
+
         for line in f:
             if line[0] != '#':
+                # Sample names should have been extracted from '#' lines.
+                assert len(samps) != 0
+
                 #actual data
                 dat = line.strip().split('\t')
                 POS = int(dat[posLoc])

--- a/augur/sequence_traits.py
+++ b/augur/sequence_traits.py
@@ -3,6 +3,7 @@ Annotate sequences based on amino-acid or nucleotide signatures.
 """
 
 import sys
+import gzip
 import numpy as np
 from treetime.vcf_utils import read_vcf
 from collections import defaultdict

--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -1,9 +1,6 @@
 import os
-import logging
 import numpy as np
-import time
 from collections import defaultdict
-import pandas as pd
 from pprint import pprint
 import sys
 

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -2,14 +2,12 @@
 Annotate a tree with actual and inferred titer measurements.
 """
 
-import json, os, sys
-import numpy as np
-from collections import defaultdict
+import sys
 from Bio import Phylo
 
 from .reconstruct_sequences import load_alignments
 from .titer_model import InsufficientDataException
-from .utils import read_node_data, write_json
+from .utils import write_json
 from .argparse_ import add_default_command
 
 

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -4,8 +4,7 @@ Infer ancestral traits based on a tree.
 
 import numpy as np
 from collections import defaultdict
-import os, sys
-import pandas as pd
+import sys
 from .errors import AugurError
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
 from .utils import write_json, get_json_name
@@ -43,9 +42,6 @@ def mugration_inference(tree=None, seq_meta=None, field='country', confidence=Tr
         mapping of character states to
     """
     from treetime.wrappers import reconstruct_discrete_traits
-    from Bio.Align import MultipleSeqAlignment
-    from Bio.SeqRecord import SeqRecord
-    from Bio.Seq import Seq
     from Bio import Phylo
 
     T = Phylo.read(tree, 'newick')

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -15,7 +15,7 @@ mutations are output to a node-data JSON file.
 
 import os, sys
 import numpy as np
-from Bio import SeqIO, SeqFeature, Seq, SeqRecord, Phylo
+from Bio import SeqIO, Seq, SeqRecord, Phylo
 from .io.vcf import write_VCF_translation
 from .utils import read_node_data, load_features, write_json, get_json_name
 from treetime.vcf_utils import read_vcf

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -498,7 +498,6 @@ def run(args):
     print("\nBuilding original tree took {} seconds".format(str(end-start)))
 
     if T:
-        import json
         tree_success = Phylo.write(T, tree_fname, 'newick', format_branch_length='%1.8f')
     else:
         return 1

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -1,13 +1,9 @@
 import argparse
 import Bio
 import Bio.Phylo
-import gzip
 import numpy as np
 import os, json, sys
 import pandas as pd
-import subprocess
-import shlex
-from contextlib import contextmanager
 from collections import defaultdict, OrderedDict
 from pkg_resources import resource_stream
 from io import TextIOWrapper

--- a/scripts/beast-to-auspice-jsons-proof-of-principle.py
+++ b/scripts/beast-to-auspice-jsons-proof-of-principle.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from Bio import Phylo
 import imp
-from pdb import set_trace
 from StringIO import StringIO
 import json
 

--- a/scripts/json_tree_to_nexus.py
+++ b/scripts/json_tree_to_nexus.py
@@ -1,11 +1,10 @@
 from __future__ import print_function
-import os, sys
+import sys
 sys.path.append('..')
 import json
 from base.io_util import json_to_tree
 from base.utils import save_as_nexus
 import Bio.Phylo
-from pdb import set_trace
 import argparse
 
 def collect_args():

--- a/scripts/plot_msa.py
+++ b/scripts/plot_msa.py
@@ -1,5 +1,4 @@
 import argparse
-import Bio
 from Bio import AlignIO
 from Bio.Align import AlignInfo
 import matplotlib as mpl

--- a/scripts/swap_colors.py
+++ b/scripts/swap_colors.py
@@ -2,7 +2,6 @@ import json
 from re import split
 import argparse
 from glob import glob
-from pprint import pprint
 
 parser = argparse.ArgumentParser(description ="Update color ramps in processed meta.JSON files")
 parser.add_argument('--jsons', '--json', default=None, nargs='+', type=str, help="Path to prepared JSON(s) to edit. If none, will update all files like ./*meta.json")

--- a/scripts/traits_from_json.py
+++ b/scripts/traits_from_json.py
@@ -1,10 +1,9 @@
 from __future__ import print_function
-import os, sys
+import sys
 sys.path.append('..') # this is an assumption and is probably wrong
 from base.utils import parse_date
 import argparse
 import json
-from pdb import set_trace
 from numpy import ndarray
 
 def get_trait(attributes, trait, dateFormat):

--- a/scripts/verify_meta_json.py
+++ b/scripts/verify_meta_json.py
@@ -1,9 +1,8 @@
 from __future__ import print_function
-import os, sys
+import sys
 sys.path.append('..') # this is an assumption and is probably wrong
 import argparse
 import json
-from pdb import set_trace
 
 
 def verify_defaults(defaults):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ with readme_file.open(encoding = "utf-8") as f:
 
 setuptools.setup(
     name = "nextstrain-augur",
-    version = __version__,
+    version = __version__,  # noqa: F821; This is imported from version_file.
     author = "Nextstrain developers",
     author_email = "trevor@bedford.io, richard.neher@unibas.ch",
     description = "A bioinformatics toolkit for phylogenetic analysis",

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setuptools.setup(
         'dev': [
             "cram >=0.7",
             "deepdiff >=4.3.2",
+            "flake8",
             "freezegun >=0.3.15",
             "mypy",
             "nextstrain-sphinx-theme >=2022.5",

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -407,12 +407,12 @@ class TestAlign:
         assert output["PREFIX"].seq.startswith("---")
         assert output["SUFFIX"].seq.endswith("---")
     
-    def test_run_with_ref_seq_remove_reference(self, test_with_ref, ref_seq, run):
+    def test_run_with_reference_name_remove_reference(self, test_with_ref, ref_seq, run):
         expected_length = len(ref_seq.seq) - ref_seq.seq.count("-")
         output = run("-s %s --reference-name %s --remove-reference" % (test_file, ref_seq.id))
         assert ref_seq.id not in output
 
-    def test_run_with_ref_seq_remove_reference(self, test_file, ref_file, ref_seq, run):
+    def test_run_with_reference_sequence_remove_reference(self, test_file, ref_file, ref_seq, run):
         expected_length = len(ref_seq.seq) - ref_seq.seq.count("-")
         output = run("-s %s --reference-sequence %s --remove-reference" % (test_file, ref_file))
         assert ref_seq.id not in output

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -385,12 +385,7 @@ class TestAlign:
         output = run("-s %s" % (test_file))
         assert output.keys() == test_seqs.keys()
         assert all(len(r.seq) == expected_length for r in output.values())
-    
-    def test_run_fill_gaps(self, test_file, run):
-        """All gaps should be filled when --fill-gaps is passed"""
-        output = run("-s %s --fill-gaps" % test_file)
-        assert all("-" not in r.seq for r in output.values())
-    
+
     def test_run_with_ref_name_no_alignment(self, test_with_ref, test_seqs, ref_seq, run):
         expected_length = len(ref_seq.seq) - ref_seq.seq.count("-")
         output = run("-s %s --reference-name %s" % (test_with_ref, ref_seq.id))

--- a/tests/test_clades.py
+++ b/tests/test_clades.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 import pytest
-import pathlib
-import networkx as nx
 
 from augur.clades import read_in_clade_definitions
 

--- a/tests/test_flake8.py
+++ b/tests/test_flake8.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from subprocess import run
+
+topdir = Path(__file__).resolve().parent.parent
+
+def test_flake8():
+    # Check the exit status ourselves for nicer test output on failure
+    result = run(["flake8"], cwd = topdir)
+    assert result.returncode == 0, "flake8 exited with errors"

--- a/tests/test_frequencies.py
+++ b/tests/test_frequencies.py
@@ -7,7 +7,6 @@ import numpy as np
 from pathlib import Path
 import pytest
 import sys
-import os
 
 # we assume (and assert) that this script is running from the tests/ directory
 sys.path.append(str(Path(__file__).parent.parent.parent))

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -6,7 +6,6 @@ for any function in mask.py, check that it is correctly updated in this file.
 import argparse
 import os
 import pytest
-import random
 import string
 
 from Bio import SeqIO

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,8 +1,6 @@
 import Bio.SeqIO
 import Bio.Seq
-import pytest
 from pathlib import Path
-import unittest
 import sys
 
 # make sure we get the local version of parse

--- a/tests/test_titer_models.py
+++ b/tests/test_titer_models.py
@@ -1,4 +1,3 @@
-import pytest
 
 from augur.titer_model import TiterCollection
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,16 +1,11 @@
 """
 Unit tests for nucleotide to acid translation
 """
-import json
-import numpy as np
 from pathlib import Path
-import pytest
 import sys
-import os
 
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
-import treetime
 
 # we assume (and assert) that this script is running from the tests/ directory
 sys.path.append(str(Path(__file__).parent.parent.parent))


### PR DESCRIPTION
### Description of proposed changes

Flake8 is already used in [nextstrain/cli](https://github.com/nextstrain/cli). It'd be good to use it here too. Some of the commits in this PR should speak to its usefulness (e.g. catching skipped tests due to duplicate names, unused imports).

### Related issue(s)

Prompted by https://github.com/nextstrain/augur/pull/1288#issuecomment-1687161856

Requires #1296 to be merged first

Closes #1288

### Checklist

- [x] Flake8 added to CI (as a pytest)
- [x] Tests updated
- [x] Fix CI issues with Python 3.7 ([thread](https://github.com/nextstrain/augur/pull/1289#discussion_r1309472245))
- [x] Checks pass