### PR TITLE
.readthedocs.yml: explicit Sphinx configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,9 @@ build:
       # generated from the full git history in conf.py.
       - git fetch --unshallow
 
+sphinx:
+  configuration: docs/conf.py
+
 python:
   install:
     - method: pip


### PR DESCRIPTION
## Description of proposed changes

Prompted by deprecation of RTD's auto-detection of Sphinx configs 
<https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/>

## Related issue(s)

Related to https://github.com/nextstrain/public/issues/15

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
