### PR TITLE
Drop support for xopen v1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,14 @@
 ### Major Changes
 
 - Drop support for older versions of jsonschema (<4.18.0). [#1691] (@victorlin)
+- Drop support for xopen <2.0.0. [#1692] (@victorlin)
 
 ### Bug fixes
 
 - export: validation will no longer crash with `KeyError: 'tree'` when newer versions of jsonschema (≥4.18.0) are installed. [#1691] (@victorlin)
 
 [#1691]: https://github.com/nextstrain/augur/pull/1691
+[#1692]: https://github.com/nextstrain/augur/pull/1692
 
 ## 26.2.0 (20 November 2024)
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -6,7 +6,7 @@ available for backwards compatibility, but should not be used in new code.
 
 ## `xopen` major version 1
 
-*Deprecated in version 25.1.0 (July 2024). Planned for removal November 2024 or after.*
+*Deprecated in version 25.1.0 (July 2024). Removed in version 27.0.0 (December 2024).*
 
 ## `augur parse` preference of `name` over `strain` as the sequence ID field
 

--- a/augur/io/file.py
+++ b/augur/io/file.py
@@ -2,21 +2,9 @@ import os
 from contextlib import contextmanager
 from io import IOBase
 from textwrap import dedent
-from xopen import xopen
+from xopen import xopen, _PipedCompressionProgram
 from augur.errors import AugurError
 
-# Workaround to maintain compatibility with both xopen v1 and v2
-# Around November 2024, we shall drop support for xopen v1
-# by removing the try-except block and using
-# _PipedCompressionProgram directly
-try:
-    from xopen import _PipedCompressionProgram as PipedCompressionReader
-    from xopen import _PipedCompressionProgram as PipedCompressionWriter
-except ImportError:
-    from xopen import (  # type: ignore[attr-defined, no-redef]  
-        PipedCompressionReader,
-        PipedCompressionWriter,
-    )
 
 ENCODING = "utf-8"
 
@@ -63,7 +51,7 @@ def open_file(path_or_buffer, mode="r", **kwargs):
                 Try re-saving the file using the {e.encoding!r} encoding."""))
 
 
-    elif isinstance(path_or_buffer, (IOBase, PipedCompressionReader, PipedCompressionWriter)):
+    elif isinstance(path_or_buffer, (IOBase, _PipedCompressionProgram)):
         yield path_or_buffer
 
     else:

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
         "python_calamine >=0.2.0",
         "referencing >=0.29.1, <1.0",
         "scipy ==1.*",
-        "xopen[zstd] >=1.7.0, <3" # TODO: Deprecated, remove v1 support around November 2024
+        "xopen[zstd] >=2.0.0, <3"
     ],
     extras_require = {
         'dev': [


### PR DESCRIPTION
## Description of proposed changes

Following through with deprecation to simplify the code.

## Related issue(s)

Follow-up to deprecation in #1532

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [ ] Post-merge: release this month as part of version 27.0.0

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
