### PR TITLE
[export] reduce numeric precision to reduce dataset size by ~30%

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## __NEXT__
 
+### Features
+
+* export v2: we now limit numerical precision on floats in the JSON. This should not change how a dataset is displayed / interpreted in Auspice but allows the gzipped & minimised JSON filesize to be reduced by around 30% (dataset-dependent). [#1512][] (@jameshadfield)
+* traits, export v2: `augur traits` now reports all confidence values above 0.1% rather than limiting them to the top 4 results. There is no change in the eventual Auspice dataset as `augur export v2` will still only consider the top 4. [#1512][] (@jameshadfield)
+
+[#1512]: https://github.com/nextstrain/augur/pull/1512
+
 
 ## 25.1.1 (15 July 2024)
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -11,7 +11,7 @@ import numbers
 import math
 import re
 from Bio import Phylo
-from typing import Dict, List, Union, TypedDict, Any
+from typing import Dict, Union, TypedDict, Any, Tuple
 
 from .argparse_ import ExtendOverwriteDefault
 from .errors import AugurError
@@ -756,7 +756,8 @@ def format_number(n: Union[int, float]) -> Union[int, float]:
 
 
 class ConfidenceNumeric(TypedDict):
-    confidence: List[Union[int,float]]
+    # the python type is a tuple, but when serialised to JSON this is an array
+    confidence: Tuple[Union[int,float], Union[int,float]]
 
 class ConfidenceCategorical(TypedDict):
     confidence: Dict[str,Union[int,float]]
@@ -784,7 +785,7 @@ def attr_confidence(
         if len(conf)!=2:
             warn(f"[confidence] node {node_name!r} specifies {conf_key!r} as a list of {len(conf)} values, not 2. Skipping confidence export.")
             return {}
-        return {"confidence": [format_number(v) for v in conf]}
+        return {"confidence": (format_number(conf[0]), format_number(conf[1]))}
 
     if isinstance(conf, dict):
         entropy = attrs.get(f"{key}_entropy", None)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -167,7 +167,7 @@ def convert_tree_to_json_structure(node, metadata, get_div, div=0):
     node_struct = {'name': node.name, 'node_attrs': {}, 'branch_attrs': {}}
 
     if get_div is not None: # Store the (cumulative) observed divergence prior to this node
-        node_struct["node_attrs"]["div"] = div
+        node_struct["node_attrs"]["div"] = format_number(div)
 
     if node.clades:
         node_struct["children"] = []
@@ -848,7 +848,7 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
             raw_data["num_date"] = raw_data["numdate"]
             del raw_data["numdate"]
         if is_valid(raw_data.get("num_date", None)): # it's ok not to have temporal information
-            node["node_attrs"]["num_date"] = {"value": raw_data["num_date"]}
+            node["node_attrs"]["num_date"] = {"value": format_number(raw_data["num_date"])}
             node["node_attrs"]["num_date"].update(attr_confidence(node["name"], raw_data, "num_date"))
 
     def _transfer_url_accession(node, raw_data):
@@ -865,8 +865,9 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
         exclude_list = ["gt", "num_date", "author"] # exclude special cases already taken care of
         trait_keys = trait_keys.difference(exclude_list)
         for key in trait_keys:
-            if is_valid(raw_data.get(key, None)):
-                node["node_attrs"][key] = {"value": raw_data[key]}
+            value = raw_data.get(key, None)
+            if is_valid(value):
+                node["node_attrs"][key] = {"value": format_number(value) if is_numeric(value) else value}
                 node["node_attrs"][key].update(attr_confidence(node["name"], raw_data, key))
 
     def _transfer_author_data(node):

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -8,8 +8,10 @@ import time
 from collections import defaultdict, deque, OrderedDict
 import warnings
 import numbers
+import math
 import re
 from Bio import Phylo
+from typing import Dict, List, Union, TypedDict, Any
 
 from .argparse_ import ExtendOverwriteDefault
 from .errors import AugurError
@@ -735,6 +737,77 @@ def set_branch_attrs_on_tree(data_json, branch_attrs):
             _recursively_set_data(child)
     _recursively_set_data(data_json["tree"])
 
+def is_numeric(n:Any) -> bool:
+    # Typing a number is surprisingly hard in python, and `number.Number`
+    # doesn't work nicely with type hints. See <https://stackoverflow.com/a/73186301>
+    return isinstance(n, (int, float))
+
+def format_number(n: Union[int, float]) -> Union[int, float]:
+    if isinstance(n, int) or n==0:
+        return n
+    # We want to use three sig figs for the fractional part of the float, while
+    # preserving all the data in the integral (integer) part. We leverage the
+    # fact that python floats (incl scientific notation) storing the shortest
+    # decimal string that’s guaranteed to round back to x. Note that this means we
+    # drop trailing zeros, so it's not _quite_ sig figs.
+    integral = int(abs(n))
+    significand = math.floor(math.log10(integral))+1 if integral!=0 else 0
+    return float(f"{n:.{significand+3}g}")
+
+
+class ConfidenceNumeric(TypedDict):
+    confidence: List[Union[int,float]]
+
+class ConfidenceCategorical(TypedDict):
+    confidence: Dict[str,Union[int,float]]
+    entropy: float
+
+class EmptyDict(TypedDict):
+    """Empty dict for typing."""
+
+def attr_confidence(
+    node_name: str,
+    attrs: dict,
+    key: str,
+) -> Union[EmptyDict, ConfidenceNumeric, ConfidenceCategorical]:
+    """
+    Extracts and formats the confidence & entropy keys from the provided node-data attrs
+    If there is no confidence-related information an empty dict is returned.
+    If the information appears incorrect / incomplete, a warning is printed and an empty dict returned.
+    """
+    conf_key = f"{key}_confidence"
+    conf = attrs.get(conf_key, None)
+    if conf is None:
+        return {}
+
+    if isinstance(conf, list):
+        if len(conf)!=2:
+            warn(f"[confidence] node {node_name!r} specifies {conf_key!r} as a list of {len(conf)} values, not 2. Skipping confidence export.")
+            return {}
+        return {"confidence": [format_number(v) for v in conf]}
+
+    if isinstance(conf, dict):
+        entropy = attrs.get(f"{key}_entropy", None)
+        if not entropy or not is_numeric(entropy):
+            warn(f"[confidence] node {node_name!r} includes a mapping of confidence values but not an associated numeric entropy value. Skipping confidence export.")
+            return {}
+        if not all([is_numeric(v) for v in conf.values()]):
+            warn(f"[confidence] node {node_name!r} includes a mapping of confidence values but they are not all numeric. Skipping confidence export.")
+            return {}
+        # While most of the time confidences come from `augur traits` which already sorts the values, we sort them (again) here
+        # and only take confidence values over .1% and the top 4 elements.
+        # To minimise the JSON size we only print values to 3 s.f. which is enough for Auspice
+        conf = {
+            key:format_number(conf[key]) for key in
+            sorted(list(conf.keys()), key=lambda x: conf[x], reverse=True)
+            if conf[key]>0.001
+        }
+        return {"confidence": conf, "entropy": format_number(entropy)}
+
+    warn(f"[confidence] {key+'_confidence'!r} is of an unknown format. Skipping.")
+    return {}
+
+
 
 def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
     '''
@@ -776,8 +849,7 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
             del raw_data["numdate"]
         if is_valid(raw_data.get("num_date", None)): # it's ok not to have temporal information
             node["node_attrs"]["num_date"] = {"value": raw_data["num_date"]}
-            if is_valid(raw_data.get("num_date_confidence", None)):
-                node["node_attrs"]["num_date"]["confidence"] = raw_data["num_date_confidence"]
+            node["node_attrs"]["num_date"].update(attr_confidence(node["name"], raw_data, "num_date"))
 
     def _transfer_url_accession(node, raw_data):
         for prop in ["url", "accession"]:
@@ -795,10 +867,7 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
         for key in trait_keys:
             if is_valid(raw_data.get(key, None)):
                 node["node_attrs"][key] = {"value": raw_data[key]}
-                if is_valid(raw_data.get(key+"_confidence", None)):
-                    node["node_attrs"][key]["confidence"] = raw_data[key+"_confidence"]
-                if is_valid(raw_data.get(key+"_entropy", None)):
-                    node["node_attrs"][key]["entropy"] = raw_data[key+"_entropy"]
+                node["node_attrs"][key].update(attr_confidence(node["name"], raw_data, key))
 
     def _transfer_author_data(node):
         if node["name"] in author_data:

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -88,7 +88,8 @@ def mugration_inference(tree=None, seq_meta=None, field='country', confidence=Tr
 
             marginal = [(letter_to_state[tt.gtr.alphabet[i]], pdis[i]) for i in range(len(tt.gtr.alphabet))]
             marginal.sort(key=lambda x: x[1], reverse=True) # sort on likelihoods
-            marginal = [(a, b) for a, b in marginal if b > 0.001][:4] #only take stuff over .1% and the top 4 elements
+            # Values are defined for all demes, although many/most will be 0, so only take those over 0.1%
+            marginal = [(a, b) for a, b in marginal if b > 0.001]
             conf = {a:b for a,b in marginal}
             node.__setattr__(field + "_entropy", S)
             node.__setattr__(field + "_confidence", conf)

--- a/tests/test_export_v2.py
+++ b/tests/test_export_v2.py
@@ -57,14 +57,15 @@ class TestConfidenceExtraction():
 
     @mock.patch("augur.export_v2.warn", no_op)
     def test_confidence_but_no_entropy(self):
-        # array confidences don't need entropy
-        assert {'confidence': [1,2]} == attr_confidence("name", {"key": 1.5, "key_confidence": [1,2]}, "key")
+        # array confidences don't need entropy (and are represented internally as tuples)
+        assert {'confidence': (1,2)} == attr_confidence("name", {"key": 1.5, "key_confidence": [1,2]}, "key")
         # but dict confidences do...
         assert {} == attr_confidence("name", {"key": "foo", "key_confidence": {"foo": 0.99}}, "key")
 
     @mock.patch("augur.export_v2.warn", no_op)
     def test_array_confidence(self):
-        assert {'confidence': [1,2]} == attr_confidence("name", {"key": 1.5, "key_confidence": [1,2]}, "key")
+        # Input JSON array -> python tuple -> exported as JSON Array
+        assert {'confidence': (1,2)} == attr_confidence("name", {"key": 1.5, "key_confidence": [1,2]}, "key")
         # invalid confidence. Warnings suppressed.
         assert {} == attr_confidence("name", {"key": 1.5, "key_confidence": [1,2,3]}, "key")
 

--- a/tests/test_export_v2.py
+++ b/tests/test_export_v2.py
@@ -1,0 +1,85 @@
+from unittest import mock
+from augur.export_v2 import is_numeric, format_number, attr_confidence
+
+class TestIsNumeric():
+    """This tests _our_ is_numeric function, it's not a philosophical discussion about numbers!"""
+    def test_strings_are_not_numeric(self):
+        assert not is_numeric("abc")
+        assert not is_numeric("1")
+        assert not is_numeric("1.0")
+    def test_numbers_are_numeric(self):
+        assert is_numeric(1)
+        assert is_numeric(1.1)
+        assert is_numeric(1.04e-2)
+
+class TestFormatNumber():
+    def test_integers_are_unchanged(self):
+        assert 123 == format_number(123)
+        assert 0 == format_number(0)
+        assert -123 == format_number(-123)
+
+    def test_positive_float_sig_figs(self):
+        assert "2010.0" == str(format_number(2010.0))
+        assert "2010.0" == str(format_number(2010.0000000001))
+        assert "2010.123" == str(format_number(2010.1234000000001))
+        assert "2010.0" == str(format_number(2010.0001))
+        assert "0.123" == str(format_number(0.123456))
+
+    def test_negative_float_sig_figs(self):
+        assert "-2010.0" == str(format_number(-2010.0))
+        assert "-2010.0" == str(format_number(-2010.0000000001))
+        assert "-2010.123" == str(format_number(-2010.1234000000001))
+        assert "-2010.0" == str(format_number(-2010.0001))
+        assert "-0.123" == str(format_number(-0.123456))
+
+    def test_exponential_notation_sig_figs(self):
+        assert "-1e-12" == str(format_number(-1.000088900581841e-12))
+        assert "-1.01e-12" == str(format_number(-1.0088900581841e-12))
+        assert "-8.89e-15" == str(format_number(-0.0088900581841e-12))
+        
+        assert "1e-12" == str(format_number(1.000088900581841e-12))
+        assert "1.01e-12" == str(format_number(1.0088900581841e-12))
+        assert "8.89e-15" == str(format_number(0.0088900581841e-12))
+
+    def test_exponential_notation_conversion(self):
+        assert ("1.23e-10") == str(format_number(0.000_000_000_123_456))
+
+
+def no_op(*args):
+    pass
+
+class TestConfidenceExtraction():
+    def test_no_confidence(self):
+        assert {} == attr_confidence("name", {"key": "something"}, "key")
+
+    def test_no_confidence_but_entropy(self):
+        assert {} == attr_confidence("name", {"key": "something", "key_entropy": 2.0}, "key")
+
+    @mock.patch("augur.export_v2.warn", no_op)
+    def test_confidence_but_no_entropy(self):
+        # array confidences don't need entropy
+        assert {'confidence': [1,2]} == attr_confidence("name", {"key": 1.5, "key_confidence": [1,2]}, "key")
+        # but dict confidences do...
+        assert {} == attr_confidence("name", {"key": "foo", "key_confidence": {"foo": 0.99}}, "key")
+
+    @mock.patch("augur.export_v2.warn", no_op)
+    def test_array_confidence(self):
+        assert {'confidence': [1,2]} == attr_confidence("name", {"key": 1.5, "key_confidence": [1,2]}, "key")
+        # invalid confidence. Warnings suppressed.
+        assert {} == attr_confidence("name", {"key": 1.5, "key_confidence": [1,2,3]}, "key")
+
+
+    @mock.patch("augur.export_v2.warn", no_op)
+    def test_dict_confidence(self):
+        conf = {"x": 0.888, "y": 1.1e-2}
+        entropy = 0.123
+        assert {'confidence': conf, "entropy": entropy} == \
+            attr_confidence("name", {"key": "x", "key_confidence": conf, "key_entropy": entropy}, "key")
+
+        # values must all be numbers
+        assert {} == \
+            attr_confidence("name", {"key": "x", "key_confidence": {**conf, "c": "d"}, "key_entropy": entropy}, "key")    
+
+    @mock.patch("augur.export_v2.warn", no_op)
+    def test_unknown_confidence(self):
+        assert {} == attr_confidence("name", {"key": "x", "key_confidence": "0.999"}, "key")


### PR DESCRIPTION
## Description of proposed changes

Reduces the precision of numerical values in the Auspice JSON (node attrs, confidence & entropy values) whilst keeping enough precision so that the rendering / display in Auspice is unchanged.

Motivated by [this slack thread](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1719528859992149)

It'd be good to get a few different eyes on this PR as it affects every single dataset Augur produces.

## Related work

The output of `augur traits` doesn't currently distinguish between a (terminal) node with a provided value vs an inferred one. They both look something like
```json
{
    "value": "foo",
    "confidence": {"foo": 1.0},
    "entropy": -1.000088900581841e-12
}
```
We could reduce the JSON size a bit more if we were able to know the value wasn't inferred and thus drop the confidence & entropy fields from the export. (This may require some small Auspice changes as well.)

## Checklist

- [ ] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

