### PR TITLE
Properly upload coverage file with upload-artifact v4.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: coverage
+        include-hidden-files: true
         path: "${{ env.COVERAGE_FILE }}"
 
   # Replicating pathogen-repo-ci workflow because we decided not to support


### PR DESCRIPTION
## Description of proposed changes

[v4.4.0 introduces a breaking change](https://github.com/actions/upload-artifact/issues/602) which prevents hidden files from being uploaded, which includes the standard .coverage filename. The coverage file could be easily renamed, but it's also easy to keep the existing name and upload the hidden file explicitly.

## Related issue(s)

Closes #1616

## Checklist

- [x] Codecov artifact upload/download is working in CI
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
