### PR TITLE
Use jsonschema ≥4.18.0 and new referencing library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 ## __NEXT__
 
+### Major Changes
+
+- Drop support for older versions of jsonschema (<4.18.0). [#1691] (@victorlin)
+
+### Bug fixes
+
+- export: validation will no longer crash with `KeyError: 'tree'` when newer versions of jsonschema (≥4.18.0) are installed. [#1691] (@victorlin)
+
+[#1691]: https://github.com/nextstrain/augur/pull/1691
 
 ## 26.2.0 (20 November 2024)
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
         "cvxopt >=1.1.9, ==1.*",
         "importlib_resources >=5.3.0; python_version < '3.11'",
         "isodate ==0.6.*",
-        "jsonschema >=3.0.0, ==3.*",
+        "jsonschema >=4.18.0, ==4.*",
         "networkx >= 2.5, <4",
         "numpy ==1.*",
         "packaging >=19.2",
@@ -65,6 +65,7 @@ setuptools.setup(
         "phylo-treetime >=0.11.2, <0.12",
         "pyfastx >=1.0.0, <3.0",
         "python_calamine >=0.2.0",
+        "referencing >=0.29.1, <1.0",
         "scipy ==1.*",
         "xopen[zstd] >=1.7.0, <3" # TODO: Deprecated, remove v1 support around November 2024
     ],


### PR DESCRIPTION
## Description of proposed changes

In [v4.18.0](https://github.com/python-jsonschema/jsonschema/blob/93e0caa5752947ec77333da81a634afe41a022ed/CHANGELOG.rst#v4180), jsonschema.RefResolver was deprecated in favor of the new referencing library. The [intro](https://python-jsonschema.readthedocs.io/en/stable/referencing/#introduction-to-the-referencing-api) and [API](https://referencing.readthedocs.io/en/stable/api/#referencing.Registry.with_contents) docs were helpful in determining the necessary changes.

I've tested that our new usage is not backwards compatible with v4.17.3 and thus updated the minimum requirement to v4.18.0. I chose v0.29.1 as the minimum supported version of referencing because that was the version released alongside jsonschema v4.18.0.

The default behavior no longer tries to access the network, so I've reworded the retrieval function comment and error message.

Local reference mismatches are now a "PointerToNowhere" error instead of an "Unresolvable JSON pointer" error. It shows the entire schema JSON in the output which can seem unnecessarily verbose, but I think it's fine since this is only intended to show on internal errors with the schema.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Closes #1358 

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
