### PR TITLE
filter: Properly check for empty metadata

### DIFF
--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -68,6 +68,12 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     >>> group_by_strain = get_groups_for_subsampling(strains, metadata, group_by)
     >>> group_by_strain
     {'strain1': (2020, (2020, 1), 'unknown'), 'strain2': (2020, (2020, 2), 'unknown')}
+
+    If we try to group metadata that doesn't have any non-ID columns, we get nothing. This is a bug.
+
+    >>> metadata = pd.DataFrame([{"strain": "strain1"}, {"strain": "strain2"}]).set_index("strain")
+    >>> get_groups_for_subsampling(strains, metadata, group_by=('_dummy',))
+    {}
     """
     metadata = metadata.loc[list(strains)]
     group_by_strain = {}

--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -69,16 +69,16 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
     >>> group_by_strain
     {'strain1': (2020, (2020, 1), 'unknown'), 'strain2': (2020, (2020, 2), 'unknown')}
 
-    If we try to group metadata that doesn't have any non-ID columns, we get nothing. This is a bug.
+    We can group metadata without any non-ID columns.
 
     >>> metadata = pd.DataFrame([{"strain": "strain1"}, {"strain": "strain2"}]).set_index("strain")
     >>> get_groups_for_subsampling(strains, metadata, group_by=('_dummy',))
-    {}
+    {'strain1': ('_dummy',), 'strain2': ('_dummy',)}
     """
     metadata = metadata.loc[list(strains)]
     group_by_strain = {}
 
-    if metadata.empty:
+    if len(metadata) == 0:
         return group_by_strain
 
     if not group_by or group_by == ('_dummy',):


### PR DESCRIPTION
## Description of proposed changes

A DataFrame is considered "empty" if it has an index but no columns. That shouldn't be considered empty in the case of metadata. Instead, emptiness of metadata is reflected directly in the number of rows.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Follow-up to https://github.com/nextstrain/augur/pull/1406#discussion_r1482261000

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR~ no functional changes

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
