### PR TITLE
Skip CI for PRs on Markdown changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
     - cron: "42 17 * * *"
 
   pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGES.md'
 
   workflow_dispatch:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,9 +28,9 @@
 
 ### Major Changes
 
-- Drop support for Python 3.8. [#1693] (@victorlin)
-- Drop support for older versions of jsonschema (<4.18.0). [#1691] (@victorlin)
-- Drop support for xopen <2.0.0. [#1692] (@victorlin)
+* Drop support for Python 3.8. [#1693] (@victorlin)
+* Drop support for older versions of jsonschema (<4.18.0). [#1691] (@victorlin)
+* Drop support for xopen <2.0.0. [#1692] (@victorlin)
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Try out an analysis of real virus data by [completing the Zika tutorial](https:/
 
 ## Documentation
 
-* [Overview of how Augur fits together with other Nextstrain tools](https://docs.nextstrain.org/en/latest/learn/parts.html)
-* [Overview of Augur usage](https://docs.nextstrain.org/projects/augur/en/stable/usage/usage.html)
-* [Technical documentation for Augur](https://docs.nextstrain.org/projects/augur/en/stable/installation/installation.html)
-* [Contributor guide](https://github.com/nextstrain/.github/blob/-/CONTRIBUTING.md)
-* [Developer docs for Augur](./docs/contribute/DEV_DOCS.md)
-* [Changelog](./CHANGES.md)
+- [Overview of how Augur fits together with other Nextstrain tools](https://docs.nextstrain.org/en/latest/learn/parts.html)
+- [Overview of Augur usage](https://docs.nextstrain.org/projects/augur/en/stable/usage/usage.html)
+- [Technical documentation for Augur](https://docs.nextstrain.org/projects/augur/en/stable/installation/installation.html)
+- [Contributor guide](https://github.com/nextstrain/.github/blob/-/CONTRIBUTING.md)
+- [Developer docs for Augur](./docs/contribute/DEV_DOCS.md)
+- [Changelog](./CHANGES.md)
 
 ## Citation
 


### PR DESCRIPTION
## Description of proposed changes

Skips the CI workflow when we change the README or change log in a PR. Changes to these files should not produce a different outcome in CI, so we don't need to waste compute rerunning CI for these files. CI will still run for these changes when pushed to `master`, since the change log gets built as part of our documentation.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

- [x] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
