### PR TITLE
Ignore gnu.org link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,6 +161,7 @@ linkcheck_ignore = [
      # <https://github.com/nextstrain/.github/issues/106#issuecomment-2408239782>
      r'^http://www\.microbesonline\.org/fasttree/',
      r'^https://academic\.oup\.com/ve/article/4/1/vex042/4794731',
+     r'https://www\.gnu\.org/software/bash/manual/bash\.html#ANSI_002dC-Quoting',
 ]
 linkcheck_anchors_ignore_for_url = [
      # Github uses anchor-looking links for highlighting lines but


### PR DESCRIPTION
## Description of proposed changes

This has been showing as broken more often than not in the recent week.

## Related issue(s)

Closes #1735

## Checklist

- [x] Link is no longer checked in `build-docs/build`
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
