### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
@@ -28,24 +27,17 @@ jobs:
         biopython-version:
           # list of Biopython versions with support for a new Python version
           # from https://github.com/biopython/biopython/blob/master/NEWS.rst
-          - '1.73' # first to support Python 3.7
           - '1.76' # first to support Python 3.8
           - '1.79' # first to support Python 3.9
           - '1.80' # first to support Python 3.10 and 3.11
           - ''     # latest
         exclude:
           # some older Biopython versions are incompatible with later Python versions
-          - { biopython-version: '1.73', python-version: '3.8' }
-          - { biopython-version: '1.73', python-version: '3.9' }
-          - { biopython-version: '1.73', python-version: '3.10' }
-          - { biopython-version: '1.73', python-version: '3.11' }
           - { biopython-version: '1.76', python-version: '3.9' }
           - { biopython-version: '1.76', python-version: '3.10' }
           - { biopython-version: '1.76', python-version: '3.11' }
           - { biopython-version: '1.79', python-version: '3.10' }
           - { biopython-version: '1.79', python-version: '3.11' }
-          # Additionally, Bioconda does not support the following combinations
-          - { biopython-version: '1.80', python-version: '3.7' }
     defaults:
       run:
         shell: bash -l {0}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,11 +9,7 @@ build:
     post_checkout:
       # Convert the shallow clone to a complete one so author information can be
       # generated from the full git history in conf.py.
-      - git fetch --unshallow || true
-      # TODO: remove `|| true` once RTD no longer uses complete cloning for this
-      # repo¹ (scheduled² August 28th, 2023).
-      # ¹ https://github.com/readthedocs/readthedocs.org/issues/5689
-      # ² https://support.nextstrain.org/agent/nextstrain/nextstrain/tickets/details/668036000004369027
+      - git fetch --unshallow
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.11"
   jobs:
     post_checkout:
       # Convert the shallow clone to a complete one so author information can be

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,16 @@
 
 ## __NEXT__
 
+### Major Changes
+
+* Drop support for Python 3.7. [#1296][] (@victorlin)
+
 ### Features
 
 * export v2: Allow the root-sequence data to be included (inlined) in the main dataset JSON file, avoiding the need for a sidecar `_root-sequence.json` file. [#1295][] (@jameshadfield)
 
 [#1295]: https://github.com/nextstrain/augur/pull/1295
+[#1296]: https://github.com/nextstrain/augur/pull/1296
 
 ## 22.4.0 (29 August 2023)
 

--- a/augur/argparse_.py
+++ b/augur/argparse_.py
@@ -76,22 +76,3 @@ class HideAsFalseAction(Action):
     """
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, option_string[2:6] != 'hide')
-
-
-# XXX TODO: Drop this when we drop support for 3.7 and use builtin "extend"
-# action.
-class ExtendAction(Action):
-    """
-    Loosely backported version of builtin "extend" action
-    (argparse._ExtendAction) in CPython v3.10.5-172-gf118661a18.  Some of the
-    ceremony we don't need has been ditched.
-
-    >>> import argparse
-    >>> p = argparse.ArgumentParser()
-    >>> a = p.add_argument("-x", action=ExtendAction, nargs="+")
-    >>> p.parse_args(["-x", "a", "b", "-x", "c", "-x", "d"]).x
-    ['a', 'b', 'c', 'd']
-    """
-    def __call__(self, parser, namespace, values, option_string=None):
-        current = getattr(namespace, self.dest, None) or []
-        setattr(namespace, self.dest, [*current, *values])

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -11,7 +11,6 @@ from Bio import Phylo
 from argparse import SUPPRESS
 from collections import defaultdict
 from .errors import AugurError
-from .argparse_ import ExtendAction
 from .io.metadata import DEFAULT_DELIMITERS, InvalidDelimiter, read_metadata
 from .utils import read_node_data, write_json, read_config, read_lat_longs, read_colors
 
@@ -316,7 +315,7 @@ def add_core_args(parser):
     core.add_argument('--metadata', required=True, metavar="FILE", help="sequence metadata")
     core.add_argument('--metadata-delimiters', default=DEFAULT_DELIMITERS, nargs="+",
                       help="delimiters to accept when reading a metadata file. Only one delimiter will be inferred.")
-    core.add_argument('--node-data', required=True, nargs='+', action=ExtendAction, help="JSON files with meta data for each node")
+    core.add_argument('--node-data', required=True, nargs='+', action="extend", help="JSON files with meta data for each node")
     core.add_argument('--output-tree', help="JSON file name that is passed on to auspice (e.g., zika_tree.json).")
     core.add_argument('--output-meta', help="JSON file name that is passed on to auspice (e.g., zika_meta.json).")
     core.add_argument('--auspice-config', help="file with auspice configuration")

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -10,7 +10,6 @@ import numbers
 import re
 from Bio import Phylo
 
-from .argparse_ import ExtendAction
 from .errors import AugurError
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
 from .types import ValidationMode
@@ -828,7 +827,7 @@ def register_parser(parent_subparsers):
         title="REQUIRED"
     )
     required.add_argument('--tree','-t', metavar="newick", required=True, help="Phylogenetic tree, usually output from `augur refine`")
-    required.add_argument('--node-data', metavar="JSON", required=True, nargs='+', action=ExtendAction, help="JSON files containing metadata for nodes in the tree")
+    required.add_argument('--node-data', metavar="JSON", required=True, nargs='+', action="extend", help="JSON files containing metadata for nodes in the tree")
     required.add_argument('--output', metavar="JSON", required=True, help="Ouput file (typically for visualisation in auspice)")
 
     config = parser.add_argument_group(

--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -15,7 +15,7 @@ Please see the [open issues list](https://github.com/nextstrain/augur/issues) fo
 
 ## Contributing code
 
-We currently target compatibility with Python 3.7 and higher. As Python releases new versions,
+We currently target compatibility with Python 3.8 and higher. As Python releases new versions,
 the minimum target compatibility may be increased in the future.
 
 ### Running local changes

--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -65,7 +65,7 @@ If you encounter environment solving errors or want a faster installation proces
 Using pip from PyPi
 -------------------
 
-Augur is written in Python 3 and requires at least Python 3.7. It's published on `PyPi <https://pypi.org>`__ as `nextstrain-augur <https://pypi.org/project/nextstrain-augur>`__, so you can install it with ``pip`` like so:
+Augur is written in Python 3 and requires at least Python 3.8. It's published on `PyPi <https://pypi.org>`__ as `nextstrain-augur <https://pypi.org/project/nextstrain-augur>`__, so you can install it with ``pip`` like so:
 
 .. code:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from pathlib    import Path
 import setuptools
 import sys
 
-py_min_version = (3, 7)  # minimal supported python version
-since_augur_version = (14, 0)  # py_min_version is required since this augur version
+py_min_version = (3, 8)  # minimal supported python version
+since_augur_version = (23, 0)  # py_min_version is required since this augur version
 
 if sys.version_info < py_min_version:
     error = """
@@ -99,7 +99,6 @@ setuptools.setup(
 
         # Python 3 only
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     # Install an "augur" program which calls augur.__main__.main()
     #   https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation


### PR DESCRIPTION
### Description of proposed changes

Python 3.7 reached EOL [~2 months ago](https://devguide.python.org/versions/). Many dependencies have already dropped support in recent versions.

Use 3.8 as the minimum Python version.

### Related issue(s)

N/A

### Checklist

- [x] Checks pass
- [x] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
