### PR TITLE
Update Biopython docs URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,7 +136,7 @@ nitpick_ignore = [
 # -- Cross-project references ------------------------------------------------
 
 intersphinx_mapping = {
-    'Bio': ('https://biopython.org/docs/latest/api/', None),
+    'Bio': ('https://biopython.org/docs/latest/', None),
     'docs.nextstrain.org': ('https://docs.nextstrain.org/en/latest/', None),
     'cli': ('https://docs.nextstrain.org/projects/cli/en/stable', None),
     'python': ('https://docs.python.org/3', None),


### PR DESCRIPTION
## Description of proposed changes

The old URL started returning 404 for objects.inv. I took some quick guesses and found another URL that works.

## Related issue(s)

- Fixes #1498

## Checklist

- [x] PR docs build is successful
- [x] ~If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR~