### PR TITLE
filter: Use Pandas function to extract all names from query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,9 @@
 ### Bug Fixes
 
 * filter: In versions 24.2.0 and 24.2.1, `--query` stopped working in cases where internal optimizations added in version 24.2.0 failed to parse the columns from the query. It now falls back to non-optimized behavior that allows queries to work. [#1418][] (@victorlin)
+* filter: Handle backtick quoting in internal optimizations of `--query`. [#1416][] (@victorlin)
 
+[#1416]: https://github.com/nextstrain/augur/pull/1416
 [#1418]: https://github.com/nextstrain/augur/pull/1418
 
 ## 24.2.1 (14 February 2024)

--- a/augur/filter/io.py
+++ b/augur/filter/io.py
@@ -14,7 +14,7 @@ from augur.io.file import open_file
 from augur.io.metadata import Metadata, METADATA_DATE_COLUMN
 from augur.io.print import print_err
 from .constants import GROUP_BY_GENERATED_COLUMNS
-from .include_exclude_rules import extract_variables, parse_filter_query
+from .include_exclude_rules import extract_names, parse_filter_query
 
 
 def get_useful_metadata_columns(args: Namespace, id_column: str, all_columns: Sequence[str]):
@@ -64,8 +64,9 @@ def get_useful_metadata_columns(args: Namespace, id_column: str, all_columns: Se
                 columns.add(column)
 
         # Attempt to automatically extract columns from the query.
-        variables = extract_variables(args.query)
-        if variables is None and not args.query_columns:
+        variables = extract_names(args.query)
+        columns_in_query = variables.intersection(set(all_columns))
+        if columns_in_query is None and not args.query_columns:
             print_err(dedent(f"""\
                 WARNING: Could not infer columns from the pandas query. Reading all metadata columns,
                 which may impact execution time. If the query is valid, please open a new issue:
@@ -77,7 +78,7 @@ def get_useful_metadata_columns(args: Namespace, id_column: str, all_columns: Se
                     {args.query}"""))
             columns.update(all_columns)
         else:
-            columns.update(variables)
+            columns.update(columns_in_query)
 
     return list(columns)
 

--- a/tests/functional/filter/cram/filter-query-backtick-quoting.t
+++ b/tests/functional/filter/cram/filter-query-backtick-quoting.t
@@ -18,14 +18,6 @@ The 'region name' column is query-able by backtick quoting.
   >  --metadata metadata.tsv \
   >  --query '(`region name` == "A")' \
   >  --output-strains filtered_strains.txt > /dev/null
-  WARNING: Could not infer columns from the pandas query. Reading all metadata columns,
-  which may impact execution time. If the query is valid, please open a new issue:
-  
-      <https://github.com/nextstrain/augur/issues/new/choose>
-  
-  and add the query to the description:
-  
-      (`region name` == "A")
 
   $ sort filtered_strains.txt
   SEQ_1

--- a/tests/functional/filter/cram/filter-query-errors.t
+++ b/tests/functional/filter/cram/filter-query-errors.t
@@ -8,7 +8,6 @@ Using a pandas query with a nonexistent column results in a specific error.
   >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "invalid == 'value'" \
   >  --output-strains filtered_strains.txt > /dev/null
-  WARNING: Column 'invalid' does not exist in the metadata file. Ignoring it.
   ERROR: Query contains a column that does not exist in metadata.
   [2]
 
@@ -41,14 +40,6 @@ However, other Pandas errors are not so helpful, so a link is provided for users
   >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --query "some bad syntax" \
   >  --output-strains filtered_strains.txt > /dev/null
-  WARNING: Could not infer columns from the pandas query. Reading all metadata columns,
-  which may impact execution time. If the query is valid, please open a new issue:
-  
-      <https://github.com/nextstrain/augur/issues/new/choose>
-  
-  and add the query to the description:
-  
-      some bad syntax
   ERROR: Internal Pandas error when applying query:
   	invalid syntax (<unknown>, line 1)
   Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Previously, ast.walk did not support the special case of backtick quoting that is supported by pandas.DataFrame.query. Instead, use the function that Pandas uses internally to parse queries.

This includes support for backtick quoting, but loses support to distinguish variable names from other names as mentioned in the changes. Intersecting the return value of this function with known metadata column names should give the columns used in the query, which is the end goal.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Fixes #1415 
- Based on #1418 
- Mutually exclusive with (closes #1417)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
