### PR TITLE
augur curate I/O: validate records have same fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
 * Added a new sub-command `augur curate abbreviate-authors` to abbreviate lists of authors to "<first author> et al." Previously, this was avaliable as the `transform-authors` script within the nextstrain/ingest repo. [#1483][] (@genehack)
 * Added a new sub-command `augur curate parse-genbank-location` to parse the `geo_loc_name` field from GenBank reconds. Previously, this was available as the `translate-genbank-location` script within the nextstrain/ingest repo. [#1485][] (@genehack)
 * curate format-dates: Added defaults to `--expected-date-formats` so that ISO 8601 dates (`%Y-%m-%d`) and its various masked forms (e.g. `%Y-XX-XX`) are automatically parsed by the command. [#1501][] (@joverlee521)
-* Added a new sub-command `augur curate translate-strain-name` to filter strain names based on matching a regular expression. Previously, this was available as the `translate-strain-names` script within the nextstrain/ingest repo. [#1486][] (@genehack)
+* Added a new sub-command `augur curate translate-strain-name` to filter strain names based on matching a regular expression. Previously, this was available as the `translate-strain-names` script within the nextstrain/ingest repo. [#1514][] (@genehack)
 
 ### Bug Fixes
 
@@ -30,6 +30,7 @@
 [#1495]: https://github.com/nextstrain/augur/pull/1495
 [#1501]: https://github.com/nextstrain/augur/pull/1501
 [#1509]: https://github.com/nextstrain/augur/pull/1509
+[#1514]: https://github.com/nextstrain/augur/pull/1514
 [#1518]: https://github.com/nextstrain/augur/pull/1518
 
 ## 24.4.0 (15 May 2024)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Major changes
 
 * curate format-dates: Raises an error if provided date field does not exist in records. [#1509][] (@joverlee521)
+* All curate subcommands: Verifies all input records have the same fields and raises an error if a record does not have matching fields. [#1518][] (@joverlee521)
 
 ### Features
 
@@ -29,6 +30,7 @@
 [#1495]: https://github.com/nextstrain/augur/pull/1495
 [#1501]: https://github.com/nextstrain/augur/pull/1501
 [#1509]: https://github.com/nextstrain/augur/pull/1509
+[#1518]: https://github.com/nextstrain/augur/pull/1518
 
 ## 24.4.0 (15 May 2024)
 

--- a/tests/functional/curate/cram/validate-records.t
+++ b/tests/functional/curate/cram/validate-records.t
@@ -1,0 +1,37 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Testing records are validated appropriately by augur curate.
+Create NDJSON file for testing validation catches records with different fields.
+
+  $ cat >records.ndjson <<~~
+  > {"string": "string_1"}
+  > {"string": "string_2"}
+  > {"string": "string_3"}
+  > {"string": "string_4", "number": 123}
+  > ~~
+
+This will always pass thru the records that pass validation but should raise an
+error when it encounters the record with mismatched fields.
+
+  $ cat records.ndjson | ${AUGUR} curate passthru
+  ERROR: Records do not have the same fields! Please check your input data has the same fields.
+  {"string": "string_1"}
+  {"string": "string_2"}
+  {"string": "string_3"}
+  [2]
+
+Passing the records through multiple augur curate commands should raise the
+same error when it encounters the record with mismatched fields.
+
+  $ set -o pipefail
+  $ cat records.ndjson \
+  >   | ${AUGUR} curate passthru \
+  >   | ${AUGUR} curate passthru \
+  >   | ${AUGUR} curate passthru
+  ERROR: Records do not have the same fields! Please check your input data has the same fields.
+  {"string": "string_1"}
+  {"string": "string_2"}
+  {"string": "string_3"}
+  [2]


### PR DESCRIPTION
## Description of proposed changes

Validate records have the same fields before and after the subcommand modifies the records.

Includes a functional test to check for the input error, but there's no good way to check for the output error. Hopefully we just never see it!

## Related issue(s)

Resolves #1510 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGES.md](https://github.com/nextstrain/augur/blob/HEAD/CHANGES.md) summarizing the changes in this PR

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
