### PR TITLE
data: add geo coordinates for asia

### DIFF
--- a/augur/data/lat_longs.tsv
+++ b/augur/data/lat_longs.tsv
@@ -1,5 +1,6 @@
 region	africa	4.070194	21.824559
 region	china	35.000074	104.999927
+region	asia	35.000074	104.999927
 region	europe	49.646237	10.799454
 region	japan_korea	35.845119	136.736386
 region	japan korea	35.845119	136.736386


### PR DESCRIPTION
we lacked a coordinate for plain 'asia' while having coordinates for 'west_asia', 'south_asia' etc. this adds a coordinate entry for `asia`. 