### PR TITLE
Write compound (segmented) sequence locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,12 +12,14 @@
 * filter: Updated docs with an example of tiered subsampling. [#1425][] (@victorlin)
 * export: Fixes bug [#1433] introduced in v23.1.0, that causes validation to fail when gene names start with `nuc`, e.g. `nucleocapsid`. [#1434][] (@corneliusroemer)
 * import: Fixes bug introduced in v24.2.0 that prevented `import beast` from running. [#1439][] (@tomkinsc)
+* translate, ancestral: Compound CDS are now exported as segmented CDS and are now viewable in Auspice.  [#1438][] (@jameshadfield)
 
 [#1425]: https://github.com/nextstrain/augur/pull/1425
 [#1429]: https://github.com/nextstrain/augur/pull/1429
 [#1433]: https://github.com/nextstrain/augur/issues/1433
 [#1434]: https://github.com/nextstrain/augur/pull/1434
 [#1436]: https://github.com/nextstrain/augur/pull/1436
+[#1438]: https://github.com/nextstrain/augur/pull/1438
 [#1439]: https://github.com/nextstrain/augur/pull/1439
 
 ## 24.2.3 (23 February 2024)

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -28,7 +28,8 @@ import numpy as np
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from .utils import parse_genes_argument, read_tree, InvalidTreeError, write_json, get_json_name
+from .utils import parse_genes_argument, read_tree, InvalidTreeError, write_json, get_json_name, \
+    genome_features_to_auspice_annotation
 from .io.file import open_file
 from .io.vcf import is_vcf as is_filename_vcf
 from treetime.vcf_utils import read_vcf, write_vcf
@@ -455,14 +456,7 @@ def run(args):
                     node["aa_sequences"][gene] = aa_result['tt'].sequence(T.root, as_string=True, reconstructed=True)
 
             anc_seqs['reference'][gene] = aa_result['root_seq']
-            # FIXME: Note that this is calculating the end of the CDS as 3*length of translation
-            # this is equivalent to the annotation for single segment CDS, but not for cds
-            # with splicing and slippage. But auspice can't handle the latter at the moment.
-            anc_seqs['annotations'][gene] = {'seqid':args.annotation,
-                                             'type':feat.type,
-                                             'start': int(feat.location.start)+1,
-                                             'end': int(feat.location.start) + 3*len(anc_seqs['reference'][gene]),
-                                             'strand': {+1:'+', -1:'-', 0:'?', None:None}[feat.location.strand]}
+            anc_seqs['annotations'].update(genome_features_to_auspice_annotation({gene: feat}, args.annotation))
 
             # Save ancestral amino acid sequences to FASTA.
             if args.output_translations:


### PR DESCRIPTION
Our current parsing for GenBank files would correctly read in complex CDSs (e.g. [the V gene in measles](https://github.com/nextstrain/measles/blob/9377ef6623cf3b5ea779ef3a3244f98b76ddc426/phylogenetic/defaults/measles_reference.gb#L105-L106)) but we didn't correctly export this CDS in the output JSON. This is fixed here.

Note that because we use BioPython's [SeqFeature.extract](https://biopython.org/docs/1.75/api/Bio.SeqFeature.html#Bio.SeqFeature.SeqFeature.extract) for both VCF and JSON/FASTA inputs the actual translations (via `augur translate`) don't need updating.

Screenshot of Measles V gene:
<img width="1034" alt="image" src="https://github.com/nextstrain/augur/assets/8350992/fe8155cb-5d1e-48db-b3bc-c406e632eb33">


Screenshot of HBV, with the nexclade+GFF translations (top) and the new `augur translate` + GenBank translations (below) - data is identical except for the CDS names:

<img width="1034" alt="image" src="https://github.com/nextstrain/augur/assets/8350992/d1641272-cd49-4bdb-9a31-30e87498e345">


- [x] Checks pass
- [x] add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR



