### PR TITLE
Don't support Biopython 1.82

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
     * separate VCF-only arguments into their own group
 * translate: Fixes a bug in the parsing behaviour of GFF files whereby the presence of the `--genes` command line argument would change how we read individual GFF lines. Issue [#1349][], PR [#1351][] (@jameshadfield)
 * If `TreeTimeError` is encountered Augur now exits with code 2 rather than 0. (This restores the original behaviour.) [#1367][] (@jameshadfield)
+* ancestral, translate: Avoid incompatibilities with Biopython 1.82. [#1374][] (@victorlin)
 
 
 [#1344]: https://github.com/nextstrain/augur/pull/1344
@@ -37,6 +38,7 @@
 [#1349]: https://github.com/nextstrain/augur/issues/1349
 [#1367]: https://github.com/nextstrain/augur/pull/1367
 [#1371]: https://github.com/nextstrain/augur/pull/1371
+[#1374]: https://github.com/nextstrain/augur/pull/1374
 
 ## 23.1.1 (7 November 2023)
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ setuptools.setup(
     python_requires = '>={}'.format('.'.join(str(n) for n in py_min_version)),
     install_requires = [
         "bcbio-gff >=0.7.0, ==0.7.*",
-        "biopython >=1.67, !=1.77, !=1.78",
+        # Skip Biopython 1.82: https://github.com/nextstrain/augur/issues/1373
+        "biopython >=1.67, !=1.77, !=1.78, !=1.82",
         "cvxopt >=1.1.9, ==1.*",
         "importlib_resources >=5.3.0; python_version < '3.11'",
         "isodate ==0.6.*",


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Biopython 1.82 was released a few hours ago¹ and has an undocumented breaking change in the SeqFeature API which is used indirectly in augur translate (through bcbio-gff).

It's possible that this should be a hard ceiling instead of a one-off exclusion, but make it the latter for now. Fixing compatibility requires upstream changes in bcbio-gff which is out of our control.

¹ <https://github.com/biopython/biopython/blob/biopython-182/NEWS.rst>

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- #1373

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
