### PR TITLE
Read a subset of metadata columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,21 @@
 
 ## __NEXT__
 
+### Features
+
+* filter: Added a new option `--query-columns` that allows specifying what columns are used in `--query` along with the expected data types. If unspecified, automatic detection of columns and types is attempted. [#1294][] (@victorlin)
+* `augur.io.read_metadata`: A new optional `columns` argument allows specifying a subset of columns to load. The default behavior still loads all columns, so this is not a breaking change. [#1294][] (@victorlin)
+
 ### Bug Fixes
 
+* filter: The order of rows in `--output-metadata` and `--output-strains` now reflects the order in the original `--metadata`. [#1294][] (@victorlin)
+* filter, frequencies, refine: Performance improvements to reading the input metadata file. [#1294][] (@victorlin)
+    * For filter, this comes with increased writing times for `--output-metadata` and `--output-strains`. However, net I/O speed still decreased during testing of this change.
 * filter: Updated the help text of `--include` and `--include-where` to explicitly state that this can add strains that are missing an entry from `--sequences`. [#1389][] (@victorlin)
 * filter: Fixed the summary messages to properly reflect force-inclusion of strains that are missing an entry from `--sequences`. [#1389][] (@victorlin)
 * filter: Updated wording of summary messages. [#1389][] (@victorlin)
 
+[#1294]: https://github.com/nextstrain/augur/pull/1294
 [#1389]: https://github.com/nextstrain/augur/pull/1389
 
 ## 24.1.0 (30 January 2024)

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -2,6 +2,7 @@
 Filter and subsample a sequence set.
 """
 from augur.dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT
+from augur.filter.io import ACCEPTED_TYPES, column_type_pair
 from augur.io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, METADATA_DATE_COLUMN
 from augur.types import EmptyOutputReportingMethod
 from . import constants
@@ -28,6 +29,11 @@ def register_arguments(parser):
         Uses Pandas Dataframe querying, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query for syntax.
         (e.g., --query "country == 'Colombia'" or --query "(country == 'USA' & (division == 'Washington'))")"""
     )
+    metadata_filter_group.add_argument('--query-columns', type=column_type_pair, nargs="+", help=f"""
+        Use alongside --query to specify columns and data types in the format 'column:type', where type is one of ({','.join(ACCEPTED_TYPES)}).
+        Automatic type inference will be attempted on all unspecified columns used in the query.
+        Example: region:str coverage:float.
+    """)
     metadata_filter_group.add_argument('--min-date', type=numeric_date_type, help=f"minimal cutoff for date, the cutoff date is inclusive; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
     metadata_filter_group.add_argument('--max-date', type=numeric_date_type, help=f"maximal cutoff for date, the cutoff date is inclusive; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
     metadata_filter_group.add_argument('--exclude-ambiguous-dates-by', choices=['any', 'day', 'month', 'year'],

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -79,7 +79,7 @@ def filter_by_exclude(metadata, exclude_file) -> FilterFunctionReturn:
     return set(metadata.index.values) - excluded_strains
 
 
-def _parse_filter_query(query):
+def parse_filter_query(query):
     """Parse an augur filter-style query and return the corresponding column,
     operator, and value for the query.
 
@@ -99,9 +99,9 @@ def _parse_filter_query(query):
 
     Examples
     --------
-    >>> _parse_filter_query("property=value")
+    >>> parse_filter_query("property=value")
     ('property', <built-in function eq>, 'value')
-    >>> _parse_filter_query("property!=value")
+    >>> parse_filter_query("property!=value")
     ('property', <built-in function ne>, 'value')
 
     """
@@ -144,7 +144,7 @@ def filter_by_exclude_where(metadata, exclude_where) -> FilterFunctionReturn:
     ['strain1', 'strain2']
 
     """
-    column, op, value = _parse_filter_query(exclude_where)
+    column, op, value = parse_filter_query(exclude_where)
     if column in metadata.columns:
         # Apply a test operator (equality or inequality) to values from the
         # column in the given query. This produces an array of boolean values we
@@ -515,7 +515,7 @@ def force_include_where(metadata, include_where) -> FilterFunctionReturn:
     set()
 
     """
-    column, op, value = _parse_filter_query(include_where)
+    column, op, value = parse_filter_query(include_where)
 
     if column in metadata.columns:
         # Apply a test operator (equality or inequality) to values from the

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -188,6 +188,14 @@ def filter_by_query(metadata: pd.DataFrame, query: str) -> FilterFunctionReturn:
     # Create a copy to prevent modification of the original DataFrame.
     metadata_copy = metadata.copy()
 
+    # Set columns for type conversion.
+    variables = extract_variables(query)
+    if variables is not None:
+        columns = variables.intersection(metadata_copy.columns)
+    else:
+        # Column extraction failed. Apply type conversion to all columns.
+        columns = metadata_copy.columns
+
     # Support numeric comparisons in query strings.
     #
     # The built-in data type inference when loading the DataFrame does not
@@ -195,14 +203,8 @@ def filter_by_query(metadata: pd.DataFrame, query: str) -> FilterFunctionReturn:
     # those columns. pd.to_numeric does proper conversion on those columns, and
     # will not make any changes to columns with other values.
     #
-    # TODO: Parse the query string and apply conversion only to columns used for
-    # numeric comparison. Pandas does not expose the API used to parse the query
-    # string internally, so this is non-trivial and requires a bit of
-    # reverse-engineering. Commit 2ead5b3e3306dc1100b49eb774287496018122d9 got
-    # halfway there but had issues so it was reverted.
-    #
     # TODO: Try boolean conversion?
-    for column in metadata_copy.columns:
+    for column in columns:
         metadata_copy[column] = pd.to_numeric(metadata_copy[column], errors='ignore')
 
     try:

--- a/augur/filter/io.py
+++ b/augur/filter/io.py
@@ -1,5 +1,7 @@
+import argparse
 import csv
 import os
+import re
 from typing import Sequence, Set
 import numpy as np
 from collections import defaultdict
@@ -63,6 +65,26 @@ def write_metadata_based_outputs(input_metadata_path: str, delimiters: Sequence[
         output_metadata_handle.close()
     if output_strains:
         output_strains.close()
+
+
+# These are the types accepted in the following function.
+ACCEPTED_TYPES = {'int', 'float', 'str'}
+
+def column_type_pair(input: str):
+    """Get a 2-tuple for column name to type.
+
+    Intended to be used as the argument type converter for argparse options that
+    take type maps in a 'column:type' format.
+    """
+
+    match = re.match(f"^(.+?):({'|'.join(ACCEPTED_TYPES)})$", input)
+    if not match:
+        raise argparse.ArgumentTypeError(f"Column data types must be in the format 'column:type', where type is one of ({','.join(ACCEPTED_TYPES)}).")
+
+    column = match[1]
+    dtype = match[2]
+
+    return (column, dtype)
 
 
 def cleanup_outputs(args):

--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -106,11 +106,6 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
 
     if generated_columns_requested:
 
-        for col in sorted(generated_columns_requested):
-            if col in metadata.columns:
-                print_err(f"WARNING: `--group-by {col}` uses a generated {col} value from the {METADATA_DATE_COLUMN!r} column. The custom '{col}' column in the metadata is ignored for grouping purposes.")
-                metadata.drop(col, axis=1, inplace=True)
-
         if METADATA_DATE_COLUMN not in metadata:
             # Set generated columns to 'unknown'.
             print_err(f"WARNING: A {METADATA_DATE_COLUMN!r} column could not be found to group-by {sorted(generated_columns_requested)}.")

--- a/augur/io/metadata.py
+++ b/augur/io/metadata.py
@@ -1,6 +1,6 @@
 import csv
 import os
-from typing import Iterable
+from typing import Iterable, Sequence
 import pandas as pd
 import pyfastx
 import sys
@@ -472,6 +472,86 @@ def write_records_to_tsv(records, output_file):
 
         for record in records:
             tsv_writer.writerow(record)
+
+
+class Metadata:
+    """Represents a metadata file."""
+
+    path: str
+    """Path to the file on disk."""
+
+    delimiter: str
+    """Inferred delimiter of metadata."""
+
+    columns: Sequence[str]
+    """Columns extracted from the first row in the metadata file."""
+
+    id_column: str
+    """Inferred ID column."""
+
+    def __init__(self, path: str, delimiters: Sequence[str], id_columns: Sequence[str]):
+        """
+        Parameters
+        ----------
+        path
+            Path of the metadata file.
+        delimiters
+            Possible delimiters to use, in order of precedence.
+        id_columns
+            Possible ID columns to use, in order of precedence.
+        """
+        self.path = path
+
+        # Infer the dialect.
+        self.delimiter = _get_delimiter(self.path, delimiters)
+
+        # Infer the column names.
+        with self.open() as f:
+            reader = csv.reader(f, delimiter=self.delimiter)
+            try:
+                self.columns = next(reader)
+            except StopIteration:
+                raise AugurError(f"{self.path}: Expected a header row but it is empty.")
+
+        # Infer the ID column.
+        self.id_column = self._find_first(id_columns)
+
+    def open(self, **kwargs):
+        """Open the file with auto-compression/decompression."""
+        return open_file(self.path, **kwargs)
+
+    def _find_first(self, columns: Sequence[str]):
+        """Return the first column in `columns` that is present in the metadata.
+        """
+        for column in columns:
+            if column in self.columns:
+                return column
+        raise AugurError(f"{self.path}: None of ({columns!r}) are in the columns {tuple(self.columns)!r}.")
+
+    def rows(self, strict: bool = True):
+        """Yield rows in a dictionary format. Empty lines are ignored.
+
+        Parameters
+        ----------
+        strict
+            If True, raise an error when a row contains more or less than the number of expected columns.
+        """
+        with self.open() as f:
+            reader = csv.DictReader(f, delimiter=self.delimiter, fieldnames=self.columns, restkey=None, restval=None)
+
+            # Skip the header row.
+            next(reader)
+
+            # NOTE: Empty lines are ignored by csv.DictReader.
+            # <https://github.com/python/cpython/blob/647b6cc7f16c03535cede7e1748a58ab884135b2/Lib/csv.py#L181-L185>
+            for row in reader:
+                if strict:
+                    if None in row.keys():
+                        raise AugurError(f"{self.path}: Line {reader.line_num} contains at least one extra column. The inferred delimiter is {self.delimiter!r}.")
+                    if None in row.values():
+                        # This is distinct from a blank value (empty string).
+                        raise AugurError(f"{self.path}: Line {reader.line_num} is missing at least one column. The inferred delimiter is {self.delimiter!r}.")
+                yield row
 
 
 def _get_delimiter(path: str, valid_delimiters: Iterable[str]):

--- a/tests/functional/filter/cram/filter-output-contents.t
+++ b/tests/functional/filter/cram/filter-output-contents.t
@@ -33,11 +33,11 @@ Check that the row for a strain is identical between input and output metadata.
 Check the order of strains in the filtered strains file.
 
   $ cat filtered_strains.txt
-  EcEs062_16
-  ZKC2/2016
   Colombia/2016/ZC204Se
-  BRA/2016/FC_6706
+  ZKC2/2016
   DOM/2016/BB_0059
+  BRA/2016/FC_6706
+  EcEs062_16
 
 Check that the order of strains in the metadata is the same as above.
 

--- a/tests/functional/filter/cram/filter-query-columns.t
+++ b/tests/functional/filter/cram/filter-query-columns.t
@@ -1,0 +1,55 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	coverage	category
+  > SEQ_1	0.94	A
+  > SEQ_2	0.95	B
+  > SEQ_3	0.96	C
+  > SEQ_4		
+  > ~~
+
+Automatic inference works.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "coverage >= 0.95 & category == 'B'" \
+  >  --output-strains filtered_strains.txt
+  3 strains were dropped during filtering
+  	3 were filtered out by the query: "coverage >= 0.95 & category == 'B'"
+  1 strain passed all filters
+
+Specifying coverage:float explicitly also works.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "coverage >= 0.95 & category == 'B'" \
+  >  --query-columns coverage:float \
+  >  --output-strains filtered_strains.txt
+  3 strains were dropped during filtering
+  	3 were filtered out by the query: "coverage >= 0.95 & category == 'B'"
+  1 strain passed all filters
+
+Specifying coverage:float category:str also works.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "coverage >= 0.95 & category == 'B'" \
+  >  --query-columns coverage:float category:str \
+  >  --output-strains filtered_strains.txt
+  3 strains were dropped during filtering
+  \t3 were filtered out by the query: "coverage >= 0.95 & category == 'B'" (esc)
+  1 strain passed all filters
+
+Specifying category:float does not work.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "coverage >= 0.95 & category == 'B'" \
+  >  --query-columns category:float \
+  >  --output-strains filtered_strains.txt
+  ERROR: Failed to convert value in column 'category' to float. Unable to parse string "A" at position 0
+  [2]

--- a/tests/functional/filter/cram/filter-query-errors.t
+++ b/tests/functional/filter/cram/filter-query-errors.t
@@ -8,6 +8,7 @@ Using a pandas query with a nonexistent column results in a specific error.
   >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "invalid == 'value'" \
   >  --output-strains filtered_strains.txt > /dev/null
+  WARNING: Column 'invalid' does not exist in the metadata file. Ignoring it.
   ERROR: Query contains a column that does not exist in metadata.
   [2]
 
@@ -40,7 +41,5 @@ However, other Pandas errors are not so helpful, so a link is provided for users
   >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "some bad syntax" \
   >  --output-strains filtered_strains.txt > /dev/null
-  ERROR: Internal Pandas error when applying query:
-  	invalid syntax (<unknown>, line 1)
-  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  ERROR: Could not infer columns from the pandas query. If the query is valid, please specify columns using --query-columns.
   [2]

--- a/tests/functional/filter/cram/filter-query-numerical.t
+++ b/tests/functional/filter/cram/filter-query-numerical.t
@@ -34,6 +34,29 @@ The 'category' column will fail when used with a numerical comparison.
   Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
   [2]
 
+With automatic type inference, the 'coverage' column isn't query-able with
+string comparisons:
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "coverage.str.endswith('.95')" \
+  >  --output-strains filtered_strains.txt > /dev/null
+  ERROR: Internal Pandas error when applying query:
+  	Can only use .str accessor with string values!
+  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  [2]
+
+However, that is still possible by explicitly specifying that it is a string column.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "coverage.str.endswith('.95')" \
+  >  --query-columns coverage:str \
+  >  --output-strains filtered_strains.txt > /dev/null
+
+  $ sort filtered_strains.txt
+  SEQ_2
+
 Create another metadata file for testing.
 
   $ cat >metadata.tsv <<~~

--- a/tests/functional/filter/cram/subsample-group-by-missing-error.t
+++ b/tests/functional/filter/cram/subsample-group-by-missing-error.t
@@ -15,6 +15,7 @@ Error on missing group-by columns.
   >   --group-by year \
   >   --sequences-per-group 1 \
   >   --output-metadata metadata-filtered.tsv > /dev/null
+  WARNING: Column 'date' does not exist in the metadata file. Ignoring it.
   ERROR: The specified group-by categories (['year']) were not found. Note that using any of ['month', 'week', 'year'] requires a column called 'date'.
   [2]
   $ cat metadata-filtered.tsv
@@ -26,6 +27,7 @@ Error on missing group-by columns.
   >   --group-by invalid \
   >   --sequences-per-group 1 \
   >   --output-metadata metadata-filtered.tsv > /dev/null
+  WARNING: Column 'invalid' does not exist in the metadata file. Ignoring it.
   ERROR: The specified group-by categories (['invalid']) were not found.
   [2]
   $ cat metadata-filtered.tsv


### PR DESCRIPTION
### Description of proposed changes

Reading a subset of metadata columns is straightforward for most subcommands, but requires some big changes in `augur filter`:

- Previously, `--output-metadata` relied on an in-memory pandas DataFrame containing all columns. This PR re-implements that option and similar options using a custom Metadata class to write output metadata based on a streamed representation of the input file.
- Reading a subset of columns for `augur filter` requires knowing which columns are used by `augur filter --query`. Automatic detection is implemented here, but `--query` is generic enough that I'm not confident the detection will always work. In cases where it doesn't, an error is raised.
- A new option `--query-columns` allows the user to specify what columns are used in `--query` along with the expected data types.

See commits for details.

### Related issues

This PR builds on ideas from [discussion on Slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1690573498445149) and experimentation in #1242.

### Checklist

- [x] Tests modified for changes in behavior
- [x] Tests added for `--query-columns`
- [x] Checks pass
- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
- [x] Try running on large datasets ([thread](https://github.com/nextstrain/augur/pull/1294#discussion_r1313613899))
