### PR TITLE
release.yaml: Restore workflow name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+name: Release
 run-name: Release ${{ inputs.version }}
 
 on:


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

When replacing this with `run-name`¹, I thought that it would be a full replacement. It turns out that `name` is still useful to show for the workflow on the GitHub Actions webpage, and for previous runs that did not have `run-name``.

¹ "Show version in release workflow name" (1e44873157)

## Related issue(s)

- Follow-up to #1405
