### PR TITLE
merge: Ignore the user's ~/.sqliterc file, if any

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,10 @@
 ### Bug Fixes
 
 * filter: Improved warning and error messages in the case of missing columns. [#1604] (@victorlin)
+* merge: Any user-customized `~/.sqliterc` file is now ignored so it doesn't break `augur merge`'s internal use of SQLite. [#1608][] (@tsibley)
 
 [#1604]: https://github.com/nextstrain/augur/pull/1604
+[#1608]: https://github.com/nextstrain/augur/pull/1608
 
 ## 25.3.0 (22 August 2024)
 

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -258,7 +258,7 @@ def sqlite3(*args, **kwargs):
             Nextstrain runtime.
             """))
 
-    argv = [sqlite3, "-batch", *args]
+    argv = [sqlite3, "-init", os.devnull, "-batch", *args]
 
     print_debug(f"running {argv!r}")
     proc = subprocess.run(argv, encoding="utf-8", text=True, **kwargs)


### PR DESCRIPTION
By default that file is evaluated by the SQLite CLI when it starts, and the user may have commands in it that affect default CLI behaviour we rely upon, such as .mode.  Since it's hard to know exactly how to reset to a "pristine" settings state, avoid the user's rc file entirely.

Resolves: <https://github.com/nextstrain/augur/issues/1603>

## Checklist

- [x] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
