### PR TITLE
chore: drop typing_extensions from deps as 3.7 no longer supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setuptools.setup(
         "phylo-treetime >=0.10.0, ==0.10.*",
         "pyfastx >=0.8.4, ==0.8.*",
         "scipy ==1.*",
-        "typing_extensions; python_version <'3.8'",
         "xopen[zstd] >=1.7.0, ==1.*"
     ],
     extras_require = {


### PR DESCRIPTION
## Description of proposed changes

With the augur 23 version bump, we've dropped support for python 3.7. Hence typing_extensions is no longer required as a dependency.

I noticed this when editing the bioconda recipe to mirror dependency changes: https://github.com/bioconda/bioconda-recipes/pull/42849/commits/29560dc3b69cabc724b5a3f81fbf88390d40ca9c