### PR TITLE
export: Clarify behavior of `--lat-longs`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,12 @@
 * ancestral, refine: Explicitly specify how the root and ambiguous states are handled during sequence reconstruction and mutation counting. [#1690][] (@rneher)
 * titers: Fix type errors in code associated with cross-validation of models. [#1688][] (@huddlej)
 * Add help text to clarify difference in behavior between options that override defaults (e.g. `--metadata-delimiters`) vs. options that extend existing defaults (e.g. `--expected-date-formats`). [#1705][] (@victorlin)
+* export: The help text for `--lat-longs` has been improved with a link to the defaults and specifics around the overriding behavior. [#1715][] (@victorlin)
 
 [#1688]: https://github.com/nextstrain/augur/pull/1688
 [#1690]: https://github.com/nextstrain/augur/pull/1690
 [#1705]: https://github.com/nextstrain/augur/pull/1705
+[#1715]: https://github.com/nextstrain/augur/pull/1715
 
 ## 27.0.0 (9 December 2024)
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -20,6 +20,7 @@ from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimite
 from .types import ValidationMode
 from .utils import read_node_data, write_json, json_size, read_config, read_lat_longs, read_colors
 from .validate import export_v2 as validate_v2, auspice_config_v2 as validate_auspice_config_v2, ValidateError
+from .version import __version__
 
 
 MINIFY_THRESHOLD_MB = 5
@@ -964,7 +965,13 @@ def register_parser(parent_subparsers):
     optional_inputs.add_argument('--metadata-id-columns', default=DEFAULT_ID_COLUMNS, nargs="+", action=ExtendOverwriteDefault,
                                  help="names of possible metadata columns containing identifier information, ordered by priority. Only one ID column will be inferred.")
     optional_inputs.add_argument('--colors', metavar="FILE", help="Custom color definitions, one per line in the format `TRAIT_TYPE\\tTRAIT_VALUE\\tHEX_CODE`")
-    optional_inputs.add_argument('--lat-longs', metavar="TSV", help="Latitudes and longitudes for geography traits (overrides built in mappings)")
+    optional_inputs.add_argument('--lat-longs', metavar="TSV",
+        help=f"""Latitudes and longitudes for geography traits. See this file for the format:
+                 <https://github.com/nextstrain/augur/blob/{__version__}/augur/data/lat_longs.tsv>.
+                 This file provides the default set of latitudes and longitudes. An additional file
+                 specified by this option will extend the default set. Duplicates based on the first
+                 two columns will be resolved by taking the coordinates from the user-provided
+                 file.""")
 
     minify_group = parser.add_argument_group(
             title="OPTIONAL MINIFY SETTINGS",


### PR DESCRIPTION
## Description of proposed changes

The previous text mentioned built in mappings but did not specify where to find them or specifics around the overriding behavior.

The link to the GitHub-hosted lat_longs.tsv file associated with the installation's version is not perfect since the local version of lat_longs.tsv can be changed (i.e. in a development environment), but this should work for most users.

## Related issue(s)

Closes #1714

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [x] Checked output locally:

    ```
      --lat-longs TSV       Latitudes and longitudes for geography traits. See this file
                            for the format: <https://github.com/nextstrain/augur/blob/27.0.
                            0/augur/data/lat_longs.tsv>. This file provides the default set
                            of latitudes and longitudes. An additional file specified by
                            this option will extend the default set. Duplicates based on
                            the first two columns will be resolved by taking the
                            coordinates from the user-provided file. (default: None)
    ```

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
