### PR TITLE
parse: Support pandas 2.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Features
 
 * filter: Added a new option `--max-length` to filter out sequences that are longer than a certain amount of base pairs. [#1429][] (@victorlin)
+* parse: Added support for environments that use pandas 2.x. [#1436][] (@emollier, @victorlin)
 
 ### Bug Fixes
 
@@ -12,6 +13,7 @@
 
 [#1425]: https://github.com/nextstrain/augur/pull/1425
 [#1429]: https://github.com/nextstrain/augur/pull/1429
+[#1436]: https://github.com/nextstrain/augur/pull/1436
 
 ## 24.2.3 (23 February 2024)
 

--- a/augur/parse.py
+++ b/augur/parse.py
@@ -32,7 +32,7 @@ def fix_dates(d, dayfirst=True):
     '''
     try:
         from pandas.core.tools.datetimes import parsing
-        results = parsing.parse_time_string(d, dayfirst=dayfirst)
+        results = parsing.parse_datetime_string_with_reso(d, dayfirst=dayfirst)
         if len(results) == 2:
             dto, res = results
         else:

--- a/augur/parse.py
+++ b/augur/parse.py
@@ -32,7 +32,12 @@ def fix_dates(d, dayfirst=True):
     '''
     try:
         from pandas.core.tools.datetimes import parsing
-        results = parsing.parse_datetime_string_with_reso(d, dayfirst=dayfirst)
+        try:
+            # pandas 2.x
+            results = parsing.parse_datetime_string_with_reso(d, dayfirst=dayfirst)
+        except AttributeError:
+            # pandas 1.x
+            results = parsing.parse_time_string(d, dayfirst=dayfirst)
         if len(results) == 2:
             dto, res = results
         else:


### PR DESCRIPTION
Replace parse_time_string() by parse_datetime_string_with_reso() to gain pandas 2.0 compatitibility.

This change was hinted by s3v in [Debian bug #1044079] and allows the resolution of the github issue #1303 appropriately.

[Debian bug #1044079]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1044079#46

Thanks: s3v <c0llapsed@yahoo.it>

PS: filling the mandatory form below for your convenience.

## Description of proposed changes

This change modifies augur/parse.py by replacing parse_time_string() by parse_datetime_string_with_reso() in order to gain pandas 2.0 compatitibility.

## Related issue(s)

#1303 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass with the newer pandas 2 versions, but I have not tested how things behaved with the older pandas 1.x, so there are good chances some further adjustments will be necessary if you want to support both. 
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
