### PR TITLE
Set pipefail for Cram tests

### DIFF
--- a/tests/functional/_setup.sh
+++ b/tests/functional/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../bin/augur}"
+set -o pipefail

--- a/tests/functional/ancestral/cram/_setup.sh
+++ b/tests/functional/ancestral/cram/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
+set -o pipefail

--- a/tests/functional/curate/cram/_setup.sh
+++ b/tests/functional/curate/cram/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
+set -o pipefail

--- a/tests/functional/curate/cram/validate-records.t
+++ b/tests/functional/curate/cram/validate-records.t
@@ -25,7 +25,6 @@ error when it encounters the record with mismatched fields.
 Passing the records through multiple augur curate commands should raise the
 same error when it encounters the record with mismatched fields.
 
-  $ set -o pipefail
   $ cat records.ndjson \
   >   | ${AUGUR} curate passthru \
   >   | ${AUGUR} curate passthru \

--- a/tests/functional/export_v2/cram/_setup.sh
+++ b/tests/functional/export_v2/cram/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
+set -o pipefail

--- a/tests/functional/filter/cram/_setup.sh
+++ b/tests/functional/filter/cram/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
+set -o pipefail

--- a/tests/functional/filter/cram/filter-mismatched-sequences-error.t
+++ b/tests/functional/filter/cram/filter-mismatched-sequences-error.t
@@ -39,6 +39,7 @@ Repeat with sequence and strain outputs. We should get the same results.
   \s*0 .* (re)
   $ grep "^>" filtered.fasta | wc -l
   \s*0 (re)
+  [1]
 
 Repeat without any sequence-based filters.
 Since we expect metadata to be filtered by presence of strains in input sequences, this should produce no results because the intersection of metadata and sequences is empty.

--- a/tests/functional/frequencies/cram/_setup.sh
+++ b/tests/functional/frequencies/cram/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
+set -o pipefail

--- a/tests/functional/merge/cram/_setup.sh
+++ b/tests/functional/merge/cram/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
+set -o pipefail

--- a/tests/functional/merge/cram/merge.t
+++ b/tests/functional/merge/cram/merge.t
@@ -1,7 +1,6 @@
 SETUP
 
   $ source "$TESTDIR"/_setup.sh
-  $ set -o pipefail
 
 
 BASIC USAGE

--- a/tests/functional/parse.t
+++ b/tests/functional/parse.t
@@ -107,6 +107,7 @@ This should use the first field as the id field and the metadata should not have
   - strain\tvirus\taccession\tdate\tregion\tcountry\tdivision\tcity\tdb\tsegment\tauthors\turl\ttitle\tjournal\tpaper_url (esc)
   ---
   + col1\tvirus\tcol3\tdate\tregion\tcountry\tdivision\tcity\tdb\tsegment\tauthors\turl\ttitle\tjournal\tpaper_url (esc)
+  [1]
   $ rm -f "$TMP/sequences.fasta" "$TMP/metadata.tsv"
 
 Parse compressed Zika sequences into sequences and metadata.

--- a/tests/functional/refine/cram/_setup.sh
+++ b/tests/functional/refine/cram/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
+set -o pipefail

--- a/tests/functional/titers/cram/_setup.sh
+++ b/tests/functional/titers/cram/_setup.sh
@@ -1,2 +1,3 @@
 pushd "$TESTDIR" > /dev/null
 export AUGUR="${AUGUR:-../../../../bin/augur}"
+set -o pipefail

--- a/tests/functional/translate/cram/_setup.sh
+++ b/tests/functional/translate/cram/_setup.sh
@@ -1,2 +1,3 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
 export SCRIPTS="$TESTDIR/../../../../scripts"
+set -o pipefail

--- a/tests/functional/tree/cram/_setup.sh
+++ b/tests/functional/tree/cram/_setup.sh
@@ -1,1 +1,2 @@
 export AUGUR="${AUGUR:-$TESTDIR/../../../../bin/augur}"
+set -o pipefail


### PR DESCRIPTION
## Description of proposed changes

This was added in places where it's been necessary. Setting it globally simplifies tests and allows future tests to use pipes without the need to set pipefail explicitly.

## Related issue(s)

- Closes #1627

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [x] Merge base PR #1637 

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
