### PR TITLE
apply-geolocation-rules: Add `--case-sensitive` flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,11 @@
 
 * export v2: The string "none" is now an invalid value for `--color-by-metadata` and `--metadata-columns` options and will be ignored to prevent clashes with Auspice's internal use of "none". [#1113][] (@joverlee521)
 * schema: The string "none" is now an invalid branch label, node_attr key, and coloring key. [#1113][] (@joverlee521)
-* curate apply-geolocation-rules: The geolocation rule matching has been updated to be case-insensitive. [#1740][] (@joverlee521)
+* curate apply-geolocation-rules: The geolocation rule matching has been updated to be case-insensitive. Use the new `--case-sensitive` flag if you want to revert to the previous behavior of case-sensitive matching. [#1740][], [#1741][] (@joverlee521)
 
 [#1113]: https://github.com/nextstrain/augur/pull/1113
 [#1740]: https://github.com/nextstrain/augur/pull/1740
+[#1741]: https://github.com/nextstrain/augur/pull/1741
 
 ## 27.2.0 (22 January 2025)
 

--- a/tests/functional/curate/cram/apply-geolocation-rules/rule-case-sensitivity.t
+++ b/tests/functional/curate/cram/apply-geolocation-rules/rule-case-sensitivity.t
@@ -15,9 +15,17 @@ Rule matching is case-insensitive and the output matches the casing of the annot
   >       --geolocation-rules rules.tsv
   {"region": "North America", "country": "USA", "division": "California", "location": "Los Angeles"}
 
-Rule matching is case-insensitive, so raw values with mismatched casing will still get updated.
+Rule matching is case-insensitive by default, so raw values with mismatched casing will still get updated.
 
   $ echo '{"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}' \
   >   |  ${AUGUR} curate apply-geolocation-rules \
   >       --geolocation-rules rules.tsv
   {"region": "North America", "country": "USA", "division": "California", "location": "Los Angeles"}
+
+Using the `--case-sensitive` flag will make rule matching case-sensitive.
+
+  $ echo '{"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}' \
+  >   |  ${AUGUR} curate apply-geolocation-rules \
+  >       --geolocation-rules rules.tsv \
+  >       --case-sensitive
+  {"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}


### PR DESCRIPTION
## Description of proposed changes

_This PR is based on https://github.com/nextstrain/augur/pull/1740_

https://github.com/nextstrain/augur/pull/1740 updates the default behavior to do case-insensitive matching. I believe the new default behavior is desired for most use cases, but it is technically a breaking change. The new `--case-sensitive` flag gives users an option to revert to the previous behavior of case-sensitive matching.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
