### PR TITLE
CI: Update mpox repo name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,9 +85,9 @@ jobs:
           - { pathogen: avian-flu, build-args: auspice/flu_avian_h5n1_ha.json }
           - { pathogen: ebola }
           - { pathogen: lassa }
-          # Disable monkeypox CI until pathogen-repo-ci supports custom build directories
+          # Disable mpox CI until pathogen-repo-ci supports custom build directories
           # See issue https://github.com/nextstrain/.github/issues/63
-          # - { pathogen: monkeypox }
+          # - { pathogen: mpox }
           - { pathogen: mumps }
           - {
               pathogen: ncov,


### PR DESCRIPTION
Not used currently but doesn't hurt to change anways.

Related-to: <nextstrain/mpox#168>
