### PR TITLE
filter: Deprecate `--output` and `-o`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,9 +13,11 @@
 * filter: Fixed an error with weighted sampling by `year`. [#1776][] (@victorlin)
 * filter: Previously, subsampling with `--group-by` `year` or `month` would crash on numeric dates. This has been fixed by switching to the same internal date parsing function that is used by other commands. [#1774][] (@victorlin)
 * filter: Made a small adjustment to use pandas's `"string"` dtype alias when processing values in metadata. [#1782][] (@victorlin)
+* filter: Options `--output` and `-o` have been deprecated and will now show a warning message. See [DEPRECATED.md](./DEPRECATED.md) for details. [#1622][] (@victorlin)
 * Updated outdated documentation on supported date formats in metadata. [#882][] (@victorlin)
 
 [#882]: https://github.com/nextstrain/augur/issues/882
+[#1622]: https://github.com/nextstrain/augur/pull/1622
 [#1756]: https://github.com/nextstrain/augur/pull/1756
 [#1769]: https://github.com/nextstrain/augur/pull/1769
 [#1772]: https://github.com/nextstrain/augur/pull/1772

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -4,6 +4,13 @@ These features are deprecated, which means they are no longer maintained and
 will go away in a future major version of Augur. They are currently still
 available for backwards compatibility, but should not be used in new code.
 
+## `augur filter` options `--output` and `-o`
+
+*Deprecated in version 29.1.0. Planned for removal October 2025 or after.*
+
+`--output` and `-o` are aliases to `--output-sequences`. They will be removed to
+avoid confusion with other output options.
+
 ## `xopen` major version 1
 
 *Deprecated in version 25.1.0 (July 2024). Removed in version 27.0.0 (December 2024).*

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -1,10 +1,11 @@
 """
 Filter and subsample a sequence set.
 """
-from augur.argparse_ import ExtendOverwriteDefault
+from augur.argparse_ import ExtendOverwriteDefault, SKIP_AUTO_DEFAULT_IN_HELP
 from augur.dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT
 from augur.filter.io import ACCEPTED_TYPES, column_type_pair
 from augur.io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, METADATA_DATE_COLUMN
+from augur.io.print import print_err
 from augur.types import EmptyOutputReportingMethod
 from . import constants
 
@@ -101,8 +102,8 @@ def register_arguments(parser):
     Since priorities represent relative values between strains, these values can be arbitrary.""")
     subsample_group.add_argument('--subsample-seed', type=int, help="random number generator seed to allow reproducible subsampling (with same input data).")
 
-    output_group = parser.add_argument_group("outputs", "options related to outputs, at least one of the possible representations of filtered data (--output, --output-metadata, --output-strains) is required")
-    output_group.add_argument('--output', '--output-sequences', '-o', help="filtered sequences in FASTA format", dest="output_sequences")
+    output_group = parser.add_argument_group("outputs", "options related to outputs, at least one of the possible representations of filtered data (--output-sequences, --output-metadata, --output-strains) is required")
+    output_group.add_argument('--output-sequences', help="filtered sequences in FASTA format")
     output_group.add_argument('--output-metadata', help="metadata for strains that passed filters")
     output_group.add_argument('--output-strains', help="list of strains that passed filters (no header)")
     output_group.add_argument('--output-log', help="tab-delimited file with one row for each filtered strain and the reason it was filtered. Keyword arguments used for a given filter are reported in JSON format in a `kwargs` column.")
@@ -113,6 +114,10 @@ def register_arguments(parser):
         choices=list(EmptyOutputReportingMethod),
         default=EmptyOutputReportingMethod.ERROR,
         help="How should empty outputs be reported when no strains pass filtering and/or subsampling.")
+
+    deprecated_group = parser.add_argument_group("deprecated", "options to be removed in a future major version")
+    deprecated_group.add_argument('--output', metavar="FILE", help="alias to --output-sequences" + SKIP_AUTO_DEFAULT_IN_HELP)
+    deprecated_group.add_argument('-o', metavar="FILE", help="alias to --output-sequences" + SKIP_AUTO_DEFAULT_IN_HELP)
 
     parser.set_defaults(probabilistic_sampling=True)
 
@@ -127,6 +132,13 @@ def run(args):
     '''
     filter and subsample a set of sequences into an analysis set
     '''
+    if args.o:
+        print_err("WARNING: -o is deprecated. Use --output-sequences instead.")
+        args.output_sequences = args.o
+    if args.output:
+        print_err("WARNING: --output is deprecated. Use --output-sequences instead.")
+        args.output_sequences = args.output
+
     from .validate_arguments import validate_arguments
     # Validate arguments before attempting any I/O.
     validate_arguments(args)

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -102,7 +102,7 @@ def register_arguments(parser):
     subsample_group.add_argument('--subsample-seed', type=int, help="random number generator seed to allow reproducible subsampling (with same input data).")
 
     output_group = parser.add_argument_group("outputs", "options related to outputs, at least one of the possible representations of filtered data (--output, --output-metadata, --output-strains) is required")
-    output_group.add_argument('--output', '--output-sequences', '-o', help="filtered sequences in FASTA format")
+    output_group.add_argument('--output', '--output-sequences', '-o', help="filtered sequences in FASTA format", dest="output_sequences")
     output_group.add_argument('--output-metadata', help="metadata for strains that passed filters")
     output_group.add_argument('--output-strains', help="list of strains that passed filters (no header)")
     output_group.add_argument('--output-log', help="tab-delimited file with one row for each filtered strain and the reason it was filtered. Keyword arguments used for a given filter are reported in JSON format in a `kwargs` column.")

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -377,10 +377,10 @@ def run(args):
     # to update the set of strains to keep based on which strains are actually
     # available.
     if is_vcf:
-        if args.output:
+        if args.output_sequences:
             # Get the samples to be deleted, not to keep, for VCF
             dropped_samps = list(sequence_strains - valid_strains)
-            write_vcf(args.sequences, args.output, dropped_samps)
+            write_vcf(args.sequences, args.output_sequences, dropped_samps)
     elif args.sequences:
         # If the user requested sequence output, stream to disk all sequences
         # that passed all filters to avoid reading sequences into memory first.
@@ -389,14 +389,14 @@ def run(args):
         # single pass to allow comparison with the provided sequence index.
         observed_sequence_strains = set()
         duplicates = set()
-        with open_file(args.output, "wt") if args.output else nullcontext() as output_handle:
+        with open_file(args.output_sequences, "wt") if args.output_sequences else nullcontext() as output_handle:
             for sequence in read_sequences(args.sequences):
                 if sequence.id in observed_sequence_strains:
                     duplicates.add(sequence.id)
 
                 observed_sequence_strains.add(sequence.id)
 
-                if args.output:
+                if args.output_sequences:
                     if sequence.id in valid_strains:
                         write_sequences(sequence, output_handle, 'fasta')
 

--- a/augur/filter/io.py
+++ b/augur/filter/io.py
@@ -160,8 +160,8 @@ def column_type_pair(input: str):
 
 def cleanup_outputs(args):
     """Remove output files. Useful when terminating midway through a loop of metadata chunks."""
-    if args.output:
-        _try_remove(args.output)
+    if args.output_sequences:
+        _try_remove(args.output_sequences)
     if args.output_metadata:
         _try_remove(args.output_metadata)
     if args.output_strains:

--- a/augur/filter/validate_arguments.py
+++ b/augur/filter/validate_arguments.py
@@ -19,11 +19,11 @@ def validate_arguments(args):
         Parsed arguments from argparse
     """
     # Don't allow sequence output when no sequence input is provided.
-    if args.output and not args.sequences:
+    if args.output_sequences and not args.sequences:
         raise AugurError("You need to provide sequences to output sequences.")
 
     # Confirm that at least one output was requested.
-    if not any((args.output, args.output_metadata, args.output_strains)):
+    if not any((args.output_sequences, args.output_metadata, args.output_strains)):
         raise AugurError("You need to select at least one output.")
 
     # Don't allow filtering on sequence-based information, if no sequences or

--- a/tests/functional/filter/cram/filter-deprecated-options.t
+++ b/tests/functional/filter/cram/filter-deprecated-options.t
@@ -1,0 +1,56 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create files
+
+  $ cat >metadata.tsv <<~~
+  > strain	col1
+  > SEQ1	A
+  > SEQ2	B
+  > ~~
+
+  $ cat >sequences.fasta <<~~
+  > >SEQ1
+  > AAAA
+  > >SEQ2
+  > AAAA
+  > >SEQ3
+  > AAAA
+  > ~~
+
+--output alias to --output-sequences
+
+  $ ${AUGUR} filter \
+  >   --metadata metadata.tsv \
+  >   --sequences sequences.fasta \
+  >   --output filtered.fasta
+  WARNING: --output is deprecated. Use --output-sequences instead.
+  Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
+  1 strain was dropped during filtering
+  	1 had no metadata
+  2 strains passed all filters
+
+  $ cat filtered.fasta
+  >SEQ1
+  AAAA
+  >SEQ2
+  AAAA
+
+-o alias to --output-sequences
+
+  $ ${AUGUR} filter \
+  >   --metadata metadata.tsv \
+  >   --sequences sequences.fasta \
+  >   -o filtered.fasta
+  WARNING: -o is deprecated. Use --output-sequences instead.
+  Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
+  1 strain was dropped during filtering
+  	1 had no metadata
+  2 strains passed all filters
+
+  $ cat filtered.fasta
+  >SEQ1
+  AAAA
+  >SEQ2
+  AAAA

--- a/tests/functional/filter/cram/filter-output-strains-no-sequence-error.t
+++ b/tests/functional/filter/cram/filter-output-strains-no-sequence-error.t
@@ -9,6 +9,6 @@ This should fail.
   >  --sequence-index "$TESTDIR/../data/sequence_index.tsv" \
   >  --metadata "$TESTDIR/../data/metadata.tsv" \
   >  --min-length 10000 \
-  >  --output filtered.fasta > /dev/null
+  >  --output-sequences filtered.fasta > /dev/null
   ERROR: You need to provide sequences to output sequences.
   [2]

--- a/tests/functional/filter/cram/filter-sequences-vcf.t
+++ b/tests/functional/filter/cram/filter-sequences-vcf.t
@@ -8,7 +8,7 @@ Filter TB strains from VCF and save as a list of filtered strains.
   >  --sequences "$TESTDIR/../data/tb.vcf.gz" \
   >  --metadata "$TESTDIR/../data/tb_metadata.tsv" \
   >  --min-date 2012 \
-  >  --output filtered.vcf \
+  >  --output-sequences filtered.vcf \
   >  --output-strains filtered_strains.txt > /dev/null
   Note: You did not provide a sequence index, so Augur will generate one. You can generate your own index ahead of time with `augur index` and pass it with `augur filter --sequence-index`.
   162 strains were dropped during filtering

--- a/tests/functional/filter/cram/subsample-max-sequences-no-probabilistic-sampling-error.t
+++ b/tests/functional/filter/cram/subsample-max-sequences-no-probabilistic-sampling-error.t
@@ -13,6 +13,6 @@ This should fail, as probabilistic sampling is explicitly disabled.
   >  --subsample-max-sequences 5 \
   >  --subsample-seed 314159 \
   >  --no-probabilistic-sampling \
-  >  --output filtered.fasta
+  >  --output-sequences filtered.fasta
   ERROR: Asked to provide at most 5 sequences, but there are 8 groups.
   [2]


### PR DESCRIPTION
## Description of proposed changes

`--output` and `-o` are aliases to `--output-sequences`. They will be removed to avoid confusion with other output options.

## Related issue(s)

Closes #1607

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
