### PR TITLE
filter: Improve speed of checking duplicates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* filter: Improve speed of checking duplicates in metadata, especially for large files. [#1466][] (@victorlin)
+
+[#1466]: https://github.com/nextstrain/augur/pull/1466
 
 ## 24.4.0 (15 May 2024)
 

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -180,7 +180,7 @@ def run(args):
     for metadata in metadata_reader:
         duplicate_strains = (
             set(metadata.index[metadata.index.duplicated()]) |
-            set(metadata.index[metadata.index.isin(metadata_strains)])
+            (set(metadata.index) & metadata_strains)
         )
         if len(duplicate_strains) > 0:
             cleanup_outputs(args)


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

pandas's `isin(set)` converts the set into a list, making each value check [scale linearly](https://github.com/pandas-dev/pandas/issues/25507) with the size of the set. In the usage here, it's unfortunate because the size of the set grows with each metadata chunk processed. That means the entire operation scales with `(size of chunk * size of metadata)`.

Do the equivalent but much faster by first making a set from the current chunk's index then intersecting that with the set of previously seen IDs. This is faster because both of these steps [scale linearly](https://wiki.python.org/moin/TimeComplexity#set) with the size of the chunk, not the size of the metadata, meaning the entire operation scales with `(2 * size of chunk)`.

## Related issue(s)

- Prompted by [Slack discussion](https://bedfordlab.slack.com/archives/C7SDVPBLZ/p1715923786459859)
- Follow-up to #918

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass (notably [filter-metadata-duplicates-error.t](https://github.com/nextstrain/augur/blob/492340849382f972e8aaf90df599858434fb3295/tests/functional/filter/cram/filter-metadata-duplicates-error.t))
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
