### PR TITLE
CI: Update pathogen-repo-ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,14 +110,19 @@ jobs:
       matrix:
         include:
           - { pathogen: avian-flu, build-args: test_target }
+          - { pathogen: ebola }
+          - { pathogen: lassa }
+          - { pathogen: mumps }
           - {
               pathogen: ncov,
               build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci,
             }
+          - { pathogen: rsv }
           - {
               pathogen: seasonal-flu,
               build-args: --configfile profiles/ci/builds.yaml -p,
             }
+          - { pathogen: tb }
 
     name: pathogen-repo-ci-v0 (${{ matrix.pathogen }})
     defaults:
@@ -188,7 +193,6 @@ jobs:
     strategy:
       matrix:
         pathogen:
-          # XXX TODO: Restore pathogens after they've been updated (ebola, lassa, mumps, rsv, tb)
           - dengue
           - measles
           - mpox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,94 +94,6 @@ jobs:
         name: coverage
         path: "${{ env.COVERAGE_FILE }}"
 
-  # Replicating pathogen-repo-ci-v0 workflow because we decided not to support
-  # local versions of Augur in the centralized workflow
-  # <https://github.com/nextstrain/.github/issues/66>
-  # This particular jobs is for pathogen repos that do not follow the standard
-  # pathogen repo structure and is not expected to be updated.
-  # Any new pathogen repos should be added to the job replicating the latest version
-  # of the pathogen-repo-ci below.
-  pathogen-repo-ci-v0:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    env:
-      repodata_use_zst: true
-    strategy:
-      matrix:
-        include:
-          - { pathogen: avian-flu, build-args: test_target }
-          - { pathogen: ebola }
-          - { pathogen: lassa }
-          - { pathogen: mumps }
-          - {
-              pathogen: ncov,
-              build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci,
-            }
-          - { pathogen: rsv }
-          - {
-              pathogen: seasonal-flu,
-              build-args: --configfile profiles/ci/builds.yaml -p,
-            }
-          - { pathogen: tb }
-
-    name: pathogen-repo-ci-v0 (${{ matrix.pathogen }})
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: ./augur
-
-      - name: Set cache key
-        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
-
-      # Set up a Conda environment that replicates Nextstrain's Conda runtime.
-      - name: Install nextstrain-base from Conda
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          create-args: nextstrain-base
-          condarc: |
-            channels:
-              - nextstrain
-              - conda-forge
-              - bioconda
-            channel_priority: strict
-          cache-environment: true
-          cache-environment-key: ${{ env.DATE }}
-          environment-name: augur
-
-      # Replace the Conda Augur installation with the local version.
-      - run: pip install ./augur
-
-      - uses: actions/checkout@v4
-        with:
-          repository: nextstrain/${{ matrix.pathogen }}
-          path: ./pathogen-repo
-
-      - name: Copy example data
-        working-directory: ./pathogen-repo
-        run: |
-          if [[ -d example_data ]]; then
-            mkdir -p data/
-            cp -r -v example_data/* data/
-          else
-            echo No example data to copy.
-          fi
-
-      - run: nextstrain build --ambient ./pathogen-repo ${{ matrix.build-args }}
-
-      - if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: output-${{ matrix.pathogen }}
-          path: |
-            ./pathogen-repo/auspice/
-            ./pathogen-repo/results/
-            ./pathogen-repo/benchmarks/
-            ./pathogen-repo/logs/
-            ./pathogen-repo/.snakemake/log/
-
   # Replicating pathogen-repo-ci workflow because we decided not to support
   # local versions of Augur in the centralized workflow
   # <https://github.com/nextstrain/.github/issues/66>
@@ -305,6 +217,94 @@ jobs:
             && ($phylogenetic == success || $phylogenetic == skipped)
             && ($nextclade    == success || $nextclade    == skipped)
           ]]
+
+  # Replicating pathogen-repo-ci-v0 workflow because we decided not to support
+  # local versions of Augur in the centralized workflow
+  # <https://github.com/nextstrain/.github/issues/66>
+  # This particular jobs is for pathogen repos that do not follow the standard
+  # pathogen repo structure and is not expected to be updated.
+  # Any new pathogen repos should be added to the job replicating the latest version
+  # of the pathogen-repo-ci above.
+  pathogen-repo-ci-v0:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      repodata_use_zst: true
+    strategy:
+      matrix:
+        include:
+          - { pathogen: avian-flu, build-args: test_target }
+          - { pathogen: ebola }
+          - { pathogen: lassa }
+          - { pathogen: mumps }
+          - {
+              pathogen: ncov,
+              build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci,
+            }
+          - { pathogen: rsv }
+          - {
+              pathogen: seasonal-flu,
+              build-args: --configfile profiles/ci/builds.yaml -p,
+            }
+          - { pathogen: tb }
+
+    name: pathogen-repo-ci-v0 (${{ matrix.pathogen }})
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ./augur
+
+      - name: Set cache key
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+
+      # Set up a Conda environment that replicates Nextstrain's Conda runtime.
+      - name: Install nextstrain-base from Conda
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          create-args: nextstrain-base
+          condarc: |
+            channels:
+              - nextstrain
+              - conda-forge
+              - bioconda
+            channel_priority: strict
+          cache-environment: true
+          cache-environment-key: ${{ env.DATE }}
+          environment-name: augur
+
+      # Replace the Conda Augur installation with the local version.
+      - run: pip install ./augur
+
+      - uses: actions/checkout@v4
+        with:
+          repository: nextstrain/${{ matrix.pathogen }}
+          path: ./pathogen-repo
+
+      - name: Copy example data
+        working-directory: ./pathogen-repo
+        run: |
+          if [[ -d example_data ]]; then
+            mkdir -p data/
+            cp -r -v example_data/* data/
+          else
+            echo No example data to copy.
+          fi
+
+      - run: nextstrain build --ambient ./pathogen-repo ${{ matrix.build-args }}
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: output-${{ matrix.pathogen }}
+          path: |
+            ./pathogen-repo/auspice/
+            ./pathogen-repo/results/
+            ./pathogen-repo/benchmarks/
+            ./pathogen-repo/logs/
+            ./pathogen-repo/.snakemake/log/
 
   codecov:
     if: github.repository == 'nextstrain/augur'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,10 +94,14 @@ jobs:
         name: coverage
         path: "${{ env.COVERAGE_FILE }}"
 
-  # TODO: Use the central pathogen-repo-ci workflow¹. Currently, this is not
-  # possible because it only supports "stock" docker and conda runtimes.
-  # ¹ https://github.com/nextstrain/.github/blob/-/.github/workflows/pathogen-repo-ci.yaml
-  pathogen-repo-ci:
+  # Replicating pathogen-repo-ci-v0 workflow because we decided not to support
+  # local versions of Augur in the centralized workflow
+  # <https://github.com/nextstrain/.github/issues/66>
+  # This particular jobs is for pathogen repos that do not follow the standard
+  # pathogen repo structure and is not expected to be updated.
+  # Any new pathogen repos should be added to the job replicating the latest version
+  # of the pathogen-repo-ci below.
+  pathogen-repo-ci-v0:
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
@@ -106,26 +110,16 @@ jobs:
       matrix:
         include:
           - { pathogen: avian-flu, build-args: test_target }
-          - { pathogen: ebola }
-          - { pathogen: lassa }
-          - { pathogen: mumps }
           - {
               pathogen: ncov,
               build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci,
             }
-          - { pathogen: rsv }
           - {
               pathogen: seasonal-flu,
               build-args: --configfile profiles/ci/builds.yaml -p,
             }
-          - { pathogen: tb }
 
-          # Disable some pathogens until pathogen-repo-ci supports custom build directories
-          # See issue https://github.com/nextstrain/.github/issues/63
-          # - { pathogen: mpox }
-          # - { pathogen: zika }
-
-    name: pathogen-repo-ci (${{ matrix.pathogen }})
+    name: pathogen-repo-ci-v0 (${{ matrix.pathogen }})
     defaults:
       run:
         shell: bash -l {0}
@@ -182,6 +176,131 @@ jobs:
             ./pathogen-repo/benchmarks/
             ./pathogen-repo/logs/
             ./pathogen-repo/.snakemake/log/
+
+  # Replicating pathogen-repo-ci workflow because we decided not to support
+  # local versions of Augur in the centralized workflow
+  # <https://github.com/nextstrain/.github/issues/66>
+  # This job is for pathogen repos _do_ follow standard pathogen repo structure
+  # and new pathogens should be added here.
+  pathogen-repo-ci:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        pathogen:
+          # XXX TODO: Restore pathogens after they've been updated (ebola, lassa, mumps, rsv, tb)
+          - dengue
+          - measles
+          - mpox
+          - seasonal-cov
+          - zika
+
+    name: pathogen-repo-ci (${{ matrix.pathogen }})
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: ./augur
+
+      - name: Set cache key
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+
+      # Set up a Conda environment that replicates Nextstrain's Conda runtime.
+      - name: Install nextstrain-base from Conda
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          create-args: nextstrain-base
+          condarc: |
+            channels:
+              - nextstrain
+              - conda-forge
+              - bioconda
+            channel_priority: strict
+          cache-environment: true
+          cache-environment-key: ${{ env.DATE }}
+          environment-name: augur
+
+      # Replace the Conda Augur installation with the local version.
+      - run: pip install ./augur
+
+      - uses: actions/checkout@v4
+        with:
+          repository: nextstrain/${{ matrix.pathogen }}
+          path: ./pathogen-repo
+
+      - name: Verify nextstrain-pathogen.yaml file
+        run: >
+          if [[ ! -f './pathogen-repo/nextstrain-pathogen.yaml' ]]; then
+
+            echo "To use this workflow, there must be a 'nextstrain-pathogen.yaml' file present in the repository root";
+            exit 1;
+          fi
+
+      - name: Run ingest
+        if: hashFiles('./pathogen-repo/ingest/Snakefile') && hashFiles('./pathogen-repo/ingest/build-configs/ci/config.yaml')
+        id: ingest
+        run: nextstrain build --ambient ./pathogen-repo/ingest --configfile build-configs/ci/config.yaml
+
+      - name: Run phylogenetic
+        if: hashFiles('./pathogen-repo/phylogenetic/Snakefile') && hashFiles('./pathogen-repo/phylogenetic/build-configs/ci/config.yaml') && !cancelled()
+        id: phylogenetic
+        run: nextstrain build --ambient ./pathogen-repo/phylogenetic --configfile build-configs/ci/config.yaml
+
+      - name: Run nextclade
+        if: hashFiles('./pathogen-repo/nextclade/Snakefile') && hashFiles('./pathogen-repo/nextclade/build-configs/ci/config.yaml') && !cancelled()
+        id: nextclade
+        run: nextstrain build --ambient ./pathogen-repo/nextclade --configfile build-configs/ci/config.yaml
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: output-${{ matrix.pathogen }}
+          if-no-files-found: ignore
+          path: |
+            ./pathogen-repo/ingest/.snakemake/log/
+            ./pathogen-repo/ingest/auspice/
+            ./pathogen-repo/ingest/benchmarks/
+            ./pathogen-repo/ingest/logs/
+            ./pathogen-repo/ingest/results/
+
+            ./pathogen-repo/phylogenetic/.snakemake/log/
+            ./pathogen-repo/phylogenetic/auspice/
+            ./pathogen-repo/phylogenetic/benchmarks/
+            ./pathogen-repo/phylogenetic/logs/
+            ./pathogen-repo/phylogenetic/results/
+
+            ./pathogen-repo/nextclade/.snakemake/log/
+            ./pathogen-repo/nextclade/auspice/
+            ./pathogen-repo/nextclade/benchmarks/
+            ./pathogen-repo/nextclade/logs/
+            ./pathogen-repo/nextclade/results/
+
+      - if: always()
+        name: Verify a workflow ran
+        env:
+          # "outcome" is success/failure/cancelled/skipped _before_
+          # "continue-on-error" is applied to calculate "conclusion"; we no
+          # longer use continue-on-error for these steps, but even so,
+          # conceptually here what we want is outcome not conclusion.
+          ingest: ${{ steps.ingest.outcome }}
+          phylogenetic: ${{ steps.phylogenetic.outcome }}
+          nextclade: ${{ steps.nextclade.outcome }}
+        run: |
+          # Show step outcomes in job logs…
+          echo "ingest        $ingest" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "phylogenetic  $phylogenetic" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "nextclade     $nextclade"| tee -a "$GITHUB_STEP_SUMMARY"
+
+          # Assert status; we're good if we see at least one success and the
+          # rest are success or skipped.
+          [[
+               ($ingest == success || $phylogenetic == success || $nextclade == success)
+            && ($ingest       == success || $ingest       == skipped)
+            && ($phylogenetic == success || $phylogenetic == skipped)
+            && ($nextclade    == success || $nextclade    == skipped)
+          ]]
 
   codecov:
     if: github.repository == 'nextstrain/augur'


### PR DESCRIPTION
## Description of proposed changes

Add comments to clearly show the job `pathogen-repo-ci-v0` is for pathogen repos that do not conform to the standard pathogen repo structure. Since these are tied to an old structure of pathogen repos, the job should not be expected to be updated.

Any new pathogen repos should be added to the `pathogen-repo-ci` job which replicates the centralized `pathogen-repo-ci` GH workflow. Replicating the centralized `pathogen-repo-ci` because we've made the decision to _not_ support ambient Augur version¹

¹ <https://github.com/nextstrain/.github/issues/66>

## Related issue(s)

Related to https://github.com/nextstrain/.github/issues/84

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
