### PR TITLE
filter: Stream filtered metadata to outputs directly

### DIFF
--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -21,7 +21,7 @@ from augur.io.print import print_err
 from augur.io.vcf import is_vcf as filename_is_vcf, write_vcf
 from augur.types import EmptyOutputReportingMethod
 from . import include_exclude_rules
-from .io import cleanup_outputs, read_priority_scores
+from .io import cleanup_outputs, read_priority_scores, write_metadata_based_outputs
 from .include_exclude_rules import apply_filters, construct_filters
 from .subsample import PriorityQueue, TooManyGroupsError, calculate_sequences_per_group, create_queues_by_group, get_groups_for_subsampling
 
@@ -128,16 +128,6 @@ def run(args):
         else:
             random_generator = np.random.default_rng(args.subsample_seed)
             priorities = defaultdict(random_generator.random)
-
-    # Setup metadata output. We track whether any records have been written to
-    # disk yet through the following variables, to control whether we write the
-    # metadata's header and open a new file for writing.
-    metadata_header = True
-    metadata_mode = "w"
-
-    # Setup strain output.
-    if args.output_strains:
-        output_strains = open(args.output_strains, "w")
 
     # Setup logging.
     output_log_writer = None
@@ -258,30 +248,6 @@ def run(args):
                         priorities[strain],
                     )
 
-        # Always write out strains that are force-included. Additionally, if
-        # we are not grouping, write out metadata and strains that passed
-        # filters so far.
-        force_included_strains_to_write = distinct_force_included_strains
-        if not group_by:
-            force_included_strains_to_write = force_included_strains_to_write | seq_keep
-
-        if args.output_metadata:
-            # TODO: wrap logic to write metadata into its own function
-            metadata.loc[list(force_included_strains_to_write)].to_csv(
-                args.output_metadata,
-                sep="\t",
-                header=metadata_header,
-                mode=metadata_mode,
-            )
-            metadata_header = False
-            metadata_mode = "a"
-
-        if args.output_strains:
-            # TODO: Output strains will no longer be ordered. This is a
-            # small breaking change.
-            for strain in force_included_strains_to_write:
-                output_strains.write(f"{strain}\n")
-
     # In the worst case, we need to calculate sequences per group from the
     # requested maximum number of sequences and the number of sequences per
     # group. Then, we need to make a second pass through the metadata to find
@@ -361,23 +327,6 @@ def run(args):
                 # Construct a data frame of records to simplify metadata output.
                 records.append(record)
 
-                if args.output_strains:
-                    # TODO: Output strains will no longer be ordered. This is a
-                    # small breaking change.
-                    output_strains.write(f"{record.name}\n")
-
-            # Write records to metadata output, if requested.
-            if args.output_metadata and len(records) > 0:
-                records = pd.DataFrame(records)
-                records.to_csv(
-                    args.output_metadata,
-                    sep="\t",
-                    header=metadata_header,
-                    mode=metadata_mode,
-                )
-                metadata_header = False
-                metadata_mode = "a"
-
         # Count and optionally log strains that were not included due to
         # subsampling.
         strains_filtered_by_subsampling = valid_strains - subsampled_strains
@@ -436,6 +385,11 @@ def run(args):
             # Update the set of available sequence strains.
             sequence_strains = observed_sequence_strains
 
+    if args.output_metadata or args.output_strains:
+        write_metadata_based_outputs(args.metadata, args.metadata_delimiters,
+                                     args.metadata_id_columns, args.output_metadata,
+                                     args.output_strains, valid_strains)
+
     # Calculate the number of strains that don't exist in either metadata or
     # sequences.
     num_excluded_by_lack_of_metadata = 0
@@ -447,8 +401,6 @@ def run(args):
 
         num_excluded_by_lack_of_metadata = len(sequence_strains - metadata_strains)
 
-    if args.output_strains:
-        output_strains.close()
 
     # Calculate the number of strains passed and filtered.
     total_strains_passed = len(valid_strains)

--- a/augur/io/metadata.py
+++ b/augur/io/metadata.py
@@ -1,6 +1,6 @@
 import csv
 import os
-from typing import Iterable
+from typing import Iterable, Sequence
 import pandas as pd
 import pyfastx
 import sys
