### PR TITLE
Support Python 3.12 and test in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
         biopython-version:
           # list of Biopython versions with support for a new Python version
           # from https://github.com/biopython/biopython/blob/master/NEWS.rst
-          - '1.80' # first to support Python 3.10 and 3.11
+          - '1.82' # first to support Python 3.10 and 3.11
           - ''     # latest
     defaults:
       run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
+          - '3.13'
         biopython-version:
           # list of Biopython versions with support for a new Python version
           # from https://github.com/biopython/biopython/blob/master/NEWS.rst

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,11 +46,15 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
-        biopython-version:
-          # list of Biopython versions with support for a new Python version
-          # from https://github.com/biopython/biopython/blob/master/NEWS.rst
+        biopython-version: 
+          # list of Biopython versions with support for a new Python version 
+          # from https://github.com/biopython/biopython/blob/master/NEWS.rst 
+          - '1.80' # first to support Python 3.10 and 3.11
           - '1.82' # first to support Python 3.12
-          - ''     # latest
+          - ''     # latest 
+        exclude: 
+          # some older Biopython versions are incompatible with later Python versions 
+          - { biopython-version: '1.80', python-version: '3.12' }
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
         biopython-version:
           # list of Biopython versions with support for a new Python version
           # from https://github.com/biopython/biopython/blob/master/NEWS.rst
-          - '1.82' # first to support Python 3.10 and 3.11
+          - '1.82' # first to support Python 3.12
           - ''     # latest
     defaults:
       run:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,6 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
-          - '3.13'
         biopython-version:
           # list of Biopython versions with support for a new Python version
           # from https://github.com/biopython/biopython/blob/master/NEWS.rst

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,14 +4,15 @@
 
 ### Features
 
-- support pandas v2. [#1671] (@corneliusroemer and @victorlin)
+- support Python 3.12 (@corneliusroemer)
+- support Pandas v2. [#1671] (@corneliusroemer and @victorlin)
 - curate: change output metadata to [RFC 4180 CSV-like TSVs][] to match the TSV format output by other Augur subcommands and the Nextstrain ecosystem as discussed in [#1566][]. [#1565][] (@joverlee521)
-
 
 [#1565]: https://github.com/nextstrain/augur/pull/1565
 [#1566]: https://github.com/nextstrain/augur/issues/1566
 [RFC 4180 CSV-like TSVs]: https://datatracker.ietf.org/doc/html/rfc4180
 [#1671]: https://github.com/nextstrain/augur/pull/1671
+[#1678]: https://github.com/nextstrain/augur/pull/1678
 
 ## 26.1.0 (12 November 2024)
 

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     # Install an "augur" program which calls augur.__main__.main()
     #   https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation


### PR DESCRIPTION
## Description of proposed changes

Requires bump of Biopython min tested version from 1.80 to 1.82 as it's the first to support 3.12.

In a future PR, we should also deprecate or even already remove Python 3.8 (has reached EOL October 31 and Biopython no longer supports it and has even already deprecated 3.9): https://github.com/nextstrain/augur/issues/1680

We can't support Python 3.13 yet because Biopython doesn't, see #1679

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

- [x] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
