### PR TITLE
Bump minimum pandas version to 1.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,11 +12,13 @@
 * titers: Fix type errors in code associated with cross-validation of models. [#1688][] (@huddlej)
 * Add help text to clarify difference in behavior between options that override defaults (e.g. `--metadata-delimiters`) vs. options that extend existing defaults (e.g. `--expected-date-formats`). [#1705][] (@victorlin)
 * export: The help text for `--lat-longs` has been improved with a link to the defaults and specifics around the overriding behavior. [#1715][] (@victorlin)
+* augur.io.read_metadata: Pandas versions <1.4.0 prevented this function from properly setting the index column's data type. Support for those older versions has been dropped. [#1716][] (@victorlin)
 
 [#1688]: https://github.com/nextstrain/augur/pull/1688
 [#1690]: https://github.com/nextstrain/augur/pull/1690
 [#1705]: https://github.com/nextstrain/augur/pull/1705
 [#1715]: https://github.com/nextstrain/augur/pull/1715
+[#1716]: https://github.com/nextstrain/augur/pull/1716
 
 ## 27.0.0 (9 December 2024)
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         "networkx >= 2.5, <4",
         "numpy ==1.*",
         "packaging >=19.2",
-        "pandas >=1.0.0, <3",
+        "pandas >=1.4.0, <3",
         "phylo-treetime >=0.11.2, <0.12",
         "pyfastx >=1.0.0, <3.0",
         "python_calamine >=0.2.0",


### PR DESCRIPTION
## Description of proposed changes

Earlier versions have a bug that prevented `augur.io.read_metadata` from properly setting the index column's data type.

## Related issue(s)

Closes #925

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
