### PR TITLE
Update sphinx-argparse pin to !=0.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,7 @@ setuptools.setup(
             "recommonmark >=0.5.0",
             "Sphinx >=2.0.1",
             "sphinx-autobuild >=2021.3.14",
-            # TODO: Remove sphinx-argparse <0.5.0 pin once upstream build issue is fixed
-            # <https://github.com/sphinx-doc/sphinx-argparse/issues/56>
-            "sphinx-argparse >=0.2.5, <0.5.0",
+            "sphinx-argparse >=0.2.5, !=0.5.0",
             "sphinx-markdown-tables >= 0.0.9",
             "sphinx-rtd-theme >=0.4.3",
             "sphinx-autodoc-typehints >=1.21.4",


### PR DESCRIPTION
## Description of proposed changes

sphinx-argparse version 0.5.1 has been released with a fix to the issue that caused the <0.5.0 pin.

Instead of removing the pin entirely, update it to avoid the bad version.

## Related issue(s)

- Follow-up to #1543

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
