### PR TITLE
Allow treetime v0.11 (no breaking changes)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,9 @@
 
 ### Features
 
-* Support treetime 0.11.* (@corneliusroemer)
+* Support treetime 0.11.* [#1310][] (@corneliusroemer)
 
-[TKTK]: https://github.com/nextstrain/augur/pull/TKTK
+[#1310]: https://github.com/nextstrain/augur/pull/1310
 
 ## 23.0.0 (5 September 2023)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Features
+
+* Support treetime 0.11.* (@corneliusroemer)
+
+[TKTK]: https://github.com/nextstrain/augur/pull/TKTK
 
 ## 23.0.0 (5 September 2023)
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setuptools.setup(
         "numpy ==1.*",
         "packaging >=19.2",
         "pandas >=1.0.0, ==1.*",
-        "phylo-treetime >=0.10.0, ==0.10.*",
+        "phylo-treetime >=0.10.0, <0.12",
         "pyfastx >=0.8.4, ==0.8.*",
         "scipy ==1.*",
         "xopen[zstd] >=1.7.0, ==1.*"


### PR DESCRIPTION
Support treetime v0.11. No changes necessary as no breaking changes in treetime.

See changes here: https://github.com/neherlab/treetime/compare/v0.10.1...v0.11.1

## Checklist

- [x] Checks pass: Being tested on treetime v0.11 in CI, so that's good! https://github.com/nextstrain/augur/actions/runs/6112050391/job/16588676615#step:5:401
- [x] Successfully used in production myself for quite a few weeks already (and Richard too)
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

## Post release
- [ ] Need to update bioconda recipe dependencies once this is released