### PR TITLE
Remove the requirement for a `database` field in `augur curate parse-genbank-location` [#1511]

### DIFF
--- a/augur/curate/parse_genbank_location.py
+++ b/augur/curate/parse_genbank_location.py
@@ -69,18 +69,8 @@ def run(
     records: List[dict],
 ) -> Generator[dict, None, None]:
     for record in records:
-        database = record.get("database", "")
-        if database in {"GenBank", "RefSeq"}:
-            parse_location(
-                record,
-                args.location_field,
-            )
-        else:
-            if database:
-                error_msg = f"""Database value of {database} not supported for `transform-genbank-location`; must be "GenBank" or "RefSeq"."""
-            else:
-                error_msg = "Record must contain `database` field to use `transform-genbank-location.`"
-
-            print_err(error_msg)
-
+        parse_location(
+            record,
+            args.location_field,
+        )
         yield record

--- a/tests/functional/curate/cram/parse-genbank-location/errors.t
+++ b/tests/functional/curate/cram/parse-genbank-location/errors.t
@@ -2,20 +2,6 @@ Setup
 
   $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
 
-Records without a `database` field result in the expected warning
-
-  $ echo '{"geo_loc_name":"Canada:Vancouver"}' \
-  >   | ${AUGUR} curate parse-genbank-location
-  Record must contain `database` field to use `transform-genbank-location.`
-  {"geo_loc_name": "Canada:Vancouver"}
-
-Records with a `database` field with an unsupported value result in the expected warning
-
-  $ echo '{"geo_loc_name":"Canada:Vancouver", "database":"database"}' \
-  >   | ${AUGUR} curate parse-genbank-location
-  Database value of database not supported for `transform-genbank-location`; must be "GenBank" or "RefSeq".
-  {"geo_loc_name": "Canada:Vancouver", "database": "database"}
-
 Records without a `location` field result in the expected warning
 
   $ echo '{"database":"GenBank"}' \


### PR DESCRIPTION
## Description of proposed changes

Per discussion on #1508 and #1511, the field standardization across records (cf #1510) makes the need to verify a `database` field less important — essentially, if there's a `geo_loc_name` field (or a field with the name given in the `--location-field` argument), parse it. Otherwise, warn that it's not found.


## Related issue(s)

* #1511 
* #1510 
* #1508 
* #1485 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
