### PR TITLE
Root sequence exported in main JSON

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Features
+
+* export v2: Allow the root-sequence data to be included (inlined) in the main dataset JSON file, avoiding the need for a sidecar `_root-sequence.json` file. [#1295][] (@jameshadfield)
+
+[#1295]: https://github.com/nextstrain/augur/pull/1295
 
 ## 22.4.0 (29 August 2023)
 

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -296,6 +296,9 @@
                     "items": {"$ref": "#/$defs/tree"}
                 }
             ]
+        },
+        "root_sequence": {
+            "$ref": "https://nextstrain.org/schemas/dataset/root-sequence"
         }
     },
     "$defs": {

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -861,7 +861,9 @@ def register_parser(parent_subparsers):
         title="OPTIONAL SETTINGS"
     )
     optional_settings.add_argument('--minify-json', action="store_true", help="export JSONs without indentation or line returns")
-    optional_settings.add_argument('--include-root-sequence', action="store_true", help="Export an additional JSON containing the root sequence (reference sequence for vcf) used to identify mutations. The filename will follow the pattern of <OUTPUT>_root-sequence.json for a main auspice JSON of <OUTPUT>.json")
+    root_sequence = optional_settings.add_mutually_exclusive_group()
+    root_sequence.add_argument('--include-root-sequence', action="store_true", help="Export an additional JSON containing the root sequence (reference sequence for vcf) used to identify mutations. The filename will follow the pattern of <OUTPUT>_root-sequence.json for a main auspice JSON of <OUTPUT>.json")
+    root_sequence.add_argument('--include-root-sequence-inline', action="store_true", help="Export the root sequence (reference sequence for vcf) used to identify mutations as part of the main dataset JSON. This should only be used for small genomes for file size reasons.")
     optional_settings.add_argument(
         '--validation-mode',
         dest="validation_mode",
@@ -1144,19 +1146,22 @@ def run(args):
 
     # Write outputs - the (unified) dataset JSON intended for auspice & perhaps the ref root-sequence JSON
     indent = {"indent": None} if args.minify_json else {}
-    write_json(data=orderKeys(data_json), file_name=args.output, include_version=False, **indent)
-
-    if args.include_root_sequence:
+    if args.include_root_sequence or args.include_root_sequence_inline:
+        # Note - argparse enforces that only one of these args will be true
         if 'reference' in node_data:
-            # Save the root sequence with the same stem from the main auspice
-            # output filename.  For example, if the main auspice output is
-            # "auspice/zika.json", the root sequence will be
-            # "auspice/zika_root-sequence.json".
-            output_path = Path(args.output)
-            root_sequence_path = output_path.parent / Path(output_path.stem + "_root-sequence" + output_path.suffix)
-            write_json(data=node_data['reference'], file_name=root_sequence_path, include_version=False, **indent)
+            if args.include_root_sequence_inline:
+                data_json['root_sequence'] = node_data['reference']
+            elif args.include_root_sequence:
+                # Save the root sequence with the same stem from the main auspice
+                # output filename.  For example, if the main auspice output is
+                # "auspice/zika.json", the root sequence will be
+                # "auspice/zika_root-sequence.json".
+                output_path = Path(args.output)
+                root_sequence_path = output_path.parent / Path(output_path.stem + "_root-sequence" + output_path.suffix)
+                write_json(data=node_data['reference'], file_name=root_sequence_path, include_version=False, **indent)
         else:
             fatal("Root sequence output was requested, but the node data provided is missing a 'reference' key.")
+    write_json(data=orderKeys(data_json), file_name=args.output, include_version=False, **indent)
 
     # validate outputs
     validate_data_json(args.output, args.validation_mode)

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -190,7 +190,8 @@ def export_v2(main_json, **kwargs):
     # filepath is specified relative to ./augur/data (where all the schemas
     # live).
     refs = {
-        'https://nextstrain.org/schemas/augur/annotations': "schema-annotations.json"
+        'https://nextstrain.org/schemas/augur/annotations': "schema-annotations.json",
+        'https://nextstrain.org/schemas/dataset/root-sequence': "schema-export-root-sequence.json",
     }
     main_schema = load_json_schema("schema-export-v2.json", refs)
 


### PR DESCRIPTION
As [discussed in Slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1690930305357089)

Data structure (schema) is identical between a root-sequence JSON and the top-level JSON key `root_sequence`

No sanity checking is done on the genome size, but the intention is for only small genomes to be inlined.

[Companion Auspice PR](https://github.com/nextstrain/auspice/pull/1688)
