### PR TITLE
filter: Replace backtick quoting in Pandas query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,9 @@
 ### Bug Fixes
 
 * filter: In versions 24.2.0 and 24.2.1, `--query` stopped working in cases where internal optimizations added in version 24.2.0 failed to parse the columns from the query. It now falls back to non-optimized behavior that allows queries to work. [#1418][] (@victorlin)
+* filter: Handle backtick quoting in internal optimizations of `--query`. [#1417][] (@victorlin)
 
+[#1417]: https://github.com/nextstrain/augur/pull/1417
 [#1418]: https://github.com/nextstrain/augur/pull/1418
 
 ## 24.2.1 (14 February 2024)

--- a/tests/functional/filter/cram/filter-query-backtick-quoting.t
+++ b/tests/functional/filter/cram/filter-query-backtick-quoting.t
@@ -18,14 +18,6 @@ The 'region name' column is query-able by backtick quoting.
   >  --metadata metadata.tsv \
   >  --query '(`region name` == "A")' \
   >  --output-strains filtered_strains.txt > /dev/null
-  WARNING: Could not infer columns from the pandas query. Reading all metadata columns,
-  which may impact execution time. If the query is valid, please open a new issue:
-  
-      <https://github.com/nextstrain/augur/issues/new/choose>
-  
-  and add the query to the description:
-  
-      (`region name` == "A")
 
   $ sort filtered_strains.txt
   SEQ_1


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

ast.walk does not support the special case of backtick quoting that is supported by pandas.DataFrame.query, so it must be replaced for ast.walk then reversed to obtain the actual variable names.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Fixes #1415 
- Based on #1418 
- Mutually exclusive with (closes #1416)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
