### PR TITLE
docs: Tone down warning about Debian package

### DIFF
--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -14,8 +14,8 @@ Install Augur
 .. warning::
    There are some package managers that have entries with a similar name.
 
-   * `Augur on PyPI <https://pypi.org/project/Augur/>`_. This is a different project. Use `nextstrain-augur <https://pypi.org/project/nextstrain-augur/>`_ instead.
-   * `augur on Debian <https://tracker.debian.org/pkg/augur>`_. This is an unofficial version **not** maintained by the Nextstrain core team. Use at your own risk.
+   * `Augur on PyPI <https://pypi.org/project/Augur/>`__. This is a different project. Use `nextstrain-augur <https://pypi.org/project/nextstrain-augur/>`__ instead.
+   * `augur on Debian <https://tracker.debian.org/pkg/augur>`__. This is an unofficial version **not** maintained by the Nextstrain core team. Use at your own risk.
 
 
 There are several ways to install Augur, ordered from least to most complex.

--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -15,7 +15,7 @@ Install Augur
    There are some package managers that have entries with a similar name.
 
    * `Augur on PyPI <https://pypi.org/project/Augur/>`__. This is a different project. Use `nextstrain-augur <https://pypi.org/project/nextstrain-augur/>`__ instead.
-   * `augur on Debian <https://tracker.debian.org/pkg/augur>`__. This is an unofficial version **not** maintained by the Nextstrain core team. Use at your own risk.
+   * `augur on Debian <https://tracker.debian.org/pkg/augur>`__. This is an unofficial version not maintained by the Nextstrain core team. It may lag behind official Augur releases. We do not generally recommend its use.
 
 
 There are several ways to install Augur, ordered from least to most complex.


### PR DESCRIPTION
I think the note about Debian's package was a bit harsh as written.  We rely on a ton of Debian's packages for our own work and they're typically very high quality for a package ecosystem.  Removing "Use at your own risk" as that implies some vague fear it may be bad that I don't think is justified.  Instead, spell out that we don't recommend it and why.

