### PR TITLE
DRAFT: add 'gene' feature capture when reading genbank files

### DIFF
--- a/augur/utils.py
+++ b/augur/utils.py
@@ -385,17 +385,18 @@ def _read_nuc_annotation_from_genbank(record, reference):
 
 def _read_genbank(reference, feature_names):
     """
-    Read a GenBank file. We only read GenBank feature keys 'CDS' or 'source'.
+    Read a GenBank file. We only read GenBank feature keys 'source', 'CDS', or 'gene'.
     We create a "feature name" via:
     - for 'source' features use 'nuc'
     - for 'CDS' features use the locus_tag or the gene. If neither, then silently ignore. 
+    - for 'gene' feature use the locus_tag or the gene. If neither, then silently ignore.
 
     Parameters
     ----------
     reference : string
         File path to GenBank reference
     feature_names : None or set or list
-        Restrict the CDSs we read to those in the set/list
+        Restrict the CDSs or genes we read to those in the set/list
 
     Returns
     -------
@@ -408,6 +409,7 @@ def _read_genbank(reference, feature_names):
     AugurError
         If 'nuc' annotation not parsed
         If a CDS feature is given the name 'nuc'
+        If a 'gene' feature is given the name 'nuc'
     """
     from Bio import SeqIO
     gb = SeqIO.read(reference, 'genbank')
@@ -428,6 +430,21 @@ def _read_genbank(reference, feature_names):
 
             if fname == 'nuc':
                 raise AugurError(f"Reference {reference!r} contains a CDS with the name 'nuc'. This is not allowed.")
+
+            if fname and (feature_names is None or fname in feature_names):
+                features[fname] = feat
+
+        if feat.type=='gene':
+            fname = None
+            if "locus_tag" in feat.qualifiers:
+                fname = feat.qualifiers["locus_tag"][0]
+            elif "gene" in feat.qualifiers:
+                fname = feat.qualifiers["gene"][0]
+            else:
+                features_skipped+=1
+
+            if fname == 'nuc':
+                raise AugurError(f"Reference {reference!r} contains a 'gene' feature with the name 'nuc'. This is not allowed.")
 
             if fname and (feature_names is None or fname in feature_names):
                 features[fname] = feat

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -447,7 +447,10 @@ def _read_genbank(reference, feature_names):
                 raise AugurError(f"Reference {reference!r} contains a 'gene' feature with the name 'nuc'. This is not allowed.")
 
             if fname and (feature_names is None or fname in feature_names):
-                features[fname] = feat
+                if fname not in features:
+                    features[fname] = feat
+                else:
+                    print(f"WARNING: gene: '{fname}' already exists as a CDS: '{fname}'. Skipping this feature.")
 
     if features_skipped:
         print(f"WARNING: {features_skipped} CDS features skipped as they didn't have a locus_tag or gene qualifier.")


### PR DESCRIPTION
## Description of proposed changes

In response to https://github.com/nextstrain/rsv/pull/55#discussion_r1518248004, adds a 'gene' feature capture when reading GenBank files.

Please feel free to commit changes to this branch, this initial commit was a draft.

We should add a test of some sort to make sure this works as expected, perhaps in [augur/tests/io](https://github.com/nextstrain/augur/tree/7197b9f88c36aaeeb39aee44afeed09011ee7bff/tests/io)?

The potential benefit of this functionality is to simplify the [newreference.py](https://github.com/nextstrain/rsv/blob/b9f4f4f734d4f340cad00fe1cfcbdb91424907c5/scripts/newreference.py) script for Nextstrain gene tree builds.

## Related issue(s)

* https://github.com/nextstrain/rsv/pull/55
* https://github.com/nextstrain/dengue/pull/18#discussion_r1454388473

## Checklist

- [ ] Add test for the new functionality of capturing 'gene' features
- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
