### PR TITLE
pyright: Use basic ruleset explicitly

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -6,7 +6,10 @@
   "include": ["augur/"],
 
 
-  // These are rules that are enabled by default and currently have violations.
+  "typeCheckingMode": "basic",
+
+  // These rules are enabled by the above checking mode and currently have
+  // violations.
 
   // TODO: go through these exceptions and determine if they should be kept or
   // removed and violations addressed.


### PR DESCRIPTION
## Description of proposed changes

This is the default for pyright but not [basedpyright](https://docs.basedpyright.com/latest/benefits-over-pyright/better-defaults/#typecheckingmode), a fork of Pyright that I am using. Setting explicitly also provides more context for the following rule exceptions.

## Related issue(s)

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
