### PR TITLE
merge: Support table-specific id columns and delimiters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,10 @@
 
 * filter: Improved warning and error messages in the case of missing columns. [#1604] (@victorlin)
 * merge: Non-id columns in metadata inputs that would conflict with the output id column are now forbidden and will cause an error if present.  Previously they would overwrite values in the output id column, causing incorrect output. [#1593][] (@tsibley)
+* merge: Table-specific id columns and delimiters may now be specified, e.g. `--metadata-id-columns X=id Y=strain` and `--metadata-delimiters X=, Y=';'`, to allow more precise behaviour and avoid ordering issues. [#1594][] (@tsibley)
 
 [#1593]: https://github.com/nextstrain/augur/pull/1593
+[#1594]: https://github.com/nextstrain/augur/pull/1594
 [#1604]: https://github.com/nextstrain/augur/pull/1604
 
 ## 25.3.0 (22 August 2024)

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -84,8 +84,8 @@ def register_parser(parent_subparsers):
     input_group = parser.add_argument_group("inputs", "options related to input")
     input_group.add_argument("--metadata", nargs="+", action="extend", required=True, metavar="NAME=FILE", help="Required. Metadata table names and file paths. Names are arbitrary monikers used solely for referring to the associated input file in other arguments and in output column names. Paths must be to seekable files, not unseekable streams. Compressed files are supported." + SKIP_AUTO_DEFAULT_IN_HELP)
 
-    input_group.add_argument("--metadata-id-columns", default=DEFAULT_ID_COLUMNS, nargs="+", action=ExtendOverwriteDefault, metavar="COLUMN", help=f"Possible metadata column names containing identifiers, considered in the order given. Columns will be considered for all metadata tables. Only one ID column will be inferred for each table. (default: {' '.join(map(shquote_humanized, DEFAULT_ID_COLUMNS))})" + SKIP_AUTO_DEFAULT_IN_HELP)
-    input_group.add_argument("--metadata-delimiters", default=DEFAULT_DELIMITERS, nargs="+", action=ExtendOverwriteDefault, metavar="CHARACTER", help=f"Possible field delimiters to use for reading metadata tables, considered in the order given. Delimiters will be considered for all metadata tables. Only one delimiter will be inferred for each table. (default: {' '.join(map(shquote_humanized, DEFAULT_DELIMITERS))})" + SKIP_AUTO_DEFAULT_IN_HELP)
+    input_group.add_argument("--metadata-id-columns", default=DEFAULT_ID_COLUMNS, nargs="+", action=ExtendOverwriteDefault, metavar="[TABLE=]COLUMN", help=f"Possible metadata column names containing identifiers, considered in the order given. Columns will be considered for all metadata tables by default. Table-specific column names may be given using the same names assigned in --metadata. Only one ID column will be inferred for each table. (default: {' '.join(map(shquote_humanized, DEFAULT_ID_COLUMNS))})" + SKIP_AUTO_DEFAULT_IN_HELP)
+    input_group.add_argument("--metadata-delimiters", default=DEFAULT_DELIMITERS, nargs="+", action=ExtendOverwriteDefault, metavar="[TABLE=]CHARACTER", help=f"Possible field delimiters to use for reading metadata tables, considered in the order given. Delimiters will be considered for all metadata tables by default. Table-specific delimiters may be given using the same names assigned in --metadata. Only one delimiter will be inferred for each table. (default: {' '.join(map(shquote_humanized, DEFAULT_DELIMITERS))})" + SKIP_AUTO_DEFAULT_IN_HELP)
 
     output_group = parser.add_argument_group("outputs", "options related to output")
     output_group.add_argument('--output-metadata', required=True, metavar="FILE", help="Required. Merged metadata as TSV. Compressed files are supported." + SKIP_AUTO_DEFAULT_IN_HELP)
@@ -110,7 +110,7 @@ def run(args):
               {indented_list(unnamed, '            ' + '  ')}
             """))
 
-    metadata = [name_path.split("=", 1) for name_path in args.metadata]
+    metadata = pairs(args.metadata)
 
     if duplicate_names := [repr(name) for name, count
                                        in count_unique(name for name, _ in metadata)
@@ -124,9 +124,35 @@ def run(args):
             """))
 
 
+    # Parse --metadata-id-columns and --metadata-delimiters
+    metadata_names = set(name for name, _ in metadata)
+
+    metadata_id_columns = pairs(args.metadata_id_columns)
+    metadata_delimiters = pairs(args.metadata_delimiters)
+
+    if unknown_names := [repr(name) for name, _ in metadata_id_columns if name and name not in metadata_names]:
+        raise AugurError(dedent(f"""\
+            Unknown metadata table {_n("name", "names", len(unknown_names))} in --metadata-id-columns:
+
+              {indented_list(unknown_names, '            ' + '  ')}
+
+            {_n("This name does", "These names do", len(unknown_names))} not appear in the NAME=FILE pairs given to --metadata.
+            """))
+
+    if unknown_names := [repr(name) for name, _ in metadata_delimiters if name and name not in metadata_names]:
+        raise AugurError(dedent(f"""\
+            Unknown metadata table {_n("name", "names", len(unknown_names))} in --metadata-delimiters:
+
+              {indented_list(unknown_names, '            ' + '  ')}
+
+            {_n("This name does", "These names do", len(unknown_names))} not appear in the NAME=FILE pairs given to --metadata.
+            """))
+
+
     # Infer delimiters and id columns
     metadata = [
-        NamedMetadata(name, path, args.metadata_delimiters, args.metadata_id_columns)
+        NamedMetadata(name, path, [delim  for name_, delim  in metadata_delimiters if not name_ or name_ == name] or DEFAULT_DELIMITERS,
+                                  [column for name_, column in metadata_id_columns if not name_ or name_ == name] or DEFAULT_ID_COLUMNS)
             for name, path in metadata]
 
 
@@ -332,6 +358,26 @@ def sqlite_quote_string(x):
     <https://www.sqlite.org/lang_expr.html#literal_values_constants_>
     """
     return "'" + x.replace("'", "''") + "'"
+
+
+def pairs(xs: Iterable[str]) -> Iterable[Tuple[str, str]]:
+    """
+    Split an iterable of ``k=v`` strings into an iterable of ``(k,v)`` tuples.
+
+    >>> pairs(["abc=123", "eight nine ten=el em en"])
+    [('abc', '123'), ('eight nine ten', 'el em en')]
+
+    Strings missing a ``k`` and/or a ``v`` part get an empty string.
+
+    >>> pairs(["v", "=v", "k=", "=", ""])
+    [('', 'v'), ('', 'v'), ('k', ''), ('', ''), ('', '')]
+
+    ``k`` ends at the first ``=``.
+
+    >>> pairs(["abc=123=xyz", "=v=v"])
+    [('abc', '123=xyz'), ('', 'v=v')]
+    """
+    return [tuple(x.split("=", 1)) if "=" in x else ("", x) for x in xs] # type: ignore
 
 
 def count_unique(xs: Iterable[T]) -> Iterable[Tuple[T, int]]:

--- a/tests/functional/merge/cram/merge.t
+++ b/tests/functional/merge/cram/merge.t
@@ -79,6 +79,26 @@ Supports --metadata-id-columns.
   two    X2a  X2b  Y2c  Y2f  Y2e  Y2d                    1                    1
   three                 Y3f  Y3e  Y3d                    0                    1
 
+Supports table-specific --metadata-id-columns.
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x-id-column.tsv Y=y.tsv \
+  >   --metadata-id-columns X=id \
+  >   --output-metadata - --quiet | csv2tsv --csv-delim $'\t' | tsv-pretty
+  id     a    b    c    f    e    d    __source_metadata_X  __source_metadata_Y
+  one    X1a  X1b  X1c                                   1                    0
+  two    X2a  X2b  Y2c  Y2f  Y2e  Y2d                    1                    1
+  three                 Y3f  Y3e  Y3d                    0                    1
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y-name-column.tsv \
+  >   --metadata-id-columns strain Y=name \
+  >   --output-metadata - --quiet | csv2tsv --csv-delim $'\t' | tsv-pretty
+  strain  a    b    c    f    e    d    __source_metadata_X  __source_metadata_Y
+  one     X1a  X1b  X1c                                   1                    0
+  two     X2a  X2b  Y2c  Y2f  Y2e  Y2d                    1                    1
+  three                  Y3f  Y3e  Y3d                    0                    1
+
 Supports Augur's standard delimiter detection.
 
   $ sed 's/\t/,/g' < x.tsv > x.csv
@@ -96,6 +116,26 @@ Supports --metadata-delimiters.
   $ ${AUGUR} merge \
   >   --metadata X=x.txt Y=y.tsv \
   >   --metadata-delimiters '|' $'\t' \
+  >   --output-metadata - --quiet | csv2tsv --csv-delim $'\t' | tsv-pretty
+  strain  a    b    c    f    e    d    __source_metadata_X  __source_metadata_Y
+  one     X1a  X1b  X1c                                   1                    0
+  two     X2a  X2b  Y2c  Y2f  Y2e  Y2d                    1                    1
+  three                  Y3f  Y3e  Y3d                    0                    1
+
+Supports table-specific --metadata-delimiters.
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.txt Y=y.tsv \
+  >   --metadata-delimiters X='|' \
+  >   --output-metadata - --quiet | csv2tsv --csv-delim $'\t' | tsv-pretty
+  strain  a    b    c    f    e    d    __source_metadata_X  __source_metadata_Y
+  one     X1a  X1b  X1c                                   1                    0
+  two     X2a  X2b  Y2c  Y2f  Y2e  Y2d                    1                    1
+  three                  Y3f  Y3e  Y3d                    0                    1
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.txt Y=y.tsv \
+  >   --metadata-delimiters $'\t' X='|' \
   >   --output-metadata - --quiet | csv2tsv --csv-delim $'\t' | tsv-pretty
   strain  a    b    c    f    e    d    __source_metadata_X  __source_metadata_Y
   one     X1a  X1b  X1c                                   1                    0
@@ -218,6 +258,60 @@ Duplicates.
   Error: stepping, UNIQUE constraint failed: metadata_dups.strain (19)
   WARNING: Skipped deletion of */augur-merge-*.sqlite due to error, but you may want to clean it up yourself (e.g. if it's large). (glob)
   ERROR: sqlite3 invocation failed
+  [2]
+
+Unknown metadata names in --metadata-delimiters.
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y.tsv \
+  >   --metadata-delimiters $'\t' whatsit=';' \
+  >   --output-metadata -
+  ERROR: Unknown metadata table name in --metadata-delimiters:
+  
+    'whatsit'
+  
+  This name does not appear in the NAME=FILE pairs given to --metadata.
+  
+  [2]
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y.tsv \
+  >   --metadata-delimiters whatsit=';' whosit=, X=$'\t' Y=$'\t' \
+  >   --output-metadata -
+  ERROR: Unknown metadata table names in --metadata-delimiters:
+  
+    'whatsit'
+    'whosit'
+  
+  These names do not appear in the NAME=FILE pairs given to --metadata.
+  
+  [2]
+
+Unknown metadata names in --metadata-id-columns.
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y.tsv \
+  >   --metadata-id-columns strain whatsit=id \
+  >   --output-metadata -
+  ERROR: Unknown metadata table name in --metadata-id-columns:
+  
+    'whatsit'
+  
+  This name does not appear in the NAME=FILE pairs given to --metadata.
+  
+  [2]
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y.tsv \
+  >   --metadata-id-columns whatsit=id whosit=accession X=strain Y=strain \
+  >   --output-metadata -
+  ERROR: Unknown metadata table names in --metadata-id-columns:
+  
+    'whatsit'
+    'whosit'
+  
+  These names do not appear in the NAME=FILE pairs given to --metadata.
+  
   [2]
 
 No id column found.


### PR DESCRIPTION
When trying out `augur merge` for our common Nextclade metadata merge step¹, I realized it would be good to allow table-specific values for these settings.

Table-specific values avoid problems with impossible orderings, e.g. two files both have columns A and B but you want to use A as the id column in the first and B in the second.  Maybe that's an edge case, but it's also just much easier to reason about table-specific values than reason about how an ordered list of N values applies to all M files.  A shared list of values is still good for when you don't know what they'll be ahead of time.

¹ <https://github.com/nextstrain/pathogen-repo-guide/blob/89b3c5dbc9b8f6a009f4a19c3ac56113bc5511ee/ingest/rules/nextclade.smk#L75-L95>


## Checklist

- [x] Add tests for error messages I missed (see coverage)
- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
