### PR TITLE
Exit code 2 if TreeTimeError encountered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,12 +27,14 @@
     * `--tree` and `--ancestral-sequences` are now required arguments.
     * separate VCF-only arguments into their own group
 * translate: Fixes a bug in the parsing behaviour of GFF files whereby the presence of the `--genes` command line argument would change how we read individual GFF lines. Issue [#1349][], PR [#1351][] (@jameshadfield)
+* If `TreeTimeError` is encountered Augur now exits with code 2 rather than 0. (This restores the original behaviour.) [#1367][] (@jameshadfield)
 
 
 [#1344]: https://github.com/nextstrain/augur/pull/1344
 [#1348]: https://github.com/nextstrain/augur/pull/1348
 [#1351]: https://github.com/nextstrain/augur/pull/1351
 [#1349]: https://github.com/nextstrain/augur/issues/1349
+[#1367]: https://github.com/nextstrain/augur/pull/1367
 
 ## 23.1.1 (7 November 2023)
 

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -87,6 +87,7 @@ def run(argv):
             Please check your input data and try again. If you continue to have problems, please open a new issue including
             the original command and the error above:  <https://github.com/nextstrain/augur/issues/new/choose>
             """))
+        sys.exit(2)
     except Exception:
         traceback.print_exc(file=sys.stderr)
         print_err("\n")


### PR DESCRIPTION
Current behaviour is to exit code 0 ("success") if augur encounters `TreeTimeError`. The initial implementation
(32563196e72f3bbda7af94202df9466089cf0d86) exited code 2 but this was removed by 403da88a1357dbf5190551bf36833ce6a0eabc06

This bug was first observed (by me, at least) as part of https://github.com/nextstrain/augur/issues/1360


- [x] Checks pass. _The relevant checks pass, but CI is failing due to https://github.com/nextstrain/rsv/issues/50_
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR
