### PR TITLE
merge: Support changing the names of, or omitting entirely, the generated source columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,17 @@
 
 ## __NEXT__
 
+### Features
+
+* merge: Generated source columns (e.g. `__source_metadata_{NAME}`) may now have their name template changed with `--source-columns=TEMPLATE` or may be omitted entirely with `--no-source-columns`. [#1625][] (@tsibley)
+
 ### Bug Fixes
 
 * filter: Previously, when `--subsample-max-sequences` was slightly lower than the number of groups, it was possible to fail with an uncaught `AssertionError`. Internal calculations have been adjusted to prevent this from happening. [#1588][] [#1598][] (@victorlin)
 
 [#1588]: https://github.com/nextstrain/augur/issues/1588
 [#1598]: https://github.com/nextstrain/augur/issues/1598
+[#1625]: https://github.com/nextstrain/augur/issues/1625
 
 ## 25.4.0 (3 September 2024)
 

--- a/tests/functional/merge/cram/merge.t
+++ b/tests/functional/merge/cram/merge.t
@@ -184,6 +184,28 @@ Metadata field values with metachars (field or record delimiters) are handled pr
   x"	1	1
   two	X2a	X2b	X2c				1	1
 
+Source columns template.
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y.tsv \
+  >   --source-columns 'origin_{NAME}' \
+  >   --output-metadata - --quiet | csv2tsv --csv-delim $'\t' | tsv-pretty
+  strain  a    b    c    f    e    d    origin_X  origin_Y
+  one     X1a  X1b  X1c                        1         0
+  two     X2a  X2b  Y2c  Y2f  Y2e  Y2d         1         1
+  three                  Y3f  Y3e  Y3d         0         1
+
+No source columns.
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y.tsv \
+  >   --no-source-columns \
+  >   --output-metadata - --quiet | csv2tsv --csv-delim $'\t' | tsv-pretty
+  strain  a    b    c    f    e    d
+  one     X1a  X1b  X1c            
+  two     X2a  X2b  Y2c  Y2f  Y2e  Y2d
+  three                  Y3f  Y3e  Y3d
+
 
 ERROR HANDLING
 
@@ -322,6 +344,52 @@ Non-id column names conflicting with output id column name.
   
   Please rename or drop the conflicting column before merging.
   Renaming may be done with `augur curate rename`.
+  
+  [2]
+
+Invalid source columns template.
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y.tsv \
+  >   --source-columns 'nope' \
+  >   --output-metadata /dev/null --quiet
+  ERROR: The --source-columns template must contain the literal
+  placeholder {NAME} but the given value ('nope') does not.
+  
+  You may need to quote the whole template value to prevent your
+  shell from interpreting the placeholder before Augur sees it.
+  
+  [2]
+
+  $ ${AUGUR} merge \
+  >   --metadata X=x.tsv Y=y.tsv \
+  >   --source-columns '' \
+  >   --output-metadata /dev/null --quiet
+  ERROR: The --source-columns template must contain the literal
+  placeholder {NAME} but the given value ('') does not.
+  
+  You may need to quote the whole template value to prevent your
+  shell from interpreting the placeholder before Augur sees it.
+  
+  [2]
+
+  $ ${AUGUR} merge \
+  >   --metadata a=x.tsv b=y.tsv \
+  >   --source-columns '{NAME}' \
+  >   --output-metadata /dev/null --quiet
+  ERROR: Generated source column names may not conflict with any column
+  names in metadata inputs.
+  
+  The given source column template ('{NAME}') with the
+  given metadata table names would conflict with the following input
+  columns:
+  
+    'a' in metadata table 'a'
+    'b' in metadata table 'a'
+    'b' in metadata table 'b'
+  
+  Please adjust the source column template with --source-columns
+  and/or adjust the metadata table names to avoid conflicts.
   
   [2]
 


### PR DESCRIPTION
This lets us more easily use `augur merge` in places where it makes no sense to include the generated source columns (e.g. in the Nextclade metadata merge step of our workflows) and in places where we have existing source column names we want to match (e.g. in ncov, replacing the bespoke combine_metadata.py).

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
