### PR TITLE
Configure output streams to support non-Unicode encodings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,10 @@
 ### Bug fixes
 
 * distance: Improve documentation by describing how gaps get treated as indels and how users can ignore specific characters in distance calculations. [#1285][] (@huddlej)
+* Fix help output compatibility with non-Unicode streams. [#1290][] (@victorlin)
 
 [#1285]: https://github.com/nextstrain/augur/pull/1285
+[#1290]: https://github.com/nextstrain/augur/pull/1290
 
 ## 22.3.0 (14 August 2023)
 

--- a/augur/__main__.py
+++ b/augur/__main__.py
@@ -8,9 +8,18 @@ from sys import argv, exit
 
 # Entry point for setuptools-installed script and bin/augur dev wrapper.
 def main():
-    # Support non-Unicode encodings by replacing Unicode characters instead of erroring.
-    sys.stdout.reconfigure(errors="backslashreplace")
-    sys.stderr.reconfigure(errors="backslashreplace")
+    sys.stdout.reconfigure(
+        # Support non-Unicode encodings by replacing Unicode characters instead of erroring.
+        errors="backslashreplace",
+
+        # Explicitly enable universal newlines mode so we do the right thing.
+        newline=None,
+    )
+    # Apply the above to stderr as well.
+    sys.stderr.reconfigure(
+        errors="backslashreplace",
+        newline=None,
+    )
 
     return augur.run( argv[1:] )
 

--- a/augur/__main__.py
+++ b/augur/__main__.py
@@ -2,11 +2,16 @@
 Stub function and module used as a setuptools entry point.
 """
 
+import sys
 import augur
 from sys import argv, exit
 
 # Entry point for setuptools-installed script and bin/augur dev wrapper.
 def main():
+    # Support non-Unicode encodings by replacing Unicode characters instead of erroring.
+    sys.stdout.reconfigure(errors="backslashreplace")
+    sys.stderr.reconfigure(errors="backslashreplace")
+
     return augur.run( argv[1:] )
 
 # Run when called as `python -m augur`, here for good measure.


### PR DESCRIPTION
### Description of proposed changes

Fixes a bug where Unicode characters in Augur's help output would result in an unhelpful error. This isn't expected to happen for most users. At the expense of those users, keep using Unicode characters; for them, print replacement characters.

### Related issue(s)

Fixes #1272

### Testing

- [x] `PYTHONIOENCODING=latin-1 augur clades --help` runs successfully with these changes.

### Checklist

- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
