### PR TITLE
Pass secrets to release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,5 +11,6 @@ on:
 jobs:
   run:
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
## Description of proposed changes

The release workflow needs to specify `secrets: inherit` so that the release job in the called workflow can access secrets to do its thing.

## Related issue(s)

Fixes #1674

## Checklist

- [x] ~Automated checks pass~ N/A
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [ ] Post-merge: next release happens successfully

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update
