### PR TITLE
index: Allow FileNotFoundError to be handled at the top level

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* index: Previously specifying a directory that does not exist in the path to `--output` would result in an incorrect error stating that the input file does not exist. It now shows the correct path responsible for the error. [#1644][] (@victorlin)
+
+[#1644]: https://github.com/nextstrain/augur/issues/1644
 
 ## 26.0.0 (17 September 2024)
 

--- a/augur/index.py
+++ b/augur/index.py
@@ -2,7 +2,6 @@
 """
 
 from itertools import combinations
-import sys
 import csv
 
 from .io.file import open_file
@@ -209,15 +208,11 @@ def run(args):
     ("?" and "-"), and other invalid characters in a set of sequences and write
     the composition as a data frame to the given sequence index path.
     '''
-    try:
-        if is_vcf(args.sequences):
-            num_of_seqs = index_vcf(args.sequences, args.output)
-            tot_length = None
-        else:
-            num_of_seqs, tot_length = index_sequences(args.sequences, args.output)
-    except FileNotFoundError:
-        print(f"ERROR: Could not open sequences file '{args.sequences}'.", file=sys.stderr)
-        return 1
+    if is_vcf(args.sequences):
+        num_of_seqs = index_vcf(args.sequences, args.output)
+        tot_length = None
+    else:
+        num_of_seqs, tot_length = index_sequences(args.sequences, args.output)
 
     if args.verbose:
         if tot_length:

--- a/tests/functional/index.t
+++ b/tests/functional/index.t
@@ -18,7 +18,16 @@ This should fail.
   $ ${AUGUR} index \
   >   --sequences index/missing_sequences.fasta \
   >   --output "$TMP/sequence_index.tsv"
-  ERROR: Could not open sequences file 'index/missing_sequences.fasta'.
-  [1]
+  ERROR: No such file or directory: 'index/missing_sequences.fasta'
+  [2]
+
+Try writing output to a directory that does not exist.
+This should fail.
+
+  $ ${AUGUR} index \
+  >   --sequences index/sequences.fasta \
+  >   --output "results/sequence_index.tsv"
+  ERROR: No such file or directory: 'results/sequence_index.tsv'
+  [2]
 
   $ popd > /dev/null


### PR DESCRIPTION
## Description of proposed changes

The removed error handling is flawed: it assumes that FileNotFoundError can only come from a missing input file (--sequences). The reality is that FileNotFoundError can also come from a missing output directory (--output). The top-level exception handler parses the filepath from the error directly, which is accurate.

## Related issue(s)

Fixes #1644

## Checklist

- [x] Automated checks pass (except unrelated docs build)
- [x] [Check][1] if you need to add a changelog message
- [x] ~[Check][2] if you need to add tests~ tested locally that this works. I don't think adding a test is necessary in this case
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
