### PR TITLE
io.json: Serialize date objects as ISO 8601 too

### DIFF
--- a/augur/io/json.py
+++ b/augur/io/json.py
@@ -40,6 +40,16 @@ from uuid import UUID
 def as_json(value):
     """
     Converts *value* to a JSON string using our custom :class:`JsonEncoder`.
+
+    The custom encoder supports serialization of :class:`~datetime.datetime` objects:
+
+    >>> as_json(datetime(year=2024, month=7, day=17, hour=11, minute=38))
+    '"2024-07-17T11:38:00"'
+
+    and :class:`~uuid.UUID` objects:
+
+    >>> as_json(UUID(int=147952133113722764103424939352979237618))
+    '"6f4e8b5a-8500-4928-b7ae-dc098a256af2"'
     """
     return json.dumps(value, allow_nan = False, cls = JsonEncoder)
 

--- a/augur/io/json.py
+++ b/augur/io/json.py
@@ -32,7 +32,7 @@ The LICENSE file included in ID3C's repo is copied below verbatim::
     SOFTWARE.
 """
 import json
-from datetime import datetime
+from datetime import date, datetime
 from typing import Iterable
 from uuid import UUID
 
@@ -41,7 +41,12 @@ def as_json(value):
     """
     Converts *value* to a JSON string using our custom :class:`JsonEncoder`.
 
-    The custom encoder supports serialization of :class:`~datetime.datetime` objects:
+    The custom encoder supports serialization of :class:`~datetime.date` objects:
+
+    >>> as_json(date(year=2024, month=7, day=17))
+    '"2024-07-17"'
+
+    :class:`~datetime.datetime` objects:
 
     >>> as_json(datetime(year=2024, month=7, day=17, hour=11, minute=38))
     '"2024-07-17T11:38:00"'
@@ -106,10 +111,11 @@ class JsonEncoder(json.JSONEncoder):
         """
         Returns *value* as JSON or raises a TypeError.
         Serializes:
+        * :class:`~datetime.date` using :meth:`~datetime.date.isoformat()`
         * :class:`~datetime.datetime` using :meth:`~datetime.datetime.isoformat()`
         * :class:`~uuid.UUID` using ``str()``
         """
-        if isinstance(value, datetime):
+        if isinstance(value, (date, datetime)):
             return value.isoformat()
 
         elif isinstance(value, UUID):


### PR DESCRIPTION
No reason to error on them, and we're going to start getting them when reading metadata from Excel.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
