### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Drop support for older versions of jsonschema (<4.18.0). [#1691] (@victorlin)
 - Drop support for xopen <2.0.0. [#1692] (@victorlin)
+- Drop support for Python 3.8. [#1693] (@victorlin)
 
 ### Bug fixes
 
@@ -13,6 +14,7 @@
 
 [#1691]: https://github.com/nextstrain/augur/pull/1691
 [#1692]: https://github.com/nextstrain/augur/pull/1692
+[#1693]: https://github.com/nextstrain/augur/pull/1693
 
 ## 26.2.0 (20 November 2024)
 

--- a/augur/__main__.py
+++ b/augur/__main__.py
@@ -24,11 +24,7 @@ def main():
         errors="backslashreplace",
         newline=None,
 
-        # Always line-buffer stderr since we only use it for messaging, not
-        # data output.  This is the Python default from 3.9 onwards, but we
-        # also run on 3.8 where it's not.  Be consistent regardless of Python
-        # version.
-        line_buffering=True,
+        # By default, stderr is always line-buffered.
     )
 
     return augur.run( argv[1:] )

--- a/augur/util_support/node_data.py
+++ b/augur/util_support/node_data.py
@@ -31,8 +31,6 @@ class NodeData:
                     raise exception
         """
 
-        # TODO Python 3.9: Use the new dictionary union operator (https://www.python.org/dev/peps/pep-0584/)
-
         if key not in d or (
             not isinstance(d[key], dict) and not isinstance(value, dict)
         ):

--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -17,7 +17,7 @@ Please see the [open issues list](https://github.com/nextstrain/augur/issues) fo
 
 ## Contributing code
 
-We currently target compatibility with Python 3.8 and higher. As Python releases new versions,
+We currently target compatibility with Python 3.9 and higher. As Python releases new versions,
 the minimum target compatibility may be increased in the future.
 
 ### Running local changes

--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -45,7 +45,7 @@ There are several ways to install Augur, ordered from least to most complex.
       .. warning::
          Installing other Python packages after Augur may cause dependency incompatibilities. If this happens, re-install Augur using the command in step 1.
 
-      Augur is written in Python 3 and requires at least Python 3.8. It's published on `PyPI <https://pypi.org>`__ as `nextstrain-augur <https://pypi.org/project/nextstrain-augur>`__.
+      Augur is written in Python 3 and requires at least Python 3.9. It's published on `PyPI <https://pypi.org>`__ as `nextstrain-augur <https://pypi.org/project/nextstrain-augur>`__.
 
       1. Install Augur along with Python dependencies.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 # Check against lowest compatible Python version
-python_version = 3.8
+python_version = 3.9
 
 # Don't set python_version. Instead, use the default behavior of checking for
 # compatibility against the version of Python used to run mypy.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,7 +1,7 @@
 {
   // Check against lowest compatible Python version
   // Sync this with python-version in .github/workflows/ci.yaml:jobs.pyright
-  "pythonVersion": "3.8",
+  "pythonVersion": "3.9",
 
   "include": ["augur/"],
 

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,6 @@ setuptools.setup(
 
         # Python 3 only
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Description of proposed changes

Python 3.8 reached EOL [~2 months ago](https://devguide.python.org/versions/). Many dependencies have already dropped support in recent versions.

Use 3.9 as the minimum Python version.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Closes #1680

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
