### PR TITLE
release: Remove condition on event_name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -357,7 +357,7 @@ jobs:
 
   release:
     # Only run when called by the release workflow on the default branch
-    if: github.event_name == 'workflow_call' && github.workflow_ref == format('{0}/.github/workflows/release.yaml@refs/heads/{1}', github.repository, github.event.repository.default_branch)
+    if: github.workflow_ref == format('{0}/.github/workflows/release.yaml@refs/heads/{1}', github.repository, github.event.repository.default_branch)
     needs: [pytest-cram]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description of proposed changes

This was flawed: even though ci.yaml is called by another workflow, the `github` context is [associated with the caller workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) so event_name is "workflow_dispatch" during a release run.

It doesn't make sense to update the condition to match "workflow_dispatch", since there are valid reasons for running ci.yaml using workflow_dispatch.

I think it makes more sense to simply remove this half of the condition as [redundant](https://github.com/nextstrain/augur/pull/1634#discussion_r1769243371). The other half of the condition sufficiently ensures that the job is run only when called by the release workflow on the default branch.

## Related issue(s)

Fixes #1674

## Checklist

- [x] ~Automated checks pass~ N/A
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [ ] Post-merge: next release happens successfully

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
