### PR TITLE
Remove augur.filenames module

### DIFF
--- a/augur/filenames.py
+++ b/augur/filenames.py
@@ -1,3 +1,0 @@
-
-timetree_fname = "{base}_timetree.nwk"
-

--- a/docs/api/developer/augur.filenames.rst
+++ b/docs/api/developer/augur.filenames.rst
@@ -1,7 +1,0 @@
-augur.filenames module
-======================
-
-.. automodule:: augur.filenames
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/api/developer/augur.rst
+++ b/docs/api/developer/augur.rst
@@ -36,7 +36,6 @@ Submodules
    augur.export
    augur.export_v1
    augur.export_v2
-   augur.filenames
    augur.frequencies
    augur.frequency_estimators
    augur.index

--- a/docs/redirects.yaml
+++ b/docs/redirects.yaml
@@ -89,10 +89,6 @@
   to_url: /api/developer/augur.export_v2.html
 
 - type: page
-  from_url: /api/augur.filenames.html
-  to_url: /api/developer/augur.filenames.html
-
-- type: page
   from_url: /api/augur.filter.html
   to_url: /api/developer/augur.filter.html
 


### PR DESCRIPTION
It was unused cruft even when originally committed six years ago in "filter and traits of new augur now working in rudimentary fashion" (fb475a6b).

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
