### PR TITLE
export: Add `--warning`, update schema

### DIFF
--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -34,6 +34,10 @@
                     "$comment": "Generally a description of the phylogeny and/or acknowledgements in Markdown format.",
                     "type": "string"
                 },
+                "warning" : {
+                    "description": "Text in Markdown format to be displayed by Auspice as a warning banner under the byline.",
+                    "type": "string"
+                },
                 "maintainers": {
                     "$ref": "https://nextstrain.org/schemas/auspice/config/v2#/properties/maintainers"
                 },

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -948,6 +948,7 @@ def register_parser(parent_subparsers):
     config.add_argument('--maintainers', metavar="name", action=ExtendOverwriteDefault, nargs='+', help="Analysis maintained by, in format 'Name <URL>' 'Name2 <URL>', ...")
     config.add_argument('--build-url', type=str, metavar="url", help="Build URL/repository to be displayed by Auspice")
     config.add_argument('--description', metavar="description.md", help="Markdown file with description of build and/or acknowledgements to be displayed by Auspice")
+    config.add_argument('--warning', metavar="warning.md", help="Markdown file with text to be displayed as a warning banner by Auspice")
     config.add_argument('--geo-resolutions', metavar="trait", nargs='+', action=ExtendOverwriteDefault, help="Geographic traits to be displayed on map")
     config.add_argument('--color-by-metadata', metavar="trait", nargs='+', action=ExtendOverwriteDefault, help="Metadata columns to include as coloring options")
     config.add_argument('--metadata-columns', nargs="+", action=ExtendOverwriteDefault,
@@ -1079,6 +1080,18 @@ def set_description(data_json, cmd_line_description_file):
         data_json['meta']['description'] = markdown_text
     except FileNotFoundError:
         fatal("Provided desciption file {} does not exist".format(cmd_line_description_file))
+
+def set_warning(data_json, input_file):
+    """
+    Read Markdown file provided by *input_file* and set
+    `meta.warning` in *data_json* to the text provided.
+    """
+    try:
+        with open_file(input_file) as description_file:
+            markdown_text = description_file.read()
+        data_json['meta']['warning'] = markdown_text
+    except FileNotFoundError:
+        fatal("Provided warning file {} does not exist".format(input_file))
 
 def create_branch_mutations(branch_attrs, node_data):
     for node_name, node_info in node_data['nodes'].items():
@@ -1247,6 +1260,8 @@ def run(args):
     set_annotations(data_json, node_data)
     if args.description:
         set_description(data_json, args.description)
+    if args.warning:
+        set_warning(data_json, args.warning)
 
     try:
         set_colorings(

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -1076,7 +1076,7 @@ def set_description(data_json, cmd_line_description_file):
     try:
         with open_file(cmd_line_description_file) as description_file:
             markdown_text = description_file.read()
-            data_json['meta']['description'] = markdown_text
+        data_json['meta']['description'] = markdown_text
     except FileNotFoundError:
         fatal("Provided desciption file {} does not exist".format(cmd_line_description_file))
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -948,7 +948,7 @@ def register_parser(parent_subparsers):
     config.add_argument('--maintainers', metavar="name", action=ExtendOverwriteDefault, nargs='+', help="Analysis maintained by, in format 'Name <URL>' 'Name2 <URL>', ...")
     config.add_argument('--build-url', type=str, metavar="url", help="Build URL/repository to be displayed by Auspice")
     config.add_argument('--description', metavar="description.md", help="Markdown file with description of build and/or acknowledgements to be displayed by Auspice")
-    config.add_argument('--warning', metavar="warning.md", help="Markdown file with text to be displayed as a warning banner by Auspice")
+    config.add_argument('--warning', metavar="text or file", help="Text or file in Markdown format to be displayed as a warning banner by Auspice")
     config.add_argument('--geo-resolutions', metavar="trait", nargs='+', action=ExtendOverwriteDefault, help="Geographic traits to be displayed on map")
     config.add_argument('--color-by-metadata', metavar="trait", nargs='+', action=ExtendOverwriteDefault, help="Metadata columns to include as coloring options")
     config.add_argument('--metadata-columns', nargs="+", action=ExtendOverwriteDefault,
@@ -1081,17 +1081,17 @@ def set_description(data_json, cmd_line_description_file):
     except FileNotFoundError:
         fatal("Provided desciption file {} does not exist".format(cmd_line_description_file))
 
-def set_warning(data_json, input_file):
+def set_warning(data_json, text_or_file):
     """
-    Read Markdown file provided by *input_file* and set
+    Read warning provided by *text_or_file* and set
     `meta.warning` in *data_json* to the text provided.
     """
-    try:
-        with open_file(input_file) as description_file:
+    if os.path.exists(text_or_file):
+        with open_file(text_or_file) as description_file:
             markdown_text = description_file.read()
         data_json['meta']['warning'] = markdown_text
-    except FileNotFoundError:
-        fatal("Provided warning file {} does not exist".format(input_file))
+    else:
+        data_json['meta']['warning'] = text_or_file
 
 def create_branch_mutations(branch_attrs, node_data):
     for node_name, node_info in node_data['nodes'].items():

--- a/tests/functional/export_v2/cram/warning.t
+++ b/tests/functional/export_v2/cram/warning.t
@@ -1,0 +1,38 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Specify a warning as text.
+
+  $ ${AUGUR} export v2 \
+  >   --tree "$TESTDIR/../data/tree.nwk" \
+  >   --warning 'A warning with "quotes"' \
+  >   --skip-validation \
+  >   --output dataset.json &>/dev/null
+
+TODO: Switch to use jq once it's available in a well-defined test environment.
+<https://github.com/nextstrain/augur/issues/1557>
+
+  $ python3 -c 'import json, sys; print(json.load(sys.stdin)["meta"]["warning"])' < dataset.json
+  A warning with "quotes"
+
+Add a warning from a markdown file.
+
+  $ cat >warning.md <<~~
+  > A warning with "quotes".
+  > ~~
+
+  $ ${AUGUR} export v2 \
+  >   --tree "$TESTDIR/../data/tree.nwk" \
+  >   --warning warning.md \
+  >   --skip-validation \
+  >   --output dataset.json &>/dev/null
+
+  $ python3 -c 'import json, sys; print(json.load(sys.stdin)["meta"]["warning"])' < dataset.json
+  A warning with "quotes".
+  
+
+Note: there is an extra newline compared to the original contents. This extra
+newline is harmless and can be explained by `augur export` embedding the
+original trailing newline explicitly, followed by an additional trailing newline
+when writing to extracted-warning.md.

--- a/tests/functional/refine/cram/year-bounds.t
+++ b/tests/functional/refine/cram/year-bounds.t
@@ -38,7 +38,8 @@ Limit ambiguous dates to be within (2000, 2020).
   >  --divergence-units mutations &> /dev/null
 
 Check that the inferred date is 2020-12-31.
-TODO: Using jq woud be cleaner, but requires an extra dev dependency.
+TODO: Switch to use jq once it's available in a well-defined test environment.
+<https://github.com/nextstrain/augur/issues/1557>
 
   $ python3 -c 'import json, sys; print(json.load(sys.stdin)["nodes"]["PAN/CDC_259359_V1_V3/2015"]["date"])' < branch_lengths.json
   2020-12-31


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Add a new option `augur export --warning` which surfaces as `meta.warning` in the exported JSON.

## Related issue(s)

Closes #1722

## Checklist

- [x] ~Automated checks pass~ failing due to #1727, changed test files work locally
- [x] [Check][1] if you need to add a changelog message: #1728
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
