### PR TITLE
curate apply-geolocation-rules: Use case-insensitive matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,10 @@
 
 * export v2: The string "none" is now an invalid value for `--color-by-metadata` and `--metadata-columns` options and will be ignored to prevent clashes with Auspice's internal use of "none". [#1113][] (@joverlee521)
 * schema: The string "none" is now an invalid branch label, node_attr key, and coloring key. [#1113][] (@joverlee521)
+* curate apply-geolocation-rules: The geolocation rule matching has been updated to be case-insensitive. [#1740][] (@joverlee521)
 
 [#1113]: https://github.com/nextstrain/augur/pull/1113
+[#1740]: https://github.com/nextstrain/augur/pull/1740
 
 ## 27.2.0 (22 January 2025)
 

--- a/augur/curate/apply_geolocation_rules.py
+++ b/augur/curate/apply_geolocation_rules.py
@@ -61,6 +61,9 @@ def load_geolocation_rules(geolocation_rules_file):
                     "Please make sure it is formatted as 'region/country/division/location'.")
                 continue
 
+            # Store raw locations in lowercase to support case-insensitive
+            # matching of geolocation rules
+            raw = [x.lower() for x in raw]
 
             geolocation_rules[raw[0]][raw[1]][raw[2]][raw[3]] = annot
 
@@ -88,7 +91,8 @@ def get_annotated_geolocation(geolocation_rules, raw_geolocation, rule_traversal
     current_rules = geolocation_rules
     # Traverse the geolocation rules based using the rule_traversal values
     for field_value in rule_traversal:
-        current_rules = current_rules.get(field_value)
+        # Use lowercase for field_value for case-insensitive rule matching
+        current_rules = current_rules.get(field_value.lower())
         # If we hit `None`, then we know there are no matching rules, so stop the rule traversal
         if current_rules is None:
             break
@@ -205,7 +209,8 @@ def register_parser(parent_subparsers):
              "are formatted as '<region>/<country>/<division>/<location>'. " +
              "If creating a general rule, then the raw field value can be substituted with '*'." +
              "Lines starting with '#' will be ignored as comments." +
-             "Trailing '#' will be ignored as comments.")
+             "Trailing '#' will be ignored as comments. " +
+             "Note that the raw geolocation matching is case-insensitive.")
 
     return parser
 

--- a/tests/functional/curate/cram/apply-geolocation-rules/rule-case-sensitivity.t
+++ b/tests/functional/curate/cram/apply-geolocation-rules/rule-case-sensitivity.t
@@ -8,16 +8,16 @@ Test a rule with different casing for the annotations.
   > North America/USA/CA/*	North America/USA/California/*
   > ~~
 
-Rule matching is case-sensitive and the output matches the casing of the annotations.
+Rule matching is case-insensitive and the output matches the casing of the annotations.
 
   $ echo '{"region": "North America", "country": "USA", "division": "CA", "location": "Los Angeles"}' \
   >   |  ${AUGUR} curate apply-geolocation-rules \
   >       --geolocation-rules rules.tsv
   {"region": "North America", "country": "USA", "division": "California", "location": "Los Angeles"}
 
-Rule matching is case-sensitive, so raw values with mismatched casing do not get changed.
+Rule matching is case-insensitive, so raw values with mismatched casing will still get updated.
 
   $ echo '{"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}' \
   >   |  ${AUGUR} curate apply-geolocation-rules \
   >       --geolocation-rules rules.tsv
-  {"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}
+  {"region": "North America", "country": "USA", "division": "California", "location": "Los Angeles"}

--- a/tests/functional/curate/cram/apply-geolocation-rules/rule-case-sensitivity.t
+++ b/tests/functional/curate/cram/apply-geolocation-rules/rule-case-sensitivity.t
@@ -1,0 +1,23 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Test a rule with different casing for the annotations.
+
+  $ cat >rules.tsv <<~~
+  > North America/USA/CA/*	North America/USA/California/*
+  > ~~
+
+Rule matching is case-sensitive and the output matches the casing of the annotations.
+
+  $ echo '{"region": "North America", "country": "USA", "division": "CA", "location": "Los Angeles"}' \
+  >   |  ${AUGUR} curate apply-geolocation-rules \
+  >       --geolocation-rules rules.tsv
+  {"region": "North America", "country": "USA", "division": "California", "location": "Los Angeles"}
+
+Rule matching is case-sensitive, so raw values with mismatched casing do not get changed.
+
+  $ echo '{"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}' \
+  >   |  ${AUGUR} curate apply-geolocation-rules \
+  >       --geolocation-rules rules.tsv
+  {"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}


### PR DESCRIPTION
## Description of proposed changes

Update the raw location matching to be case-insensitive so that users don't have to maintain multiple rules for the different string casings.

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/1738

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
