### PR TITLE
Update docs for (new) `augur curate rename`

### DIFF
--- a/docs/api/developer/augur.curate.rename.rst
+++ b/docs/api/developer/augur.curate.rename.rst
@@ -1,0 +1,7 @@
+augur.curate.rename module
+==========================
+
+.. automodule:: augur.curate.rename
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/developer/augur.curate.rst
+++ b/docs/api/developer/augur.curate.rst
@@ -20,5 +20,6 @@ Submodules
    augur.curate.normalize_strings
    augur.curate.parse_genbank_location
    augur.curate.passthru
+   augur.curate.rename
    augur.curate.titlecase
    augur.curate.transform_strain_name

--- a/docs/usage/cli/curate/index.rst
+++ b/docs/usage/cli/curate/index.rst
@@ -25,4 +25,5 @@ We will continue to add more subcommands as we identify other common data curati
     abbreviate-authors
     parse-genbank-location
     transform-strain-name
+    rename
 

--- a/docs/usage/cli/curate/rename.rst
+++ b/docs/usage/cli/curate/rename.rst
@@ -1,0 +1,9 @@
+======
+rename
+======
+
+.. argparse::
+    :module: augur
+    :func: make_parser
+    :prog: augur
+    :path: curate rename


### PR DESCRIPTION
Following instructions in `DEV_DOCS.md` and the (forthcoming) PR <https://github.com/nextstrain/augur/pull/1527/files>.

These docs were missed during development of the rename command <https://github.com/nextstrain/augur/pull/1506> as that predated the CI checks added in <https://github.com/nextstrain/augur/pull/1525>

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

