### PR TITLE
Don't support Biopython >=1.82

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@
     * separate VCF-only arguments into their own group
 * translate: Fixes a bug in the parsing behaviour of GFF files whereby the presence of the `--genes` command line argument would change how we read individual GFF lines. Issue [#1349][], PR [#1351][] (@jameshadfield)
 * If `TreeTimeError` is encountered Augur now exits with code 2 rather than 0. (This restores the original behaviour.) [#1367][] (@jameshadfield)
-* ancestral, translate: Avoid incompatibilities with Biopython 1.82. [#1374][] (@victorlin)
+* ancestral, translate: Avoid incompatibilities with Biopython >=1.82. [#1374][], [#1387][] (@victorlin)
 * ancestral, translate: Address Biopython deprecation warnings. [#1379][] (@victorlin)
 * ancestral: Previously, the help text for `--genes` falsely claimed that it could accept a file. Now, it can truly claim that. [#1353][] (@victorlin)
 * Deprecate `read_strains` from `augur.utils` and add it to the public API under `augur.io`. [#1353][] (@victorlin)
@@ -46,6 +46,7 @@
 [#1379]: https://github.com/nextstrain/augur/pull/1379
 [#1352]: https://github.com/nextstrain/augur/pull/1352
 [#1353]: https://github.com/nextstrain/augur/pull/1353
+[#1387]: https://github.com/nextstrain/augur/pull/1387
 
 ## 23.1.1 (7 November 2023)
 

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,8 @@ setuptools.setup(
     python_requires = '>={}'.format('.'.join(str(n) for n in py_min_version)),
     install_requires = [
         "bcbio-gff >=0.7.0, ==0.7.*",
-        # Skip Biopython 1.82: https://github.com/nextstrain/augur/issues/1373
-        "biopython >=1.67, !=1.77, !=1.78, !=1.82",
+        # Skip Biopython >=1.82: https://github.com/nextstrain/augur/issues/1373
+        "biopython >=1.67, !=1.77, !=1.78, <1.82",
         "cvxopt >=1.1.9, ==1.*",
         "importlib_resources >=5.3.0; python_version < '3.11'",
         "isodate ==0.6.*",


### PR DESCRIPTION
This is a follow-up to "Don't support Biopython 1.82" (ee35e7e71) which only excludes 1.82. The newly released 1.83 also includes the same breaking changes to bcbio-gff, so we can expect all future versions to have the same effect.

## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- #1373

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
