### PR TITLE
docs: Allow BUILDDIR to be set from environment

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -7,8 +7,10 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
+if "%BUILDDIR%" == "" (
+	set BUILDDIR=_build
+)
 set SOURCEDIR=.
-set BUILDDIR=_build
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
Follow-up to #1650 where I forgot the existence of the make.bat file.

## Checklist

- [x] ~Checks pass~ changes are not checked