### PR TITLE
Hide BiopythonDeprecationWarnings when reading certain sequence files

### DIFF
--- a/augur/align.py
+++ b/augur/align.py
@@ -196,7 +196,7 @@ def read_sequences(*fnames):
     seqs = {}
     try:
         for fname in fnames:
-            for record in SeqIO.parse(fname, 'fasta'):
+            for record in SeqIO.parse(fname, 'fasta-pearson'):
                 if record.name in seqs and record.seq != seqs[record.name].seq:
                     raise AlignmentError("Detected duplicate input strains \"%s\" but the sequences are different." % record.name)
                     # if the same sequence then we can proceed (and we only take one)
@@ -240,7 +240,7 @@ def read_reference(ref_fname):
         raise AlignmentError("ERROR: Cannot read reference sequence."
                              "\n\tmake sure the file \"%s\" exists"%ref_fname)
     try:
-        ref_seq = SeqIO.read(ref_fname, 'genbank' if ref_fname.split('.')[-1] in ['gb', 'genbank'] else 'fasta')
+        ref_seq = SeqIO.read(ref_fname, 'genbank' if ref_fname.split('.')[-1] in ['gb', 'genbank'] else 'fasta-pearson')
     except:
         raise AlignmentError("ERROR: Cannot read reference sequence."
                 "\n\tmake sure the file %s contains one sequence in genbank or fasta format"%ref_fname)

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -398,7 +398,7 @@ def run(args):
         aln = args.alignment
         ref = None
         if args.root_sequence:
-            for fmt in ['fasta', 'genbank']:
+            for fmt in ['fasta-pearson', 'genbank']:
                 try:
                     ref = str(SeqIO.read(args.root_sequence, fmt).seq).upper()
                     break

--- a/augur/reconstruct_sequences.py
+++ b/augur/reconstruct_sequences.py
@@ -73,7 +73,7 @@ def run(args):
     if(is_vcf):
         node_data["nodes"][root_node]['aa_sequences'] = {}
         with open_file(args.vcf_aa_reference) as handle:
-            for record in SeqIO.parse(handle, "fasta"):
+            for record in SeqIO.parse(handle, "fasta-pearson"):
                 if record.id==args.gene:
                     #'root' may not be same as 'reference', so apply any mutations at root here!
                     node_data["nodes"][root_node]['aa_sequences'][record.id] = get_sequence(str(record.seq), node_data["nodes"][root_node]["aa_muts"][record.id])

--- a/augur/sequence_traits.py
+++ b/augur/sequence_traits.py
@@ -91,7 +91,7 @@ def read_in_translate_vcf(vcf_file, ref_file):
                 samps = header[sampLoc:]
                 nsamp = len(samps)
 
-    for refSeq in SeqIO.parse(ref_file, format='fasta'):
+    for refSeq in SeqIO.parse(ref_file, format='fasta-pearson'):
         prots[refSeq.name]['reference'] = str(refSeq.seq)
         posN = np.unique(prots[refSeq.name]['positions'])
         prots[refSeq.name]['positions'] = list(posN)


### PR DESCRIPTION
## Description of proposed changes

Biopython 1.85 will show a deprecation warning when using format='fasta' with files that start with anything but '>'. This will be triggered in 2 cases:

1. when attempting to read GenBank files as FASTA
2. when attempting to read a FASTA file with comments

For (1), this deprecation warning will eventually become a ValueError which works with the existing try/catch block in ancentral.py to continue parsing as GenBank. For (2), it should be decided independently of Biopython if Augur should support FASTA with comments.

In both cases, the warning as-is should not be exposed to Augur users. It is not triggered when reading files format='fasta-pearson', so this is the easiest thing to do to maintain behavior of Biopython <1.85.

An alternative workaround is to suppress BiopythonDeprecationWarnings entirely with

    warnings.simplefilter("ignore", BiopythonDeprecationWarning)

but that is less targeted and can lead to suppression of meaningful warnings.

## Related issue(s)

Closes #1727

## Checklist

- [ ] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs
- [ ] Post-merge: create issue for deciding if Augur should support FASTA with comments

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
