### PR TITLE
bugfix tree file opening in beast import

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,12 +11,14 @@
 
 * filter: Updated docs with an example of tiered subsampling. [#1425][] (@victorlin)
 * export: Fixes bug [#1433] introduced in v23.1.0, that causes validation to fail when gene names start with `nuc`, e.g. `nucleocapsid`. [#1434][] (@corneliusroemer)
+* import: Fixes bug introduced in v24.2.0 that prevented `import beast` from running. [#1439][] (@tomkinsc)
 
 [#1425]: https://github.com/nextstrain/augur/pull/1425
 [#1429]: https://github.com/nextstrain/augur/pull/1429
 [#1433]: https://github.com/nextstrain/augur/issues/1433
 [#1434]: https://github.com/nextstrain/augur/pull/1434
 [#1436]: https://github.com/nextstrain/augur/pull/1436
+[#1439]: https://github.com/nextstrain/augur/pull/1439
 
 ## 24.2.3 (23 February 2024)
 


### PR DESCRIPTION
## Description of proposed changes

`parse_nexus()` had a block to inspect the tree argument provided and if a path string, open the file and read tree data, or if a file handle, use it directly. Comparable functionality was recently [made available](https://github.com/nextstrain/augur/commit/51a77a9260a0e9eaaaf1c717861a3794a6e2dd64) via the `augur.io.file.open_file()` context manager, which was then employed in place of `open()` calls across the codebase. The change from `open()` to `open_file()` broke `parse_beast_tree()` since `augur.io.file.open_file()` returns a context manager rather than the file handle expected by `parse_nexus()`.

This commit removes the use file-or-handle logic from `parse_beast_tree()`, and has the function consume the file handle yielded by the `augur.io.file.open_file()` context manager (i.e. it adds a `with open_file(...) as handle:`).