### PR TITLE
Run release from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,12 @@ on:
 
   workflow_dispatch:
 
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
 jobs:
   mypy:
     runs-on: ubuntu-latest
@@ -348,3 +354,51 @@ jobs:
             echo "If there are changes to the Augur CLI, please manually adjust files under 'docs/usage/cli/'." >&2
             exit 1
           fi
+
+  release:
+    # Only run when called by the release workflow on the default branch
+    if: github.event_name == 'workflow_call' && github.workflow_ref == format('{0}/.github/workflows/release.yaml@refs/heads/{1}', github.repository, github.event.repository.default_branch)
+    needs: [pytest-cram]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch all branches and tags.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Set Nextstrain bot as git user
+        run: |
+          git config --global user.email "hello@nextstrain.org"
+          git config --global user.name "Nextstrain bot"
+      - run: python3 -m pip install --upgrade build twine
+      - run: devel/release ${{ github.event.inputs.version }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - run: git push origin master tag ${{ github.event.inputs.version }}
+      - name: Publish to PyPI
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+      - name: Create GitHub Release
+        run: ./devel/create-github-release "${{github.event.inputs.version }}" dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  rebuild-docker-image:
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+    # Delay for 10 minutes to allow the PyPI package to be available.
+    # See https://github.com/nextstrain/docker-base/issues/128
+    - name: Sleep for 10 minutes
+      run: sleep 600
+      shell: bash
+    - run: gh workflow run ci.yml --repo nextstrain/docker-base
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,46 +10,6 @@ on:
         type: string
 jobs:
   run:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # Fetch all branches and tags.
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - name: Set Nextstrain bot as git user
-        run: |
-          git config --global user.email "hello@nextstrain.org"
-          git config --global user.name "Nextstrain bot"
-      - run: python3 -m pip install --upgrade build twine
-      - run: devel/release ${{ github.event.inputs.version}}
-      - run: devel/test
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-      - run: git push origin master tag ${{ github.event.inputs.version}}
-      - name: Publish to PyPI
-        run: twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
-      - name: Create GitHub Release
-        run: ./devel/create-github-release "${{github.event.inputs.version}}" dist/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  rebuild-docker-image:
-    needs: [run]
-    runs-on: ubuntu-latest
-    steps:
-    # Delay for 10 minutes to allow the PyPI package to be available.
-    # See https://github.com/nextstrain/docker-base/issues/128
-    - name: Sleep for 10 minutes
-      run: sleep 600
-      shell: bash
-    - run: gh workflow run ci.yml --repo nextstrain/docker-base
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
+    uses: ./.github/workflows/ci.yaml
+    with:
+      version: ${{ inputs.version }}


### PR DESCRIPTION
## Description of proposed changes

This leverages the existing test matrix setup for CI which can sufficiently replace devel/test. A downside is that it does not test the changes created by devel/release, but those should not have an impact on test results.

## Related issue(s)

Closes #1633

## Checklist

- [x] Automated checks pass
- [x] `release` job is skipped for PR run
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [ ] Post-merge: next release happens successfully
- [ ] Post-merge: create issue for further improvements to release process ([ref](https://github.com/nextstrain/augur/pull/1634#pullrequestreview-2316684982))

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
