### PR TITLE
Update avian-flu CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { pathogen: avian-flu, build-args: test_target }
+          - { pathogen: avian-flu, build-args: --configfile config/gisaid.yaml -pf test_target }
           - { pathogen: ebola }
           - { pathogen: lassa }
           - { pathogen: mumps }


### PR DESCRIPTION
**Status: Blocked, awaiting merge of <https://github.com/nextstrain/avian-flu/pull/72>**

Mirrors the change in [avian-flu's CI](https://github.com/nextstrain/avian-flu/pull/72)

I ran the CI from this branch which [(as expected) failed](https://github.com/nextstrain/augur/actions/runs/9998964369/job/27638993334) because <https://github.com/nextstrain/avian-flu/pull/72> is not yet merged.
```
FileNotFoundError: [Errno 2] No such file or directory: 'config/gisaid.yaml'
```

While I could make a temporary modification to the CI to checkout the avian-flu repo at the PR's branch/commit, this feels unnecessary. Happy to do so if people feel it's necessary.

