### PR TITLE
frequencies: Initialize variables in proper scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* frequencies: Fixed a bug introduced in 24.2.0 that prevented `--method diffusion` from working alongside `--tree`. [#1412][] (@victorlin)
+
+[#1412]: https://github.com/nextstrain/augur/issues/1412
 
 ## 24.2.0 (12 February 2024)
 

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -108,16 +108,16 @@ def run(args):
     stiffness = args.stiffness
     inertia = args.inertia
 
-    if args.method == "kde":
-        # Load weights if they have been provided.
-        if args.weights:
-            with open_file(args.weights, "r") as fh:
-                weights = json.load(fh)
+    # For KDE
+    weights = None
+    weights_attribute = None
 
-            weights_attribute = args.weights_attribute
-        else:
-            weights = None
-            weights_attribute = None
+    if args.method == "kde" and args.weights:
+        # Load weights if they have been provided.
+        with open_file(args.weights, "r") as fh:
+            weights = json.load(fh)
+
+        weights_attribute = args.weights_attribute
 
     if args.tree:
         tree = Phylo.read(args.tree, 'newick')

--- a/tests/functional/frequencies/cram/diffusion.t
+++ b/tests/functional/frequencies/cram/diffusion.t
@@ -1,0 +1,14 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Calculate diffusion-based tip frequencies from a refined tree.
+This currently doesn't work due to a bug.
+
+  $ ${AUGUR} frequencies \
+  >  --method diffusion \
+  >  --tree "$TESTDIR/../data/tree.nwk" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
+  >  --pivot-interval 3 \
+  >  --output tip-frequencies.json > /dev/null 2>&1
+  [2]

--- a/tests/functional/frequencies/cram/diffusion.t
+++ b/tests/functional/frequencies/cram/diffusion.t
@@ -3,12 +3,112 @@ Setup
   $ source "$TESTDIR"/_setup.sh
 
 Calculate diffusion-based tip frequencies from a refined tree.
-This currently doesn't work due to a bug.
 
   $ ${AUGUR} frequencies \
   >  --method diffusion \
   >  --tree "$TESTDIR/../data/tree.nwk" \
   >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --pivot-interval 3 \
-  >  --output tip-frequencies.json > /dev/null 2>&1
-  [2]
+  >  --output tip-frequencies.json > /dev/null
+
+  $ cat tip-frequencies.json
+  {
+    "BRA/2016/FC_6706": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "COL/FLR_00008/2015": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "Colombia/2016/ZC204Se": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "DOM/2016/BB_0183": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "EcEs062_16": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "HND/2016/HU_ME59": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "PAN/CDC_259359_V1_V3/2015": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "PRVABC59": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "VEN/UF_1/2016": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "ZKC2/2016": {
+      "global": [
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ]
+    },
+    "counts": {
+      "global": [
+        0,
+        5,
+        5,
+        0
+      ]
+    },
+    "generated_by": {
+      "program": "augur",
+      "version": ".*" (re)
+    },
+    "pivots": [
+      2015.7521,
+      2016.0041,
+      2016.2527,
+      2016.5014
+    ]
+  } (no-eol)


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

#1398 referenced the `weights_attribute` variable before it was initialized, resulting in an `UnboundLocalError` when a non-KDE method (i.e. diffusion) is used with `--tree`. This brings that variable and another related one to a higher scope where the reference is now valid.

## Related issue(s)

- Fixes #1412 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Test added for `--method diffusion`
- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
