### PR TITLE
Add note on quoting behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+- merge: Clarify quoting behavior in docs. [#1694] (@victorlin)
+
+[#1694]: https://github.com/nextstrain/augur/issues/1694
 
 ## 27.0.0 (9 December 2024)
 

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -34,6 +34,13 @@ this should be considered an implementation detail that may change in the
 future.  The SQLite 3 CLI, sqlite3, must be available.  If it's not on PATH (or
 you want to use a version different from what's on PATH), set the SQLITE3
 environment variable to path of the desired sqlite3 executable.
+
+Quotes are added around values with `certain characters`_ (array maps to `ASCII`_ positions).
+This should not impact downstream usage.
+
+.. _certain characters: https://sqlite.org/src/artifact/883d1470#:~:text=static%20const%20char%20needCsvQuote%5B%5D
+.. _ASCII: https://en.wikipedia.org/wiki/ASCII
+
 """
 import os
 import re

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,3 +168,8 @@ linkcheck_anchors_ignore_for_url = [
      # checks for Github URLs:
      r'^https://github\.com',
 ]
+
+# Ignore text fragment anchors
+linkcheck_anchors_ignore = [
+    r'^:~:text='
+]


### PR DESCRIPTION
_[preview](https://nextstrain--1699.org.readthedocs.build/projects/augur/en/1699/usage/cli/merge.html)_

## Description of proposed changes

The command quotes more than [necessary](https://datatracker.ietf.org/doc/html/rfc4180#autoid-2). Add a reference to the source of the quoting behavior and note that it should be harmless.

## Related issue(s)

Closes #1694

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