@@ -470,3 +470,85 @@ def _get_delimiter(path: str, valid_delimiters: Iterable[str]):
             # This assumes all csv.Errors imply a delimiter issue. That might
             # change in a future Python version.
             raise InvalidDelimiter from error
+
+
+class Metadata:
+    """Represents a metadata file."""
+
+    path: str
+    """Path to the file on disk."""
+
+    delimiter: str
+    """Inferred delimiter of metadata."""
+
+    columns: Sequence[str]
+    """Columns extracted from the first row in the metadata file."""
+
+    id_column: str
+    """Inferred ID column."""
+
+    def __init__(self, path: str, delimiters: Sequence[str], id_columns: Sequence[str]):
+        """
+        Parameters
+        ----------
+        path
+            Path of the metadata file.
+        delimiters
+            Possible delimiters to use, in order of precedence.
+        id_columns
+            Possible ID columns to use, in order of precedence.
+        """
+        self.path = path
+
+        # Infer the delimiter.
+        self.delimiter = _get_delimiter(self.path, delimiters)
+
+        # Infer the column names.
+        with self.open() as f:
+            reader = csv.reader(f, delimiter=self.delimiter)
+            try:
+                self.columns = next(reader)
+            except StopIteration:
+                raise AugurError(f"{self.path}: Expected a header row but it is empty.")
+
+        # Infer the ID column.
+        self.id_column = self._find_first(id_columns)
+
+    def open(self, **kwargs):
+        """Open the file with auto-compression/decompression."""
+        return open_file(self.path, **kwargs)
+
+    def _find_first(self, columns: Sequence[str]):
+        """Return the first column in `columns` that is present in the metadata.
+        """
+        for column in columns:
+            if column in self.columns:
+                return column
+        raise AugurError(f"{self.path}: None of ({columns!r}) are in the columns {tuple(self.columns)!r}.")
+
+    def rows(self, skip_blank_lines: bool = True, strict: bool = True):
+        """Yield rows in a dictionary format.
+
+        Parameters
+        ----------
+        skip_blank_lines
+            If True, skip over blank lines.
+        strict
+            If True, raise an error when a row contains more or less than the number of expected columns.
+        """
+        with self.open() as f:
+            reader = csv.DictReader(f, delimiter=self.delimiter, fieldnames=self.columns, restkey=None, restval=None)
+
+            # Skip the header row.
+            next(reader)
+
+            for row in reader:
+                if skip_blank_lines and not row:
+                    continue
+                if strict:
+                    if None in row.keys():
+                        raise AugurError(f"{self.path}: Line {reader.line_num} contains at least one extra column. Note that the inferred delimiter is {self.delimiter!r}.")
+                    if None in row.values():
+                        # Note that this is distinct from a blank value (empty string).
+                        raise AugurError(f"{self.path}: Line {reader.line_num} is missing at least one column. Note that the inferred delimiter is {self.delimiter!r}.")
+                yield row

--- a/tests/functional/filter/cram/filter-output-contents.t
+++ b/tests/functional/filter/cram/filter-output-contents.t
@@ -33,11 +33,11 @@ Check that the row for a strain is identical between input and output metadata.
 Check the order of strains in the filtered strains file.
 
   $ cat filtered_strains.txt
-  EcEs062_16
-  ZKC2/2016
   Colombia/2016/ZC204Se
-  BRA/2016/FC_6706
+  ZKC2/2016
   DOM/2016/BB_0059
+  BRA/2016/FC_6706
+  EcEs062_16
 
 Check that the order of strains in the metadata is the same as above.
 


### PR DESCRIPTION
### Description of proposed changes

This PR builds on ideas from experimentation in #1242.

- 94563cac54906351b5c0456837e72586984ed0db is a subset of 197899e6093e7a6992bc3a13e58e2618ad65053e scoped to just one `Metadata` class.
- 17f71f4b6f471dbe70508e4b29cc46c121da7d69 is a prerequisite for the idea of loading only a subset of columns into the database. The same idea can also be applied to the current pandas implementation, which should improve performance.

### Related issue(s)

Motivated by the idea to read only a subset of columns from the metadata.

### Testing

- [x] Test updated for minor change in behavior
- [ ] Address compressed output (seems to be the reason for [ncov CI failure](https://github.com/nextstrain/augur/actions/runs/5960037197/job/16166694566?pr=1291#step:7:374))
- [ ] Checks pass
- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
