### PR TITLE
Add a debugging mode controlled by AUGUR_DEBUG

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Features
 
 * Two new commands, `augur read-file` and `augur write-file`, now allow external programs to do i/o like Augur by piping from/to these new commands.  They provide handling of compression formats and newlines consistent with the rest of Augur. [#1562][] (@tsibley)
+* A new debugging mode can be enabled by setting the `AUGUR_DEBUG` environment variable to `1` (or another truthy value).  Currently the only effect is to print more information about handled (i.e. anticipated) errors.  For example, stack traces and parent exceptions in an exception chain are normally omitted for handled errors, but setting this env var includes them.  Future debugging and troubleshooting features, like verbose operation logging, will likely also condition on this new debugging mode. [#1577][] (@tsibley)
 
 ### Bug Fixes
 
@@ -13,6 +14,7 @@
 [#1561]: https://github.com/nextstrain/augur/pull/1561
 [#1562]: https://github.com/nextstrain/augur/pull/1562
 [#1564]: https://github.com/nextstrain/augur/pull/1564
+[#1577]: https://github.com/nextstrain/augur/pull/1577
 
 
 

--- a/augur/debug.py
+++ b/augur/debug.py
@@ -1,0 +1,12 @@
+"""
+Debug flags and utilities.
+
+.. envvar:: AUGUR_DEBUG
+
+    Set to a truthy value (e.g. 1) to print more information about (handled)
+    errors.  For example, when this is not set or falsey, stack traces and
+    parent exceptions in an exception chain are omitted from handled errors.
+"""
+from os import environ
+
+DEBUGGING = bool(environ.get("AUGUR_DEBUG"))

--- a/docs/api/developer/augur.debug.rst
+++ b/docs/api/developer/augur.debug.rst
@@ -1,0 +1,7 @@
+augur.debug module
+==================
+
+.. automodule:: augur.debug
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/developer/augur.rst
+++ b/docs/api/developer/augur.rst
@@ -31,6 +31,7 @@ Submodules
    augur.ancestral
    augur.argparse_
    augur.clades
+   augur.debug
    augur.distance
    augur.errors
    augur.export


### PR DESCRIPTION
At the moment, this only enables printing of stack traces and the full exception chain for handled (i.e. anticipated) errors, which otherwise were not printed.  In the future, this mode can also control the output of verbose debugging/troubleshooting logging for more commands.

Commit contents and message based on similar commits I made to Nextstrain CLI.¹

Resolves <https://github.com/nextstrain/augur/issues/1308>.

¹ <https://github.com/nextstrain/cli/commit/229f2e87ffbf2fd5e1578512b0ff3c1ecc5d4a38>
  <https://github.com/nextstrain/cli/commit/b6d92909b96520ae545bae007a4cce82013fc0fd>
  <https://github.com/nextstrain/cli/pull/208>


## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
