### PR TITLE
augur curate format-dates: accept masked dates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 * Added a new sub-command `augur curate apply-record-annotations` to apply user curated annotations to existing fields in a metadata file. Previously, this was available as a `merge-user-metadata` in the nextstrain/ingest repo. [#1495][] (@joverlee521)
 * Added a new sub-command `augur curate abbreviate-authors` to abbreviate lists of authors to "<first author> et al." Previously, this was avaliable as the `transform-authors` script within the nextstrain/ingest repo. [#1483][] (@genehack)
 * Added a new sub-command `augur curate parse-genbank-location` to parse the `geo_loc_name` field from GenBank reconds. Previously, this was available as the `translate-genbank-location` script within the nextstrain/ingest repo. [#1485][] (@genehack)
+* curate format-dates: Added defaults to `--expected-date-formats` so that ISO 8601 dates (`%Y-%m-%d`) and its various masked forms (e.g. `%Y-XX-XX`) are automatically parsed by the command. [#1501][] (@joverlee521)
+
 ### Bug Fixes
 
 * filter: Improve speed of checking duplicates in metadata, especially for large files. [#1466][] (@victorlin)
@@ -19,6 +21,7 @@
 [#1491]: https://github.com/nextstrain/augur/pull/1491
 [#1493]: https://github.com/nextstrain/augur/pull/1493
 [#1495]: https://github.com/nextstrain/augur/pull/1495
+[#1501]: https://github.com/nextstrain/augur/pull/1501
 
 ## 24.4.0 (15 May 2024)
 

--- a/augur/curate/format_dates.py
+++ b/augur/curate/format_dates.py
@@ -12,6 +12,16 @@ from augur.types import DataErrorMethod
 from .format_dates_directives import YEAR_DIRECTIVES, YEAR_MONTH_DIRECTIVES, YEAR_MONTH_DAY_DIRECTIVES
 
 
+# Default date formats that this command should parse
+# without additional input from the user.
+DEFAULT_EXPECTED_DATE_FORMATS = [
+    '%Y-%m-%d',
+    '%Y-%m-XX',
+    '%Y-XX-XX',
+    'XXXX-XX-XX',
+]
+
+
 def register_parser(parent_subparsers):
     parser = parent_subparsers.add_parser("format-dates",
         parents=[parent_subparsers.shared_parser],
@@ -21,6 +31,7 @@ def register_parser(parent_subparsers):
     required.add_argument("--date-fields", nargs="+", action="extend",
         help="List of date field names in the record that need to be standardized.")
     required.add_argument("--expected-date-formats", nargs="+", action="extend",
+        default=DEFAULT_EXPECTED_DATE_FORMATS,
         help="Expected date formats that are currently in the provided date fields, " +
              "defined by standard format codes as listed at " +
              "https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes. " +

--- a/tests/functional/curate/cram/format-dates/accept-masked-dates.t
+++ b/tests/functional/curate/cram/format-dates/accept-masked-dates.t
@@ -17,14 +17,12 @@ Test input with masked dates works as expected if the masked format is provided.
   {"record": 1, "masked-date": "2020-XX-XX", "date": "2020"}
 
 Test mutliple passes through format-dates where the first pass masks dates.
-This is expected to fail without the masked format
+This is expected to work without providing additional date formats.
 
   $ cat records.ndjson \
   >   | ${AUGUR} curate format-dates \
   >     --date-fields "date" \
   >     --expected-date-formats "%Y" \
   >   | ${AUGUR} curate format-dates \
-  >     --date-fields "date" \
-  >     --expected-date-formats "%Y-%m-%d"
-  ERROR: Unable to format date string '2020-XX-XX' in field 'date' of record 0.
-  [2]
+  >     --date-fields "date"
+  {"record": 1, "masked-date": "2020-XX-XX", "date": "2020-XX-XX"}

--- a/tests/functional/curate/cram/format-dates/accept-masked-dates.t
+++ b/tests/functional/curate/cram/format-dates/accept-masked-dates.t
@@ -1,0 +1,30 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Create NDJSON file for testing format_dates with different forms
+
+  $ cat >records.ndjson <<~~
+  > {"record": 1, "masked-date": "2020-XX-XX", "date": "2020"}
+  > ~~
+
+Test input with masked dates works as expected if the masked format is provided.
+
+  $ cat records.ndjson \
+  >   | ${AUGUR} curate format-dates \
+  >     --date-fields "masked-date" \
+  >     --expected-date-formats "%Y-XX-XX"
+  {"record": 1, "masked-date": "2020-XX-XX", "date": "2020"}
+
+Test mutliple passes through format-dates where the first pass masks dates.
+This is expected to fail without the masked format
+
+  $ cat records.ndjson \
+  >   | ${AUGUR} curate format-dates \
+  >     --date-fields "date" \
+  >     --expected-date-formats "%Y" \
+  >   | ${AUGUR} curate format-dates \
+  >     --date-fields "date" \
+  >     --expected-date-formats "%Y-%m-%d"
+  ERROR: Unable to format date string '2020-XX-XX' in field 'date' of record 0.
+  [2]

--- a/tests/functional/curate/cram/format-dates/failure-reporting.t
+++ b/tests/functional/curate/cram/format-dates/failure-reporting.t
@@ -8,14 +8,6 @@ Create NDJSON file for testing format_dates with different forms
   > {"record": 1, "date": "2020", "collectionDate": "2020-01", "releaseDate": "2020-01","updateDate": "2020-07-18T00:00:00Z"}
   > ~~
 
-Test output with matching expected date formats.
-
-  $ cat records.ndjson \
-  >   | ${AUGUR} curate format-dates \
-  >     --date-fields "date" "collectionDate" "releaseDate" "updateDate" \
-  >     --expected-date-formats "%Y" "%Y-%m" "%Y-%m-%dT%H:%M:%SZ"
-  {"record": 1, "date": "2020-XX-XX", "collectionDate": "2020-01-XX", "releaseDate": "2020-01-XX", "updateDate": "2020-07-18"}
-
 Test output with unmatched expected date formats with default `ERROR_FIRST` failure reporting.
 This is expected to fail with an error, so redirecting stdout since we don't care about the output.
 
@@ -63,37 +55,3 @@ This is expected to return the masked date strings for failures.
   >     --expected-date-formats "%Y" "%Y-%m-%dT%H:%M:%SZ" \
   >     --failure-reporting "silent"
   {"record": 1, "date": "2020-XX-XX", "collectionDate": "XXXX-XX-XX", "releaseDate": "XXXX-XX-XX", "updateDate": "2020-07-18"}
-
-Test output with unmatched expected date formats while silencing failures with `--no-mask-failure`.
-This is expected to return the date strings in their original format.
-
-  $ cat records.ndjson \
-  >   | ${AUGUR} curate format-dates \
-  >     --date-fields "date" "collectionDate" "releaseDate" "updateDate" \
-  >     --expected-date-formats "%Y" "%Y-%m-%dT%H:%M:%SZ" \
-  >     --failure-reporting "silent" \
-  >     --no-mask-failure
-  {"record": 1, "date": "2020-XX-XX", "collectionDate": "2020-01", "releaseDate": "2020-01", "updateDate": "2020-07-18"}
-
-Test output with multiple matching expected date formats.
-Date with multiple matches will be parsed according to first matching format.
-The "collectionDate" and "releaseDate" will match the first "%Y-%j" format, which is a complete date.
-
-  $ cat records.ndjson \
-  >   | ${AUGUR} curate format-dates \
-  >     --date-fields "date" "collectionDate" "releaseDate" "updateDate" \
-  >     --expected-date-formats "%Y" "%Y-%j" "%Y-%m" "%Y-%m-%dT%H:%M:%SZ"
-  {"record": 1, "date": "2020-XX-XX", "collectionDate": "2020-01-01", "releaseDate": "2020-01-01", "updateDate": "2020-07-18"}
-
-Test output with chained format-dates commands that parses different fields with different expected formats.
-Since "collectionDate" and "releaseDate" have expected formats overlap,
-we can split them into two chained commands that parses them with different expected formats to produce the desired results.
-
-  $ cat records.ndjson \
-  >   | ${AUGUR} curate format-dates \
-  >     --date-fields "date" "releaseDate" "updateDate" \
-  >     --expected-date-formats "%Y" "%Y-%m" "%Y-%m-%dT%H:%M:%SZ" \
-  >   | ${AUGUR} curate format-dates \
-  >     --date-field "collectionDate" \
-  >     --expected-date-formats "%Y-%j"
-  {"record": 1, "date": "2020-XX-XX", "collectionDate": "2020-01-01", "releaseDate": "2020-01-XX", "updateDate": "2020-07-18"}

--- a/tests/functional/curate/cram/format-dates/fields-with-different-formats.t
+++ b/tests/functional/curate/cram/format-dates/fields-with-different-formats.t
@@ -1,0 +1,31 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Create NDJSON file for testing format_dates with different forms
+
+  $ cat >records.ndjson <<~~
+  > {"record": 1, "date": "2020", "collectionDate": "2020-01", "releaseDate": "2020-01","updateDate": "2020-07-18T00:00:00Z"}
+  > ~~
+
+Test output with matching expected date formats for multiple fields.
+
+  $ cat records.ndjson \
+  >   | ${AUGUR} curate format-dates \
+  >     --date-fields "date" "collectionDate" "releaseDate" "updateDate" \
+  >     --expected-date-formats "%Y" "%Y-%m" "%Y-%m-%dT%H:%M:%SZ"
+  {"record": 1, "date": "2020-XX-XX", "collectionDate": "2020-01-XX", "releaseDate": "2020-01-XX", "updateDate": "2020-07-18"}
+
+
+Test output with chained format-dates commands that parses different fields with different expected formats.
+Since "collectionDate" and "releaseDate" have expected formats overlap,
+we can split them into two chained commands that parses them with different expected formats to produce the desired results.
+
+  $ cat records.ndjson \
+  >   | ${AUGUR} curate format-dates \
+  >     --date-fields "date" "releaseDate" "updateDate" \
+  >     --expected-date-formats "%Y" "%Y-%m" "%Y-%m-%dT%H:%M:%SZ" \
+  >   | ${AUGUR} curate format-dates \
+  >     --date-field "collectionDate" \
+  >     --expected-date-formats "%Y-%j"
+  {"record": 1, "date": "2020-XX-XX", "collectionDate": "2020-01-01", "releaseDate": "2020-01-XX", "updateDate": "2020-07-18"}

--- a/tests/functional/curate/cram/format-dates/format_dates.t
+++ b/tests/functional/curate/cram/format-dates/format_dates.t
@@ -1,6 +1,6 @@
 Setup
 
-  $ source "$TESTDIR"/_setup.sh
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
 
 Create NDJSON file for testing format_dates with different forms
 

--- a/tests/functional/curate/cram/format-dates/multiple-matching-formats.t
+++ b/tests/functional/curate/cram/format-dates/multiple-matching-formats.t
@@ -1,0 +1,19 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Create NDJSON file for testing format_dates with different forms
+
+  $ cat >records.ndjson <<~~
+  > {"record": 1, "date": "2020", "collectionDate": "2020-01", "releaseDate": "2020-01","updateDate": "2020-07-18T00:00:00Z"}
+  > ~~
+
+Test output with multiple matching expected date formats.
+Date with multiple matches will be parsed according to first matching format.
+The "collectionDate" and "releaseDate" will match the first "%Y-%j" format, which is a complete date.
+
+  $ cat records.ndjson \
+  >   | ${AUGUR} curate format-dates \
+  >     --date-fields "date" "collectionDate" "releaseDate" "updateDate" \
+  >     --expected-date-formats "%Y" "%Y-%j" "%Y-%m" "%Y-%m-%dT%H:%M:%SZ"
+  {"record": 1, "date": "2020-XX-XX", "collectionDate": "2020-01-01", "releaseDate": "2020-01-01", "updateDate": "2020-07-18"}

--- a/tests/functional/curate/cram/format-dates/no-mask-failure.t
+++ b/tests/functional/curate/cram/format-dates/no-mask-failure.t
@@ -1,0 +1,20 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Create NDJSON file for testing format_dates with different forms
+
+  $ cat >records.ndjson <<~~
+  > {"record": 1, "date": "2020", "collectionDate": "2020-01", "releaseDate": "2020-01","updateDate": "2020-07-18T00:00:00Z"}
+  > ~~
+
+Test output with unmatched expected date formats while silencing failures with `--no-mask-failure`.
+This is expected to return the date strings in their original format.
+
+  $ cat records.ndjson \
+  >   | ${AUGUR} curate format-dates \
+  >     --date-fields "date" "collectionDate" "releaseDate" "updateDate" \
+  >     --expected-date-formats "%Y" "%Y-%m-%dT%H:%M:%SZ" \
+  >     --failure-reporting "silent" \
+  >     --no-mask-failure
+  {"record": 1, "date": "2020-XX-XX", "collectionDate": "2020-01", "releaseDate": "2020-01", "updateDate": "2020-07-18"}


### PR DESCRIPTION
## Description of proposed changes

Add `DEFAULT_EXPECTED_DATE_FORMATS` to `augur curate format-dates`. These are default date formats that the command should parse without additional input from the user, which includes the ISO 8601 date format and it's various masked forms.

Also includes some minor restructuring of tests for `format-dates` to be more modular cram tests.

## Related issue(s)

Resolves #1496 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass (seasonal-flu CI expected to fail due to [unrelated issue](https://github.com/nextstrain/conda-base/issues/75))
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
