### PR TITLE
merge: Avoid overwriting the output id column with non-id columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,9 @@
 ### Bug Fixes
 
 * filter: Improved warning and error messages in the case of missing columns. [#1604] (@victorlin)
+* merge: Non-id columns in metadata inputs that would conflict with the output id column are now forbidden and will cause an error if present.  Previously they would overwrite values in the output id column, causing incorrect output. [#1593][] (@tsibley)
 
+[#1593]: https://github.com/nextstrain/augur/pull/1593
 [#1604]: https://github.com/nextstrain/augur/pull/1604
 
 ## 25.3.0 (22 August 2024)

--- a/tests/functional/merge/cram/merge.t
+++ b/tests/functional/merge/cram/merge.t
@@ -143,6 +143,29 @@ Metadata field values with metachars (field or record delimiters) are handled pr
   x"	1	1
   two	X2a	X2b	X2c				1	1
 
+Output column renamed when it conflicts with id column.
+
+  $ cat >id-and-strain.csv <<~~
+  > id,strain
+  > one,1
+  > two,2
+  > three,3
+  > ~~
+  $ ${AUGUR} merge \
+  >   --metadata strain-only=x.tsv id-and-strain=id-and-strain.csv \
+  >   --metadata-id-columns id strain \
+  >   --output-metadata - | csv2tsv --csv-delim $'\t' | tsv-pretty
+  ERROR: Non-id column names in metadata inputs may not conflict with the
+  output id column name ('strain', the first input's id column).
+  
+  The following input column would conflict:
+  
+    'strain' in metadata table 'id-and-strain' (id column: 'id')
+  
+  Please rename or drop the conflicting column before merging.
+  Renaming may be done with `augur curate rename`.
+  
+
 
 ERROR HANDLING
 


### PR DESCRIPTION
This edge case occurs when an input table has an id column used for joining (in tests, literally "id", but any valid id column name) and also another, non-id column that matches the output id column name (in tests, literally "strain").

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
