### PR TITLE
curate apply-geolocation-rules: use default rules and custom rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,14 @@
 ### Major Changes
 
 * Updated default latitudes and longitudes for geography traits that includes location name changes. See the pull request for more details. [#1744][] (@joverlee521)
+* curate apply-geolocation-rules: Augur's standard geolocation rules are used by default and rules provided via `--geolocation-rules` are considered custom rules that have precedence over the default rules. The `--no-default-rules` flag can be used to ignore the default rules. See the pull request for more details. [#1745][] (@joverlee521)
 
 ### Features
 
 * Added standard geolocation rules in "augur/data/geolocation_rules.tsv" that can be used with `augur curate apply-geolocation-rules`. [#1744][] (@joverlee521)
 
 [#1744]: https://github.com/nextstrain/augur/pull/1744
+[#1745]: https://github.com/nextstrain/augur/pull/1745
 
 ## 28.0.1 (10 February 2025)
 

--- a/augur/curate/apply_geolocation_rules.py
+++ b/augur/curate/apply_geolocation_rules.py
@@ -9,6 +9,10 @@ from augur.utils import first_line
 from augur.version import __version__
 
 
+class NoGeolocationRulesProvidedError(AugurError):
+    pass
+
+
 class CyclicGeolocationRulesError(AugurError):
     pass
 
@@ -227,6 +231,12 @@ def register_parser(parent_subparsers):
 
 
 def run(args, records):
+
+    if args.no_default_rules and not args.geolocation_rules:
+        raise NoGeolocationRulesProvidedError(
+            "No geolocation rules were provided! Either remove the `--no-default-rules` flag to use Augur's default " +
+            "geolocation rules or provide custom rules via `--geolocation-rules`.")
+
     location_fields = [args.region_field, args.country_field, args.division_field, args.location_field]
 
     default_rules = {}

--- a/augur/curate/apply_geolocation_rules.py
+++ b/augur/curate/apply_geolocation_rules.py
@@ -220,6 +220,8 @@ def register_parser(parent_subparsers):
              f"<https://github.com/nextstrain/augur/blob/{__version__}/augur/data/geolocation_rules.tsv>.")
     parser.add_argument("--case-sensitive", action="store_true",
         help="Use case-sensitive matching of raw geolocation fields to geolocation rules.")
+    parser.add_argument("--no-default-rules", action="store_true",
+        help="Do not use Augur's default geolocation rules.")
 
     return parser
 
@@ -227,8 +229,10 @@ def register_parser(parent_subparsers):
 def run(args, records):
     location_fields = [args.region_field, args.country_field, args.division_field, args.location_field]
 
-    with as_file("geolocation_rules.tsv") as default_rules_file:
-        default_rules = load_geolocation_rules(default_rules_file, args.case_sensitive)
+    default_rules = {}
+    if args.no_default_rules != True:
+        with as_file("geolocation_rules.tsv") as default_rules_file:
+            default_rules = load_geolocation_rules(default_rules_file, args.case_sensitive)
 
     custom_rules = {}
     if args.geolocation_rules:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,6 +162,9 @@ linkcheck_ignore = [
      r'^http://www\.microbesonline\.org/fasttree/',
      r'^https://academic\.oup\.com/ve/article/4/1/vex042/4794731',
      r'https://www\.gnu\.org/software/bash/manual/bash\.html#ANSI_002dC-Quoting',
+     # Temporarily ignoring this URL since the new file does not exist
+     # until we do a new release of Augur with the added file.
+     r'^https://github.com/nextstrain/augur/blob/\d\d\.\d\.\d/augur/data/geolocation_rules.tsv'
 ]
 linkcheck_anchors_ignore_for_url = [
      # Github uses anchor-looking links for highlighting lines but

--- a/tests/functional/curate/cram/apply-geolocation-rules/custom-rules-have-precedence.t
+++ b/tests/functional/curate/cram/apply-geolocation-rules/custom-rules-have-precedence.t
@@ -1,0 +1,70 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Test the custom rules have precedence over the default rules.
+
+Create the raw location NDJSON.
+
+  $ cat >raw_geolocation.ndjson <<~~
+  > {"region": "North America", "country": "USA", "division": "Wa", "location": "Seattle"}
+  > {"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}
+  > ~~
+
+Create a custom rule for a specific location that is different
+than the default rule in augur/data/geolocation_rules.tsv
+
+  $ cat >custom-rules.tsv <<~~
+  > North America/USA/Wa/Seattle	North America/United States of America/Washington/Seattle
+  > ~~
+
+Run the command without the custom rules to keep the
+result of annotations from default rules for comparison.
+
+  $ cat raw_geolocation.ndjson \
+  >   |  ${AUGUR} curate apply-geolocation-rules > default-annotations.ndjson
+
+Run the command with the custom rules.
+
+  $ cat raw_geolocation.ndjson \
+  >   |  ${AUGUR} curate apply-geolocation-rules \
+  >       --geolocation-rules custom-rules.tsv > custom-annotations.ndjson
+
+Show the difference between the default annotations and the custom annotations.
+Note the the custom rules only affected the single location.
+
+  $ diff -u default-annotations.ndjson custom-annotations.ndjson
+  --- default-annotations.ndjson.* (re)
+  \+\+\+ custom-annotations.ndjson.* (re)
+  @@ -1,2 +1,2 @@
+  -{"region": "North America", "country": "USA", "division": "Washington", "location": "King County WA"}
+  +{"region": "North America", "country": "United States of America", "division": "Washington", "location": "Seattle"}
+   {"region": "North America", "country": "USA", "division": "California", "location": "Los Angeles County CA"}
+  [1]
+
+Create custom rule with wildcards below the country level that is different
+than the default rules in augur/data/geolocation_rules.tsv
+
+  $ cat >wildcard-custom-rules.tsv <<~~
+  > North America/USA/*/*	North America/United States of America/*/*
+  > ~~
+
+Run the command with the wildcard custom rules.
+
+  $ cat raw_geolocation.ndjson \
+  >   |  ${AUGUR} curate apply-geolocation-rules \
+  >       --geolocation-rules wildcard-custom-rules.tsv > wildcard-custom-annotations.ndjson
+
+Show the difference between the default annotations and the wildcard custom annotations.
+The wildcard custom rules will be applied to all records that matched and
+they will no longer have the default annotations below the country level.
+
+  $ diff -u default-annotations.ndjson wildcard-custom-annotations.ndjson
+  --- default-annotations.ndjson.* (re)
+  \+\+\+ wildcard-custom-annotations.ndjson.* (re)
+  @@ -1,2 +1,2 @@
+  -{"region": "North America", "country": "USA", "division": "Washington", "location": "King County WA"}
+  -{"region": "North America", "country": "USA", "division": "California", "location": "Los Angeles County CA"}
+  +{"region": "North America", "country": "United States of America", "division": "Wa", "location": "Seattle"}
+  +{"region": "North America", "country": "United States of America", "division": "Ca", "location": "Los Angeles"}
+  [1]

--- a/tests/functional/curate/cram/apply-geolocation-rules/no-default-rules-flag.t
+++ b/tests/functional/curate/cram/apply-geolocation-rules/no-default-rules-flag.t
@@ -1,0 +1,44 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Test the default rules are ignored when using the `--no-default-rules` flag.
+
+Create the raw location NDJSON.
+
+  $ cat >raw_geolocation.ndjson <<~~
+  > {"region": "North America", "country": "USA", "division": "Wa", "location": "Seattle"}
+  > {"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}
+  > ~~
+
+Create a custom rule for a specific location.
+
+  $ cat >custom-rules.tsv <<~~
+  > North America/USA/Wa/Seattle	North America/United States of America/Washington/Seattle
+  > ~~
+
+Run the command with default rules and the custom rules to keep the
+result of annotations for comparison.
+
+  $ cat raw_geolocation.ndjson \
+  >   |  ${AUGUR} curate apply-geolocation-rules \
+  >       --geolocation-rules custom-rules.tsv > default-and-custom-annotations.ndjson
+
+Run the command with the custom rules and the `--no-default-rules` flag.
+
+  $ cat raw_geolocation.ndjson \
+  >   |  ${AUGUR} curate apply-geolocation-rules \
+  >       --geolocation-rules custom-rules.tsv \
+  >       --no-default-rules > custom-annotations-only.ndjson
+
+Show the difference between annotations.
+Note the location that is not included in the custom rules still has it's original raw value.
+
+  $ diff -u default-and-custom-annotations.ndjson custom-annotations-only.ndjson
+  --- default-and-custom-annotations.ndjson.* (re)
+  \+\+\+ custom-annotations-only.ndjson.* (re)
+  @@ -1,2 +1,2 @@
+   {"region": "North America", "country": "United States of America", "division": "Washington", "location": "Seattle"}
+  -{"region": "North America", "country": "USA", "division": "California", "location": "Los Angeles County CA"}
+  +{"region": "North America", "country": "USA", "division": "Ca", "location": "Los Angeles"}
+  [1]

--- a/tests/functional/curate/cram/apply-geolocation-rules/no-geolocation-rules-error.t
+++ b/tests/functional/curate/cram/apply-geolocation-rules/no-geolocation-rules-error.t
@@ -1,0 +1,11 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Running the command without default rules or custom rules will result in an error.
+
+  $ echo '{"region": "North America", "country": "USA", "division": "Wa", "location": "Seattle"}' \
+  >   |  ${AUGUR} curate apply-geolocation-rules \
+  >      --no-default-rules
+  ERROR: No geolocation rules were provided! Either remove the `--no-default-rules` flag to use Augur's default geolocation rules or provide custom rules via `--geolocation-rules`.
+  [2]


### PR DESCRIPTION
## Description of proposed changes

_This PR is based on https://github.com/nextstrain/augur/pull/1744_

Improvements to `augur curate apply-geolocation-rules`:
- use the default geolocation rules by default
- custom rules provided via `--geolocation-rules` have precedence over the default rules
- allow users to ignore the default rules with `--no-default-rules` flag
- raise an error if both default rules and custom rules are not provided

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/1648

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
