### PR TITLE
filter: Restore automatic boolean conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+* filter: In version 24.1.0, automatic conversion of boolean columns was accidentally removed. It has been restored with additional support for empty values evaluated as `None`. [#1410][] (@victorlin)
 * filter: The order of rows in `--output-metadata` and `--output-strains` now reflects the order in the original `--metadata`. [#1294][] (@victorlin)
 * filter, frequencies, refine: Performance improvements to reading the input metadata file. [#1294][] (@victorlin)
     * For filter, this comes with increased writing times for `--output-metadata` and `--output-strains`. However, net I/O speed still decreased during testing of this change.
@@ -18,6 +19,7 @@
 
 [#1294]: https://github.com/nextstrain/augur/pull/1294
 [#1389]: https://github.com/nextstrain/augur/pull/1389
+[#1410]: https://github.com/nextstrain/augur/pull/1410
 
 ## 24.1.0 (30 January 2024)
 

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -202,11 +202,8 @@ def filter_by_query(metadata: pd.DataFrame, query: str, column_types: Optional[D
         columns = metadata_copy.columns
 
     # If a type is not explicitly provided, try converting the column to numeric.
-    # This should cover most use cases, since one common problem is that the
-    # built-in data type inference when loading the DataFrame does not
-    # support nullable numeric columns, so numeric comparisons won't work on
-    # those columns. pd.to_numeric does proper conversion on those columns,
-    # and will not make any changes to columns with other values.
+    # pd.to_numeric supports nullable numeric columns unlike pd.read_csv's
+    # built-in data type inference.
     for column in columns:
         column_types.setdefault(column, 'numeric')
 

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -208,6 +208,8 @@ def filter_by_query(metadata: pd.DataFrame, query: str, column_types: Optional[D
         column_types.setdefault(column, 'numeric')
 
     # Convert data types before applying the query.
+    # NOTE: This can behave differently between different chunks of metadata,
+    # but it's the best we can do.
     for column, dtype in column_types.items():
         if dtype == 'numeric':
             metadata_copy[column] = pd.to_numeric(metadata_copy[column], errors='ignore')

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -232,6 +232,11 @@ def filter_by_query(metadata: pd.DataFrame, query: str, column_types: Optional[D
                 metadata_copy[column] = pd.to_numeric(metadata_copy[column], errors='raise', downcast='float')
             except ValueError as e:
                 raise AugurError(f"Failed to convert value in column {column!r} to float. {e}")
+        elif dtype == 'bool':
+            try:
+                metadata_copy[column] = metadata_copy[column].map(_string_to_boolean)
+            except ValueError as e:
+                raise AugurError(f"Failed to convert value in column {column!r} to bool. {e}")
         elif dtype == 'str':
             metadata_copy[column] = metadata_copy[column].astype('str', errors='ignore')
 

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -244,7 +244,7 @@ def filter_by_query(metadata: pd.DataFrame, query: str, column_types: Optional[D
 
 
 def _string_to_boolean(s: str):
-    """Convert a string to a boolean value.
+    """Convert a string to an optional boolean value.
 
     Raises ValueError if it cannot be converted.
     """
@@ -252,6 +252,8 @@ def _string_to_boolean(s: str):
         return True
     elif s.lower() == 'false':
         return False
+    elif s == '':
+        return None
 
     raise ValueError(f"Unable to convert {s!r} to a boolean value.")
 

--- a/augur/filter/io.py
+++ b/augur/filter/io.py
@@ -128,7 +128,7 @@ def write_metadata_based_outputs(input_metadata_path: str, delimiters: Sequence[
 
 
 # These are the types accepted in the following function.
-ACCEPTED_TYPES = {'numeric', 'int', 'float', 'str'}
+ACCEPTED_TYPES = {'int', 'float', 'str'}
 
 def column_type_pair(input: str):
     """Get a 2-tuple for column name to type.

--- a/augur/filter/io.py
+++ b/augur/filter/io.py
@@ -128,7 +128,7 @@ def write_metadata_based_outputs(input_metadata_path: str, delimiters: Sequence[
 
 
 # These are the types accepted in the following function.
-ACCEPTED_TYPES = {'int', 'float', 'str'}
+ACCEPTED_TYPES = {'int', 'float', 'bool', 'str'}
 
 def column_type_pair(input: str):
     """Get a 2-tuple for column name to type.

--- a/tests/functional/filter/cram/filter-query-boolean.t
+++ b/tests/functional/filter/cram/filter-query-boolean.t
@@ -56,3 +56,23 @@ Note that 1/0 can also be compared to boolean literals.
   1 strain was dropped during filtering
   	1 was filtered out by the query: "column == True"
   2 strains passed all filters
+
+Empty values are ignored.
+
+  $ cat >metadata.tsv <<~~
+  > strain	column
+  > SEQ_1	True
+  > SEQ_2	False
+  > SEQ_3	
+  > ~~
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "column == True" \
+  >  --output-strains filtered_strains.txt
+  2 strains were dropped during filtering
+  	2 were filtered out by the query: "column == True"
+  1 strain passed all filters
+
+  $ sort filtered_strains.txt
+  SEQ_1

--- a/tests/functional/filter/cram/filter-query-boolean.t
+++ b/tests/functional/filter/cram/filter-query-boolean.t
@@ -1,0 +1,26 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata file for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	column
+  > SEQ_1	True
+  > SEQ_2	True
+  > SEQ_3	False
+  > ~~
+
+Ideally, the column should be query-able by boolean comparisons.
+This does not currently work because all dtypes are strings.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "column == True" \
+  >  --output-strains filtered_strains.txt
+  ERROR: All samples have been dropped! Check filter rules and metadata file format.
+  3 strains were dropped during filtering
+  \t3 were filtered out by the query: "column == True" (esc)
+  [2]
+
+  $ sort filtered_strains.txt

--- a/tests/functional/filter/cram/filter-query-boolean.t
+++ b/tests/functional/filter/cram/filter-query-boolean.t
@@ -22,3 +22,37 @@ A column with True and False values is query-able by boolean comparisons.
   $ sort filtered_strains.txt
   SEQ_1
   SEQ_2
+
+Note that the string value is case-insensitive.
+
+  $ cat >metadata.tsv <<~~
+  > strain	column
+  > SEQ_1	True
+  > SEQ_2	trUe
+  > SEQ_3	FALSE
+  > ~~
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "column == True" \
+  >  --output-strains filtered_strains.txt
+  1 strain was dropped during filtering
+  	1 was filtered out by the query: "column == True"
+  2 strains passed all filters
+
+Note that 1/0 can also be compared to boolean literals.
+
+  $ cat >metadata.tsv <<~~
+  > strain	column
+  > SEQ_1	1
+  > SEQ_2	1
+  > SEQ_3	0
+  > ~~
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "column == True" \
+  >  --output-strains filtered_strains.txt
+  1 strain was dropped during filtering
+  	1 was filtered out by the query: "column == True"
+  2 strains passed all filters

--- a/tests/functional/filter/cram/filter-query-boolean.t
+++ b/tests/functional/filter/cram/filter-query-boolean.t
@@ -2,8 +2,7 @@ Setup
 
   $ source "$TESTDIR"/_setup.sh
 
-Ideally, A column with True and False values should be query-able by boolean comparisons.
-This does not currently work because all dtypes are strings.
+A column with True and False values is query-able by boolean comparisons.
 
   $ cat >metadata.tsv <<~~
   > strain	column
@@ -16,9 +15,10 @@ This does not currently work because all dtypes are strings.
   >  --metadata metadata.tsv \
   >  --query "column == True" \
   >  --output-strains filtered_strains.txt
-  ERROR: All samples have been dropped! Check filter rules and metadata file format.
-  3 strains were dropped during filtering
-  \t3 were filtered out by the query: "column == True" (esc)
-  [2]
+  1 strain was dropped during filtering
+  	1 was filtered out by the query: "column == True"
+  2 strains passed all filters
 
   $ sort filtered_strains.txt
+  SEQ_1
+  SEQ_2

--- a/tests/functional/filter/cram/filter-query-boolean.t
+++ b/tests/functional/filter/cram/filter-query-boolean.t
@@ -2,7 +2,8 @@ Setup
 
   $ source "$TESTDIR"/_setup.sh
 
-Create metadata file for testing.
+Ideally, A column with True and False values should be query-able by boolean comparisons.
+This does not currently work because all dtypes are strings.
 
   $ cat >metadata.tsv <<~~
   > strain	column
@@ -10,9 +11,6 @@ Create metadata file for testing.
   > SEQ_2	True
   > SEQ_3	False
   > ~~
-
-Ideally, the column should be query-able by boolean comparisons.
-This does not currently work because all dtypes are strings.
 
   $ ${AUGUR} filter \
   >  --metadata metadata.tsv \

--- a/tests/functional/filter/cram/filter-query-columns.t
+++ b/tests/functional/filter/cram/filter-query-columns.t
@@ -53,3 +53,13 @@ Specifying category:float does not work.
   >  --output-strains filtered_strains.txt
   ERROR: Failed to convert value in column 'category' to float. Unable to parse string "A" at position 0
   [2]
+
+Specifying category:bool also does not work.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --query "coverage >= 0.95 & category == 'B'" \
+  >  --query-columns category:bool \
+  >  --output-strains filtered_strains.txt
+  ERROR: Failed to convert value in column 'category' to bool. Unable to convert 'A' to a boolean value.
+  [2]


### PR DESCRIPTION
## Description of proposed changes

Boolean conversion was not considered when automatic nullable numeric conversion was applied¹, but it continued to work because augur filter relied on pandas.read_csv's automatic type inference up until it was disabled in favor of reading all columns as string².

A note to include boolean was added³ but removed inadvertently in another big change⁴.

¹ b325b970: Try converting all columns to numerical type
² 9f9be3a1: Read all metadata as string type
³ 725e1b44: Expand comment on numeric conversion
⁴ b0a0d112: Add --query-columns option

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Fixes #1411

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tests added
- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
