### PR TITLE
Fix titer substitution model tree annotations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,13 @@
 * traits, export v2: `augur traits` now reports all confidence values above 0.1% rather than limiting them to the top 4 results. There is no change in the eventual Auspice dataset as `augur export v2` will still only consider the top 4. [#1512][] (@jameshadfield)
 * curate: Excel (`.xlsx` and `.xls`) and OpenOffice (`.ods`) spreadsheet files are now also supported as metadata inputs (`--metadata`).  The first sheet in the workbook is read as tabular data.  [#1550][] (@tsibley)
 
+### Bug Fixes
+
+* titers sub: Fixes a bug where antigenic weights were assigned to branches for substitutions in the incorrect order of `<derived allele><position><ancestral allele>` instead of `<ancestral allele><position><derived allele>`. [#1555][] (@huddlej)
+
 [#1512]: https://github.com/nextstrain/augur/pull/1512
 [#1550]: https://github.com/nextstrain/augur/pull/1550
+[#1555]: https://github.com/nextstrain/augur/pull/1555
 
 
 ## 25.1.1 (15 July 2024)

--- a/augur/titer_model.py
+++ b/augur/titer_model.py
@@ -1142,7 +1142,7 @@ class SubstitutionModel(TiterModel):
         for node in tree.find_clades():
             for child in node.clades:
                 # Get mutations between the current node and its parent.
-                mutations = self.get_mutations(child.name, node.name)
+                mutations = self.get_mutations(node.name, child.name)
 
                 # Calculate titer drop on the branch to the current node.
                 child.dTiterSub = 0

--- a/tests/functional/titers/cram/titers-sub-with-tree.t
+++ b/tests/functional/titers/cram/titers-sub-with-tree.t
@@ -17,3 +17,11 @@ Test titer substitution model with alignment and tree inputs.
    --- 272 total measurements
   $ grep cTiterSub $TMP/titers-sub.json | wc -l
   \s*120 (re)
+
+Verify that the titer drops assigned per branch correspond to the expected values for this dataset.
+In this example, we know that the HA1 amino acid sequence for A/Fujian/445/2003 carries a S193N substitution and that the titer model assigns a weight of 0.6 to that substitution.
+The titer model assigns a higher weight of 1.22 to the opposite substitution N193S.
+When we search for that sequence's per-branch titer drop, we should get the smaller value below.
+
+  $ grep -A 3 '"A/Fujian/445/2003": {' $TMP/titers-sub.json | grep dTiterSub
+  \s*"dTiterSub": 0.60.* (re)

--- a/tests/functional/titers/cram/titers-sub-with-tree.t
+++ b/tests/functional/titers/cram/titers-sub-with-tree.t
@@ -23,5 +23,5 @@ In this example, we know that the HA1 amino acid sequence for A/Fujian/445/2003 
 The titer model assigns a higher weight of 1.22 to the opposite substitution N193S.
 When we search for that sequence's per-branch titer drop, we should get the smaller value below.
 
-  $ grep -A 3 '"A/Fujian/445/2003": {' $TMP/titers-sub.json | grep dTiterSub
-  \s*"dTiterSub": 0.60.* (re)
+  $ python3 -c 'import json, sys; print(json.load(sys.stdin)["nodes"]["A/Fujian/445/2003"]["dTiterSub"])' < $TMP/titers-sub.json
+  0.60* (glob)


### PR DESCRIPTION
## Description of proposed changes

Fixes a bug in the `augur titers sub` tree annotations in the JSON output where antigenic weights were assigned per branch for the opposite substitution values than expected. Specifically, the bug caused each branch to get the antigenic weight associated with substitutions in the form of `<derived allele><position><ancestral allele>` instead of `<ancestral allele><position><derived allele>`. For example, when the substitution model found antigenic weights for HA1 substitutions N193S and S193N, the tree annotations would have assigned the N193S weight to branches with the S193N substitution.

This commit expands an existing functional test to check for a data-specific antigenic weight. After confirming this test failed, I fixed the bug and confirmed that the test passed.

Note that this bug dates back to December 2018 when [I first added the code to annotate the tree with the substitution model weights](https://github.com/nextstrain/augur/commit/6721b7d67193361b9b41906e7cbc1d0346289350#diff-96cfc90794aa092cbb7b8577ca92d5757a777325d78078da3761ea26ee4c5956R67). This bug had no impact on the accuracy of the underlying model itself, so we would never have noticed it without manually comparing the titer drops in the tree to the "substitution" array in the JSON output.

I found this issue today when I noticed:

1. an antigenic weight of 2.93 associated with HA1:G155E in an H1N1pdm HA dataset
2. a weight of 0.59 associated with the opposite mutation HA1:E155G
3. nodes in the tree with HA1:G155E annotated with the smaller weight

The following screenshot shows what the cumulative antigenic advance from the substitution model looks like for the H1 HA dataset mentioned above before the bug is fixed (note small advance for nodes with HA1:155E):

<img width="1143" alt="image 2" src="https://github.com/user-attachments/assets/59dbbf93-8cfd-43d2-8993-a9d856c7fdbf">

This screenshot shows what the advance looks like after the bug is fixed (note larger advance for 155E nodes):

<img width="1143" alt="image" src="https://github.com/user-attachments/assets/5d0b0462-a507-47c2-8799-c0c1e840313c">

As another point of comparison, here is the scatterplot of the antigenic advance from the tree model on the x-axis and the substitution model on the y-axis with the bug. Note the low correlation value between the data.

<img width="1143" alt="image 3" src="https://github.com/user-attachments/assets/e4fd82aa-a5a4-4a43-928a-cdb33948905f">

Here is the updated scatterplot view after fixing the bug with a much higher correlation between the models.

<img width="1141" alt="image 4" src="https://github.com/user-attachments/assets/201daa99-12b8-4e2a-8949-8dfd1ee9c9d3">

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
