### PR TITLE
feat: treat CDS as a valid feature for GFFs in `load_features`

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -153,7 +153,7 @@ def load_features(reference, feature_names=None):
     if '.gff' in reference.lower():
         #looks for 'gene' and 'gene' as best for TB
         from BCBio import GFF
-        limit_info = dict( gff_type = ['gene', 'source'] )
+        limit_info = dict( gff_type = ['gene', 'source', 'CDS'] )
 
         with open(reference, encoding='utf-8') as in_handle:
             for rec in GFF.parse(in_handle, limit_info=limit_info):


### PR DESCRIPTION
We currently don't load CDS features from GFF files
Within Nextclade, we now treat CDS as the translatable unit, not gene
So to use Nextclade GFF annotations in ancestral, we need to be able to read in CDS features

Reading in CDS in addition to gene and source could potentially break some workflows that use gffs that have both gene and CDS features
