### PR TITLE
augur/parse.py: fix test failure with pandas 2.2.

### DIFF
--- a/augur/parse.py
+++ b/augur/parse.py
@@ -31,7 +31,12 @@ def fix_dates(d, dayfirst=True):
     On failure to parse the date, the function will return the input.
     '''
     try:
-        from pandas.core.tools.datetimes import parsing
+        try:
+            # pandas <= 2.1
+            from pandas.core.tools.datetimes import parsing
+        except ImportError:
+            # pandas >= 2.2
+            from pandas._libs.tslibs import parsing
         try:
             # pandas 2.x
             results = parsing.parse_datetime_string_with_reso(d, dayfirst=dayfirst)


### PR DESCRIPTION
## Description of proposed changes

This change fixes another case of change in pandas internals causing a breakage in the date parser; initial report is [Debian bug #1071122].

[Debian bug #1071122]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1071122

Here is a copy of the test failure message for your convenience:
```
=================================== FAILURES ===================================
___________________________ TestParse.test_fix_dates ___________________________

self = <test_parse.TestParse object at 0x7fe8586a3590>
capsys = <_pytest.capture.CaptureFixture object at 0x7fe8582e7ce0>

    def test_fix_dates(self, capsys):
        full_date = "4-5-2020"
>       assert parse.fix_dates(full_date) == "2020-05-04"

tests/test_parse.py:14:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

d = '4-5-2020', dayfirst = True

    def fix_dates(d, dayfirst=True):
        '''
        attempt to parse a date string using pandas date parser. If ambiguous,
        the argument 'dayfirst' determines whether month or day is assumed to be
        the first field. Incomplete dates will be padded with XX.
        On failure to parse the date, the function will return the input.
        '''
        try:
>           from pandas.core.tools.datetimes import parsing
E           ImportError: cannot import name 'parsing' from 'pandas.core.tools.datetimes' (/usr/lib/python3/dist-packages/pandas/core/tools/datetimes.py)

augur/parse.py:34: ImportError
```

I agree adjusting the date parser to stick to pandas public api should be preferred; this change is available if need be.

## Related issue(s)

- nextstrain/augur#1303 
- nextstrain/augur#1436 

## Checklist

- [x] Checks pass: note I verified tests kept passing in Debian sid context with pandas 2.1, and were now passing with pandas 2.2 from Debian experimental.
- [ ] ~If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR~ I did not make user facing changes I believe.