### PR TITLE
feat: support treetime ambiguous date format

### DIFF
--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -121,6 +121,12 @@ def get_numerical_date_from_value(value, fmt=None, min_max_year=None):
         except InvalidDate as error:
             raise AugurError(str(error)) from error
         return [treetime.utils.numeric_date(d) for d in ambig_date]
+    if value.startswith('[') and value.endswith(']') and len(value[1:-1].split(':'))==2:
+        # Treetime ambiguous date format, e.g. [2019.5:2020.5]
+        try:
+            return [float(x) for x in value[1:-1].split(':')]
+        except ValueError as error:
+            raise AugurError(str(error)) from error
     try:
         return treetime.utils.numeric_date(datetime.datetime.strptime(value, fmt))
     except:

--- a/tests/dates/test_dates.py
+++ b/tests/dates/test_dates.py
@@ -99,3 +99,7 @@ class TestDates:
         }
         with pytest.raises(AugurError):
             dates.get_numerical_dates(metadata)
+
+    def test_get_numerical_date_from_value_treetime_ambiguous_date_format(self):
+        assert dates.get_numerical_date_from_value("[2019.5:2020.5]") == [2019.5, 2020.5]
+        assert dates.get_numerical_date_from_value("[2013.543:2013.544]") == [2013.543, 2013.544]


### PR DESCRIPTION
Add support for the treetime ambiguous date format `[float_min:float_max]`, e.g. `[2004.43:2005.58]`
This is useful for when ambiguity is not limited to month/year boundaries, e.g. in case of Danish SARS-CoV-2 sequences which have their dates binned rounded down to the most recent Monday.

Resolves #1304

With this PR, we can use cross-month ambiguous dates that aren't whole year, and within-month ambiguous dates as well.
E.g. this wouldn't have been possible previously without unconstraining everything but the year:
<img width="927" alt="image" src="https://github.com/nextstrain/augur/assets/25161793/91e781fa-68a8-4ca5-b5eb-9be05d9b4046">


### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

- [x] Added unit tests
- [x] Using it in production in `ncov-simplest`, turning Danish dates into ranges [here](https://github.com/corneliusroemer/ncov-simplest/blob/0f074c36819b9c4f277f49bb7bb2528d45d9d0d9/Snakefile#L179-L183) and running refine with the new parsing feature [here](https://github.com/corneliusroemer/ncov-simplest/blob/0f074c36819b9c4f277f49bb7bb2528d45d9d0d9/Snakefile#L342-L367)

### Checklist

- [ ] Add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR that are end user focused. Keep headers and formatting consistent with the rest of the file.
