### PR TITLE
chore(deps): allow xopen major version 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* Support xopen major version 2. [#1532][] (@corneliusroemer)
+* Support xopen major version 2. Deprecate v1. Schedule for removal around November 2024. [#1532][] (@corneliusroemer)
 
 [#1532]: https://github.com/nextstrain/augur/pull/1532
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Features
+
+* Support xopen major version 2. [#1532][] (@corneliusroemer)
+
+[#1532]: https://github.com/nextstrain/augur/pull/1532
 
 ## 25.0.0 (10 July 2024)
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -6,7 +6,7 @@ available for backwards compatibility, but should not be used in new code.
 
 ## `xopen` major version 1
 
-*Deprecated in version __NEXT__ (Month Year). Planned for removal at the earliest with next major version and not before November 2024*
+*Deprecated in version __NEXT__ (July 2024). Planned for removal at the earliest with major version 26 not before November 2024*
 
 ## `augur parse` preference of `name` over `strain` as the sequence ID field
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -4,6 +4,10 @@ These features are deprecated, which means they are no longer maintained and
 will go away in a future major version of Augur. They are currently still
 available for backwards compatibility, but should not be used in new code.
 
+## `xopen` major version 1
+
+*Deprecated in version __NEXT__ (Month Year). Planned for removal at the earliest with next major version and not before November 2024*
+
 ## `augur parse` preference of `name` over `strain` as the sequence ID field
 
 *Deprecated in February 2024. Planned to be reordered June 2024 or after.*

--- a/augur/io/file.py
+++ b/augur/io/file.py
@@ -8,7 +8,7 @@ from xopen import xopen
 from augur.errors import AugurError
 
 # Workaround to maintain compatibility with both xopen v1 and v2
-# In some time, we can drop support for xopen v1
+# Around November 2024, we shall drop support for xopen v1
 # by removing the try-except block and using
 # _PipedCompressionProgram directly
 try:

--- a/augur/io/file.py
+++ b/augur/io/file.py
@@ -2,9 +2,23 @@ import os
 from contextlib import contextmanager
 from io import IOBase
 from textwrap import dedent
-from xopen import PipedCompressionReader, PipedCompressionWriter, xopen
+
+from xopen import xopen
+
 from augur.errors import AugurError
 
+# Workaround to maintain compatibility with both xopen v1 and v2
+# In some time, we can drop support for xopen v1
+# by removing the try-except block and using
+# _PipedCompressionProgram directly
+try:
+    from xopen import _PipedCompressionProgram as PipedCompressionReader
+    from xopen import _PipedCompressionProgram as PipedCompressionWriter
+except ImportError:
+    from xopen import (  # type: ignore[attr-defined, no-redef]  
+        PipedCompressionReader,
+        PipedCompressionWriter,
+    )
 
 ENCODING = "utf-8"
 

--- a/augur/io/file.py
+++ b/augur/io/file.py
@@ -2,9 +2,7 @@ import os
 from contextlib import contextmanager
 from io import IOBase
 from textwrap import dedent
-
 from xopen import xopen
-
 from augur.errors import AugurError
 
 # Workaround to maintain compatibility with both xopen v1 and v2

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
         "phylo-treetime >=0.11.2, <0.12",
         "pyfastx >=1.0.0, <3.0",
         "scipy ==1.*",
-        "xopen[zstd] >=1.7.0, <3"
+        "xopen[zstd] >=1.7.0, <3" # TODO: Deprecated, remove v1 support around November 2024
     ],
     extras_require = {
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
         "phylo-treetime >=0.11.2, <0.12",
         "pyfastx >=1.0.0, <3.0",
         "scipy ==1.*",
-        "xopen[zstd] >=1.7.0, ==1.*"
+        "xopen[zstd] >=1.7.0, <3"
     ],
     extras_require = {
         'dev': [


### PR DESCRIPTION
~There were no breaking changes of relevance to us, so we can allow xopen v2.~

One small change: PipedCompressionReader/Writer was renamed to _pipedCompressionProgram.

If we want to support both v1 and v2, we have to do a bit of an ugly try/except import workaround. Probably worth keeping that for a few months because some programs people might want to use with augur potentially only support v1 at this point.

Once we merge and release this, we can install latest augur via conda-forge/bioconda natively on osx-arm64.

See xopen changelog: https://github.com/pycompression/xopen/blob/main/README.rst#v200-2024-03-26

## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
