### PR TITLE
Add help text to clarify extend actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,11 @@
 
 * ancestral, refine: Explicitly specify how the root and ambiguous states are handled during sequence reconstruction and mutation counting. [#1690][] (@rneher)
 * titers: Fix type errors in code associated with cross-validation of models. [#1688][] (@huddlej)
+* Add help text to clarify difference in behavior between options that override defaults (e.g. `--metadata-delimiters`) vs. options that extend existing defaults (e.g. `--expected-date-formats`). [#1705][] (@victorlin)
 
 [#1688]: https://github.com/nextstrain/augur/pull/1688
 [#1690]: https://github.com/nextstrain/augur/pull/1690
+[#1705]: https://github.com/nextstrain/augur/pull/1705
 
 ## 27.0.0 (9 December 2024)
 

--- a/augur/argparse_.py
+++ b/augur/argparse_.py
@@ -1,7 +1,7 @@
 """
 Custom helpers for the argparse standard library.
 """
-from argparse import Action, ArgumentParser, _ArgumentGroup, HelpFormatter, SUPPRESS, OPTIONAL, ZERO_OR_MORE
+from argparse import Action, ArgumentParser, _ArgumentGroup, HelpFormatter, SUPPRESS, OPTIONAL, ZERO_OR_MORE, _ExtendAction
 from typing import Union
 from .types import ValidationMode
 
@@ -27,6 +27,13 @@ class CustomHelpFormatter(HelpFormatter):
     """
     def _get_help_string(self, action: Action):
         help = action.help
+
+        if action.default is not None and action.default != []:
+            if isinstance(action, ExtendOverwriteDefault):
+                help += ' Specified values will override the default list.'
+            if isinstance(action, _ExtendAction):
+                help += ' Specified values will extend the default list.'
+
         if '%(default)' not in action.help:
             if action.default is not SUPPRESS:
                 defaulting_nargs = [OPTIONAL, ZERO_OR_MORE]

--- a/augur/argparse_.py
+++ b/augur/argparse_.py
@@ -1,23 +1,38 @@
 """
 Custom helpers for the argparse standard library.
 """
-from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentParser, _ArgumentGroup
+from argparse import Action, ArgumentParser, _ArgumentGroup, HelpFormatter, SUPPRESS, OPTIONAL, ZERO_OR_MORE
 from typing import Union
 from .types import ValidationMode
 
 
 # Include this in an argument help string to suppress the automatic appending
-# of the default value by argparse.ArgumentDefaultsHelpFormatter.  This works
-# because the automatic appending is conditional on the presence of %(default),
-# so we include it but then format it as a zero-length string .0s.  🙃
+# of the default value by CustomHelpFormatter.  This works because the
+# automatic appending is conditional on the presence of %(default), so we
+# include it but then format it as a zero-length string .0s.  🙃
 #
 # Another solution would be to add an extra attribute to the argument (the
-# argparse.Action instance) and then subclass ArgumentDefaultsHelpFormatter to
-# condition on that new attribute, but that seems more brittle.
+# argparse.Action instance) and then modify CustomHelpFormatter to condition
+# on that new attribute, but that seems more brittle.
 #
-# Copied from the Nextstrain CLI repo
+# Initially copied from the Nextstrain CLI repo
 # https://github.com/nextstrain/cli/blob/017c53805e8317951327d24c04184615cc400b09/nextstrain/cli/argparse.py#L13-L21
 SKIP_AUTO_DEFAULT_IN_HELP = "%(default).0s"
+
+
+class CustomHelpFormatter(HelpFormatter):
+    """Customize help text.
+
+    Initially copied from argparse.ArgumentDefaultsHelpFormatter.
+    """
+    def _get_help_string(self, action: Action):
+        help = action.help
+        if '%(default)' not in action.help:
+            if action.default is not SUPPRESS:
+                defaulting_nargs = [OPTIONAL, ZERO_OR_MORE]
+                if action.option_strings or action.nargs in defaulting_nargs:
+                    help += ' (default: %(default)s)'
+        return help
 
 
 def add_default_command(parser):
@@ -61,7 +76,7 @@ def add_command_subparsers(subparsers, commands, command_attribute='__command__'
 
         # Use the same formatting class for every command for consistency.
         # Set here to avoid repeating it in every command's register_parser().
-        subparser.formatter_class = ArgumentDefaultsHelpFormatter
+        subparser.formatter_class = CustomHelpFormatter
 
         if not subparser.description and command.__doc__:
             subparser.description = command.__doc__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,9 +132,10 @@ nitpick_ignore = [
      ("py:class", "json.decoder.JSONDecodeError"),
      ("py:class", "json.encoder.JSONEncoder"),
 
-     # This class can't be referenced.
+     # These classes can't be referenced.
      # <https://github.com/python/cpython/issues/101503>
      ("py:class", "argparse._SubParsersAction"),
+     ("py:class", "argparse.HelpFormatter"),
 ]
 
 # -- Cross-project references ------------------------------------------------


### PR DESCRIPTION
## Description of proposed changes

Done programmatically by replacing `ArgumentDefaultsHelpFormatter` with a new `CustomHelpFormatter`.

## Related issue(s)

- Closes #1654

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [x] Tested locally with output of `augur curate format-dates -h`:

    ```
      --metadata-delimiters METADATA_DELIMITERS [METADATA_DELIMITERS ...]
                            Delimiters to accept when reading a plain text metadata file. Only
                            one delimiter will be inferred. Specified values will override the
                            default list. (default: (',', '\t'))

      --date-fields DATE_FIELDS [DATE_FIELDS ...]
                            List of date field names in the record that need to be standardized.
                            (default: None)

      --expected-date-formats EXPECTED_DATE_FORMATS [EXPECTED_DATE_FORMATS ...]
                            Expected date formats that are currently in the provided date fields,
                            defined by standard format codes as listed at
                            https://docs.python.org/3/library/datetime.html#strftime-and-
                            strptime-format-codes. If a date string matches multiple formats, it
                            will be parsed as the first matched format in the provided order.
                            Specified values will extend the default list. (default: ['%Y-%m-%d',
                            '%Y-%m-XX', '%Y-XX-XX', 'XXXX-XX-XX'])
    ```


[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
