### PR TITLE
export v2: Automatically minify output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
      * Incompatible arguments are now checked, especially related to VCF vs FASTA inputs. 
      * `--vcf-reference` and `--root-sequence` are now mutually exclusive.
 * translate: Tree nodes are checked against the node-data JSON input to ensure sequences are present. [#1348][] (@jameshadfield)
+* export v2: Automatically minify large outputs. Use `--no-minify-json` to disable this default behavior. [#1352][] (@victorlin)
 
 ### Bug Fixes
 
@@ -41,6 +42,7 @@
 [#1371]: https://github.com/nextstrain/augur/pull/1371
 [#1374]: https://github.com/nextstrain/augur/pull/1374
 [#1379]: https://github.com/nextstrain/augur/pull/1379
+[#1352]: https://github.com/nextstrain/augur/pull/1352
 
 ## 23.1.1 (7 November 2023)
 

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -126,6 +126,11 @@ def write_json(data, file_name, indent=(None if os.environ.get("AUGUR_MINIFY_JSO
         json.dump(data, handle, indent=indent, sort_keys=sort_keys, cls=AugurJSONEncoder)
 
 
+def json_size(data, indent=2):
+    """Return size in bytes of a Python object in JSON string form."""
+    return len(json.dumps(data, indent=indent, cls=AugurJSONEncoder).encode("utf-8"))
+
+
 class AugurJSONEncoder(json.JSONEncoder):
     """
     A custom JSONEncoder subclass to serialize data types used for various data

--- a/tests/functional/export_v2/cram/minify-output.t
+++ b/tests/functional/export_v2/cram/minify-output.t
@@ -1,0 +1,87 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Define a function to generate a Newick tree of a given size. Use lengthy node
+names to create larger file sizes with less recursion.
+
+  $ generate_newick() {
+  >   local n=$1
+  >   local prefix=$(printf 'N%.0s' {1..1000}})
+  >   if [ $n -eq 1 ]; then
+  >        echo "$prefix$n"
+  >    else
+  >        echo "($(generate_newick $((n-1))),$prefix$n)"
+  >    fi
+  > }
+
+A small tree is not automatically minified.
+The unminified output is 13KB which is considered acceptable.
+
+  $ echo "$(generate_newick 10);" > small_tree.nwk
+
+  $ ${AUGUR} export v2 \
+  >   --tree small_tree.nwk \
+  >   --skip-validation \
+  >   --output output.json &>/dev/null
+
+  $ head -c 20 output.json
+  {
+    "version": "v2", (no-eol)
+
+  $ ls -l output.json | awk '{print $5}'
+  13813
+
+It can be forcefully minified with an argument.
+
+  $ ${AUGUR} export v2 \
+  >   --tree small_tree.nwk \
+  >   --skip-validation \
+  >   --minify-json \
+  >   --output output.json &>/dev/null
+
+  $ head -c 20 output.json
+  {"version": "v2", "m (no-eol)
+
+It can also be forcefully minified by setting AUGUR_MINIFY_JSON to any value,
+even if it may seem "falsey".
+
+  $ AUGUR_MINIFY_JSON=0 ${AUGUR} export v2 \
+  >   --tree small_tree.nwk \
+  >   --skip-validation \
+  >   --output output.json &>/dev/null
+
+  $ head -c 20 output.json
+  {"version": "v2", "m (no-eol)
+
+
+A large tree, when forcefully not minified, has an output size of 6MB which is
+considered large.
+
+  $ echo "$(generate_newick 500);" > big_tree.nwk
+
+  $ ${AUGUR} export v2 \
+  >   --tree big_tree.nwk \
+  >   --skip-validation \
+  >   --no-minify-json \
+  >   --output output.json &>/dev/null
+
+  $ head -c 20 output.json
+  {
+    "version": "v2", (no-eol)
+
+  $ ls -l output.json | awk '{print $5}'
+  6568454
+
+This means it is automatically minified.
+
+  $ ${AUGUR} export v2 \
+  >   --tree big_tree.nwk \
+  >   --skip-validation \
+  >   --output output.json &>/dev/null
+
+  $ head -c 20 output.json
+  {"version": "v2", "m (no-eol)
+
+  $ ls -l output.json | awk '{print $5}'
+  561436


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Automatically format the output JSON file based on the number of tips, unless either --minify-json or --no-minify-json (new option) is specified.

Snippet of updated help output:

```
OPTIONAL SETTINGS:
  --minify-json         export JSONs without indentation or line returns,
                        regardless of how many nodes are in the tree.
                        (default: False)
  --no-minify-json      export JSONs to be human readable, regardless of how
                        many nodes are in the tree. (default: False)
```

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- #1331 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
