### PR TITLE
Fix location field recognition [#1530]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* curate parse-genbank-location: Fix a bug where a mix of empty and populated location-field values would result in inconsistent fields in the output NDJSON [#1531][](@genehack)
+
+[#1531]: https://github.com/nextstrain/augur/pull/1531
+
 
 ## 25.1.0 (11 July 2024)
 
@@ -1370,9 +1376,9 @@
 ### Features
 
 * improve testing by
-	* adding a simple shell script to run tests and improving pytest configuration and output [#463][]
-	* adding code coverage reports ([#486][], [#491][]) and integration with codecov.io [#508][]
-	* adding unit tests for align ([#477][]), filter ([#478][], [#479][], [#487][]), utils ([#501][])
+    * adding a simple shell script to run tests and improving pytest configuration and output [#463][]
+    * adding code coverage reports ([#486][], [#491][]) and integration with codecov.io [#508][]
+    * adding unit tests for align ([#477][]), filter ([#478][], [#479][], [#487][]), utils ([#501][])
 * align: reverse complement sequences when necessary using mafft’s autodirection flag [#467][]
 * align: speed up replacement of gaps with “ambiguous” bases [#474][]
 * mask: add support for FASTA input files [#493][]
@@ -1534,9 +1540,9 @@
   [Also part of PR 431](https://github.com/nextstrain/augur/pull/431)
 * traits: Allow input of `--weights` which references a `.tsv` file in the following format:
   ```
-  division	Hubei	10.0
-  division	Jiangxi	1.0
-  division	Chongqing	1.0
+  division  Hubei   10.0
+  division  Jiangxi 1.0
+  division  Chongqing   1.0
   ```
   where these weights represent equilibrium frequencies in the CTMC transition model. We imagine the
   primary use of user-specified weights to correct for strong sampling biases in available data.

--- a/augur/curate/parse_genbank_location.py
+++ b/augur/curate/parse_genbank_location.py
@@ -21,8 +21,8 @@ def parse_location(
     #
     # See GenBank docs for their "country" field:
     # https://www.ncbi.nlm.nih.gov/genbank/collab/country/
-    location_field = record.get(location_field_name, "")
-    if not location_field:
+    location_field = record.get(location_field_name, None)
+    if location_field is None:
         print_err(
             f"`parse-genbank-location` requires a `{location_field_name}` field; this record does not have one.",
         )

--- a/tests/functional/curate/cram/parse-genbank-location/empty-location.t
+++ b/tests/functional/curate/cram/parse-genbank-location/empty-location.t
@@ -1,0 +1,10 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+  $ echo -e '{"geo_loc_name":"Canada:Vancouver"}\n{"geo_loc_name":""}' > test.ndjson
+
+Parsing multiple records, some of which have an empty location field, works as expected.
+
+  $  ${AUGUR} curate parse-genbank-location < test.ndjson
+  {"geo_loc_name": "Canada:Vancouver", "country": "Canada", "division": "Vancouver", "location": ""}
+  {"geo_loc_name": "", "country": "", "division": "", "location": ""}


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->
Previously, if the `geo-loc-name` field was the empty string, the `if not location_field` condition would match, and the early return branch would trigger.

When processing multiple records, some of which had empty `geo-loc-name` fields and some of which didn't, this command would produce output where some records had `country`, `division`, and `location` fields added and some didn't, which triggers the "inconsistent fields" check in the top-level `run()` method, causing the command to exit.

Instead, use a default value of `None` when trying to get the `geo-loc-name` value from the record, and then check explicitly for `None` in the "early out" condition.

Also adds a test to validate this works as expected.


## Related issue(s)

#1530 

## Checklist

- [ ] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
