### PR TITLE
Show version in release workflow name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
-name: Release
+run-name: Release ${{ inputs.version }}
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Thought of this while releasing 24.1.0. Previously this wasn't possible, but [now it is](https://github.com/orgs/community/discussions/11396#discussioncomment-3738106).

This change will allow the the workflow run [history](https://github.com/nextstrain/augur/actions/workflows/release.yaml) for release.yaml to show versions. Currently it doesn't:

![image](https://github.com/nextstrain/augur/assets/13424970/71a16c18-41de-431b-83ad-dbcae58dac9d)

## Checklist

- [x] [Tested similar changes in a separate repo](https://github.com/victorlin/github-test/actions/runs/7716849052)
- [ ] Verify that it works on the next release