### PR TITLE
export v2: Add --metadata-columns option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 
 * `augur.io.read_metadata`: A new optional `dtype` argument allows custom data types for all columns. Automatic type inference still happens by default, so this is not a breaking change. [#1252][] (@victorlin)
 * `augur.io.read_vcf` has been removed and usage replaced with TreeTime's function of the same name which has improved validation of the VCF file. [#1366][] (@jameshadfield)
+* export v2: Add support to specify metadata columns to export without using them as colorings. This can be done with the `metadata_columns` property in the Auspice config JSON or via the `--metadata-columns` flag in the command line. [#1384][] (@joverlee521)
 
 ### Bug Fixes
 
@@ -18,13 +19,14 @@
 
 [#1252]: https://github.com/nextstrain/augur/pull/1252
 [#1366]: https://github.com/nextstrain/augur/pull/1366
+[#1384]: https://github.com/nextstrain/augur/pull/1384
 [#1400]: https://github.com/nextstrain/augur/pull/1400
 
 ## 24.0.0 (22 January 2024)
 
 ### Major Changes
 
-* ancestral, translate: For VCF inputs please ensure you are using TreeTime 0.11.2 or later. A large number of bugfixes and improvements have been added in both Augur and TreeTime. [#1355][] and [TreeTime #263][] (@jameshadfield) 
+* ancestral, translate: For VCF inputs please ensure you are using TreeTime 0.11.2 or later. A large number of bugfixes and improvements have been added in both Augur and TreeTime. [#1355][] and [TreeTime #263][] (@jameshadfield)
 * ancestral, translate: GenBank files now require the (GFF mandatory) source feature to be present. [#1351][] (@jameshadfield)
 * ancestral, translate: For GFF files, we extract the genome/sequence coordinates by inspecting the sequence-region pragma, region type and/or source type. This information is now required. [#1351][] (@jameshadfield)
 
@@ -41,7 +43,7 @@
     * If a Gene/CDS in the GFF/GenBank file is unparsed we now print a warning.
 * ancestral: For VCF alignments, a VCF output file is now only created when requested via `--output-vcf`. [#1344][] (@jameshadfield)
 * ancestral: Improvements to command line arguments. [#1344][] (@jameshadfield)
-     * Incompatible arguments are now checked, especially related to VCF vs FASTA inputs. 
+     * Incompatible arguments are now checked, especially related to VCF vs FASTA inputs.
      * `--vcf-reference` and `--root-sequence` are now mutually exclusive.
 * translate: Tree nodes are checked against the node-data JSON input to ensure sequences are present. [#1348][] (@jameshadfield)
 * utils::load_features: This function may now raise `AugurError`. [#1351][] (@jameshadfield)

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -260,6 +260,13 @@
                 }
             }
         },
+        "metadata_columns": {
+            "description": "Metadata TSV columns to export in addition to columns provided as colorings.",
+            "$comment": "These columns will not be used as coloring options in Auspice but will be visible in the tree.",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"type": "string"}
+        },
         "extensions": {
             "description": "Data to be passed through to the the resulting dataset JSON",
             "$comment": "Any type is accepted"

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -394,7 +394,7 @@ def set_colorings(data_json, config, command_line_colorings, metadata_names, nod
             warn("[colorings] You asked for mutations (\"gt\"), but none are defined on the tree. They cannot be used as a coloring.")
             return False
         if key != "gt" and not trait_values:
-            warn("You asked for a color-by for trait '{}', but it has no values on the tree. It has been ignored.".format(key))
+            warn(f"Requested color-by field {key!r} does not exist and will not be used as a coloring or exported.")
             return False
         return True
 
@@ -1162,7 +1162,7 @@ def run(args):
             # Match the column names corrected within parse_node_data_and_metadata
             corrected_col = update_deprecated_names(col)
             if corrected_col not in metadata_names:
-                print(f"WARNING: Requested metadata column {col!r} does not exist and will not be exported")
+                warn(f"Requested metadata column {col!r} does not exist and will not be exported")
                 continue
             additional_metadata_columns.append(corrected_col)
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -157,7 +157,7 @@ def convert_tree_to_json_structure(node, metadata, get_div, div=0):
     Returns
     -------
     dict:
-        See schema-export-v2.json#/$defs/tree for full details. 
+        See schema-export-v2.json#/$defs/tree for full details.
         Node names are always set, and divergence is set if applicable
     """
     node_struct = {'name': node.name, 'node_attrs': {}, 'branch_attrs': {}}
@@ -853,7 +853,7 @@ def register_parser(parent_subparsers):
     required.add_argument('--tree','-t', metavar="newick", required=True, help="Phylogenetic tree, usually output from `augur refine`")
     required.add_argument('--output', metavar="JSON", required=True, help="Output file (typically for visualisation in auspice)")
 
-    config = parser.add_argument_group(                                                                                                                              
+    config = parser.add_argument_group(
         title="DISPLAY CONFIGURATION",
         description="These control the display settings for auspice. \
             You can supply a config JSON (which has all available options) or command line arguments (which are more limited but great to get started). \

--- a/tests/functional/export_v2/cram/metadata-columns.t
+++ b/tests/functional/export_v2/cram/metadata-columns.t
@@ -38,12 +38,8 @@ Missing columns are skipped with a warning.
   >  --metadata metadata.tsv \
   >  --metadata-columns "field_A" "field_B" "missing_field" \
   >  --maintainers "Nextstrain Team" \
-  >  --output dataset.json
+  >  --output dataset.json > /dev/null
   WARNING: Requested metadata column 'missing_field' does not exist and will not be exported
-  Validating produced JSON
-  Validating schema of 'dataset.json'...
-  Validating that the JSON is internally consistent...
-  Validation of 'dataset.json' succeeded.
   \s{0} (re)
 
   $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
@@ -63,3 +59,21 @@ Specifying a fields with both --metadata-columns and --colory-by-metadata should
   $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
   >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
   {'iterable_item_added': {"root['meta']['colorings'][0]": {'key': 'field_B', 'title': 'field_B', 'type': 'categorical'}, "root['meta']['filters'][0]": 'field_B'}}
+
+Missing columns are skipped with a warning when specified by both --metadata-columns and --color-by-metadata.
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata.tsv \
+  >  --metadata-columns "field_A" "field_B" "missing_field" \
+  >  --color-by-metadata "missing_field" \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset.json > /dev/null
+  WARNING: Requested metadata column 'missing_field' does not exist and will not be exported
+  \s{0} (re)
+  WARNING: Requested color-by field 'missing_field' does not exist and will not be used as a coloring or exported.
+  \s{0} (re)
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}

--- a/tests/functional/export_v2/cram/metadata-columns.t
+++ b/tests/functional/export_v2/cram/metadata-columns.t
@@ -18,6 +18,14 @@ Create files for testing.
   > (tipA:1,(tipB:1,tipC:1)internalBC:2,(tipD:3,tipE:4,tipF:1)internalDEF:5)ROOT:0;
   > ~~
 
+  $ cat >auspice-config.json <<~~
+  > {"metadata_columns": ["field_A", "field_B"]}
+  > ~~
+
+  $ cat >auspice-config-overridden.json <<~~
+  > {"metadata_columns": ["overridden_field"]}
+  > ~~
+
 Run export with tree and metadata with additional columns.
 
   $ ${AUGUR} export v2 \
@@ -73,6 +81,33 @@ Missing columns are skipped with a warning when specified by both --metadata-col
   \s{0} (re)
   WARNING: Requested color-by field 'missing_field' does not exist and will not be used as a coloring or exported.
   \s{0} (re)
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+
+Specifying additional metadata columns via the Auspice configuration file.
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata.tsv \
+  >  --auspice-config auspice-config.json \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset.json > /dev/null
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+
+Specifying additional metadata columns via command line overrides the Auspice configuration file.
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata.tsv \
+  >  --auspice-config auspice-config-overridden.json \
+  >  --metadata-columns "field_A" "field_B" \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset.json > /dev/null
 
   $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
   >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"

--- a/tests/functional/export_v2/cram/metadata-columns.t
+++ b/tests/functional/export_v2/cram/metadata-columns.t
@@ -1,0 +1,65 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create files for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	field_A	field_B
+  > tipA	AA	AAA
+  > tipB	BB	BBB
+  > tipC	CC	CCC
+  > tipD	DD	DDD
+  > tipE	EE	EEE
+  > tipF	FF	FFF
+  > ~~
+
+  $ cat >tree.nwk <<~~
+  > (tipA:1,(tipB:1,tipC:1)internalBC:2,(tipD:3,tipE:4,tipF:1)internalDEF:5)ROOT:0;
+  > ~~
+
+Run export with tree and metadata with additional columns.
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata.tsv \
+  >  --metadata-columns "field_A" "field_B" \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset.json > /dev/null
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+
+Missing columns are skipped with a warning.
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata.tsv \
+  >  --metadata-columns "field_A" "field_B" "missing_field" \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset.json
+  WARNING: Requested metadata column 'missing_field' does not exist and will not be exported
+  Validating produced JSON
+  Validating schema of 'dataset.json'...
+  Validating that the JSON is internally consistent...
+  Validation of 'dataset.json' succeeded.
+  \s{0} (re)
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}
+
+Specifying a fields with both --metadata-columns and --colory-by-metadata should result in field used as a coloring and a filter.
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata.tsv \
+  >  --metadata-columns "field_A" "field_B" \
+  >  --color-by-metadata "field_B" \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset.json > /dev/null
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {'iterable_item_added': {"root['meta']['colorings'][0]": {'key': 'field_B', 'title': 'field_B', 'type': 'categorical'}, "root['meta']['filters'][0]": 'field_B'}}

--- a/tests/functional/export_v2/data/dataset-with-additional-metadata-columns.json
+++ b/tests/functional/export_v2/data/dataset-with-additional-metadata-columns.json
@@ -1,0 +1,121 @@
+{
+  "version": "v2",
+  "meta": {
+    "updated": "2024-01-05",
+    "maintainers": [
+      {
+        "name": "Nextstrain Team"
+      }
+    ],
+    "colorings": [],
+    "filters": [],
+    "panels": [
+      "tree"
+    ]
+  },
+  "tree": {
+    "name": "ROOT",
+    "node_attrs": {
+      "div": 0
+    },
+    "branch_attrs": {},
+    "children": [
+      {
+        "name": "tipA",
+        "node_attrs": {
+          "div": 1.0,
+          "field_A": {
+            "value": "AA"
+          },
+          "field_B": {
+            "value": "AAA"
+          }
+        },
+        "branch_attrs": {}
+      },
+      {
+        "name": "internalBC",
+        "node_attrs": {
+          "div": 2.0
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipB",
+            "node_attrs": {
+              "div": 3.0,
+              "field_A": {
+                "value": "BB"
+              },
+              "field_B": {
+                "value": "BBB"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipC",
+            "node_attrs": {
+              "div": 3.0,
+              "field_A": {
+                "value": "CC"
+              },
+              "field_B": {
+                "value": "CCC"
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      },
+      {
+        "name": "internalDEF",
+        "node_attrs": {
+          "div": 5.0
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipD",
+            "node_attrs": {
+              "div": 8.0,
+              "field_A": {
+                "value": "DD"
+              },
+              "field_B": {
+                "value": "DDD"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipE",
+            "node_attrs": {
+              "div": 9.0,
+              "field_A": {
+                "value": "EE"
+              },
+              "field_B": {
+                "value": "EEE"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipF",
+            "node_attrs": {
+              "div": 6.0,
+              "field_A": {
+                "value": "FF"
+              },
+              "field_B": {
+                "value": "FFF"
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description of proposed changes
Allows users to specify additional metadata columns to export as
node attributes that are not specified as coloring options via
the existing `--color-by-metadata` option or the Auspice config JSON.
This allows the metadata columns to be visible in the tree in Auspice
without polluting the color-by options.

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/1383

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
