### PR TITLE
Remove unsupported pylint `no-space-check` option

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -317,13 +317,6 @@ max-line-length=100
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no


### PR DESCRIPTION
## Description of proposed changes

As of pylint 2.6, `no-space-check` is not a supported option in the pylint configuration file [1]. This commit removes the option from the project-specific pylintrc to silence errors from pylint during development in emacs. Since pylint is now at version 4 and no one else on the team has run into this issue, I strongly suspect no one else is using this pylintrc the same way I am. If folks want to make a case for removing this file entirely in favor of some other IDE-based linting they prefer, I'm open to that.

[1] https://pylint.pycqa.org/en/latest/whatsnew/2/2.6/summary.html#other-changes

## Checklist

- [x] Automated checks pass