### PR TITLE
Fix curate internal quotes take 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## __NEXT__
 
+### Features
+
+- curate: change output metadata to [RFC 4180 CSV-like TSVs][] to match the TSV format output by other Augur subcommands and the Nextstrain ecosystem as discussed in [#1566][]. [#1565][] (@joverlee521)
+
+[#1565]: https://github.com/nextstrain/augur/pull/1565
+[#1566]: https://github.com/nextstrain/augur/issues/1566
+[RFC 4180 CSV-like TSVs]: https://datatracker.ietf.org/doc/html/rfc4180
 
 ## 26.1.0 (12 November 2024)
 

--- a/augur/io/metadata.py
+++ b/augur/io/metadata.py
@@ -273,7 +273,8 @@ def read_table_to_dict(table, delimiters, duplicate_reporting=DataErrorMethod.ER
                 # change in a future Python version.
                 raise InvalidDelimiter from error
 
-            metadata_reader = csv.DictReader(handle, dialect=dialect)
+            # Only use the dialect delimiter and keep all other default format params
+            metadata_reader = csv.DictReader(handle, delimiter=dialect.delimiter)
 
             columns, records = metadata_reader.fieldnames, iter(metadata_reader)
 

--- a/augur/io/metadata.py
+++ b/augur/io/metadata.py
@@ -549,8 +549,6 @@ def write_records_to_tsv(records, output_file):
             extrasaction='ignore',
             delimiter='\t',
             lineterminator='\n',
-            quoting=csv.QUOTE_NONE,
-            quotechar=None,
         )
         tsv_writer.writeheader()
         tsv_writer.writerow(first_record)

--- a/tests/functional/curate/cram/metadata-output-with-internal-quotes.t
+++ b/tests/functional/curate/cram/metadata-output-with-internal-quotes.t
@@ -12,7 +12,7 @@ Create NDJSON with internal quotes
   > ~~
 
 Test passthru with output to TSV.
-This should not add any quotes around the field with internal quotes.
+This should add double quotes around the internal quotes to match CSV-like quoting.
 
   $ cat records.ndjson \
   >   | ${AUGUR} curate passthru \
@@ -20,10 +20,10 @@ This should not add any quotes around the field with internal quotes.
 
   $ cat output-metadata.tsv
   strain\tsubmitting_lab (esc)
-  sequence_A\tSRC VB "Vector", Molecular Biology of Genomes (esc)
+  sequence_A\t"SRC VB ""Vector"", Molecular Biology of Genomes" (esc)
 
 Run the output TSV through augur curate passthru again.
-The new output should still be identical to the first output.
+The new output should still be identical to the first output because it is already double quoted.
 
   $ ${AUGUR} curate passthru \
   > --metadata output-metadata.tsv \

--- a/tests/io/test_metadata.py
+++ b/tests/io/test_metadata.py
@@ -458,7 +458,7 @@ def output_records():
 def expected_output_tsv():
     return (
         "strain\tcountry\tdate\n"
-        'SEQ_A\t"USA"\t2020-10-01\n'
+        'SEQ_A\t"""USA"""\t2020-10-01\n'
         "SEQ_T\tUSA\t2020-10-02\n"
     )
 


### PR DESCRIPTION
## Description of proposed changes

Follow the general pattern of creating CSV-like TSVs as discussed in https://github.com/nextstrain/augur/pull/1563#discussion_r1699260164. 

We are expecting the CSV-like double quoting when there are internal quotes. If the field value is already correctly double quoted, then there should not be any additional quotes.

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/1312

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
