### PR TITLE
curate format-dates: Mention that 'XX' can be used in `--expected-date-formats`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,13 +15,14 @@
 * In version 24.4.0, one of the new features was that all options that take multiple values could be repeated. Unfortunately, it overlooked a few that have been fixed in this version. [#1707][] (@victorlin)
     * `augur curate rename --field-map`
     * `augur curate transform-strain-name --backup-fields`
-* `augur curate format-dates --expected-date-formats` help text has been improved with clarifications regarding how values provided interact with builtin formats. [#1707][] (@victorlin)
+* `augur curate format-dates --expected-date-formats` help text has been improved with clarifications regarding how values provided interact with builtin formats and how to match masked date parts. [#1707][], [#1718][] (@victorlin)
 
 [#1688]: https://github.com/nextstrain/augur/pull/1688
 [#1690]: https://github.com/nextstrain/augur/pull/1690
 [#1707]: https://github.com/nextstrain/augur/issues/1707
 [#1715]: https://github.com/nextstrain/augur/pull/1715
 [#1716]: https://github.com/nextstrain/augur/pull/1716
+[#1718]: https://github.com/nextstrain/augur/pull/1718
 
 ## 27.0.0 (9 December 2024)
 

--- a/augur/curate/format_dates.py
+++ b/augur/curate/format_dates.py
@@ -42,6 +42,7 @@ def register_parser(parent_subparsers):
             format codes available at
             <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes>.
             If a value matches multiple formats, it will be parsed using the first match.
+            Use 'XX' to match masked parts of the date (e.g. '%%m/XX/%%Y').
             The following formats are builtin and automatically used:
             {", ".join(repr(x).replace("%", "%%") for x in BUILTIN_DATE_FORMATS)}.
             User-provided values are considered after the builtin formats."""))


### PR DESCRIPTION
## Description of proposed changes

This is worth calling out because it would be reasonable for a user to assume that Augur's support XX is automatically applied to dates like %Y-%m-%d. The added explicit mention + existing list of builtin formats including XX explicitly should help avoid that assumption.

## Related issue(s)

https://github.com/nextstrain/augur/pull/1709#discussion_r1913634054

## Checklist

- [ ] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [x] Merge base PR #1709

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
