### PR TITLE
schema-export-v2: explicitly allow node attributes to include url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug Fixes
+
+* schema: document node property values support `url`. This feature has been supported in Auspice since v2.25.0. [#1743][] (@joverlee521)
+
+[#1743]: https://github.com/nextstrain/augur/pull/1743
 
 ## 28.0.0 (30 January 2025)
 

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -250,6 +250,12 @@
                                 "value": {
                                     "type": ["string", "number", "boolean"]
                                 },
+                                "url": {
+                                    "description": "URL for the property value.",
+                                    "$comment": "If a url is specified, then the value is rendered as a link in the on-click panel.",
+                                    "type": "string",
+                                    "pattern": "^https?://.+$"
+                                },
                                 "confidence": {
                                     "description": "Confidence of the trait date",
                                     "$comment": "Should we use different keys for the two structures here?",


### PR DESCRIPTION
## Description of proposed changes
_Prompted by question on [Slack](https://bedfordlab.slack.com/archives/C0K3GS3J8/p1738675589998829)_

This feature has been supported in Auspice since v2.25.0, but we never updated the schema to match.

## Related issue(s)

Follow up to https://github.com/nextstrain/auspice/pull/1308

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
