### PR TITLE
[tree] don't modify strain names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,11 +14,14 @@
 
 ### Bug fixes
 
+* Certain strain names would be silently renamed by `augur tree [--method iqtree]`. We now avoid such renaming wherever possible and in cases where there are backslashes or single quotes we now raise a fatal error.
+Note that names with spaces in the FASTA header (description line) continue to be modified such that everything after the first space is not used in the resulting tree. [#1750][] (@jameshadfield)
 * Fixed the error that occurred when running `augur curate --help`. [#1755][] (@joverlee521)
 
 [#1744]: https://github.com/nextstrain/augur/pull/1744
 [#1745]: https://github.com/nextstrain/augur/pull/1745
 [#1755]: https://github.com/nextstrain/augur/pull/1755
+[#1750]: https://github.com/nextstrain/augur/pull/1750
 
 ## 28.0.1 (10 February 2025)
 

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -242,9 +242,9 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
     # Note: See <https://github.com/nextstrain/augur/pull/1085> for an alternate
     # approach to escaping using a local-specific non-word regex.
     prefix = "DELIM"
-    invalid_newick_chars = ["'"]
+    invalid_newick_chars = ["'", "\\"] # "\\" is a single backslash
     invalid_replaceable_chars = ['(', ')', '{', '}', '[', ']', '<', '>',
-                                 '/', "\\", '|', '*', ':', '%', '+', '!', ';', # "\\" is a single backslash
+                                 '/', '|', '*', ':', '%', '+', '!', ';',
                                  '&', '@', ',', '$', '=', '^', '~', '?', '#',
                                  '"', '`', ' ',
                                 ]

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -1,5 +1,7 @@
 """
 Build a tree using a variety of methods.
+
+IQ-TREE specific: Strain names with spaces are modified to remove all characters after (and including) the first space.
 """
 
 import os
@@ -246,7 +248,7 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
     invalid_replaceable_chars = ['(', ')', '{', '}', '[', ']', '<', '>',
                                  '/', '|', '*', ':', '%', '+', '!', ';',
                                  '&', '@', ',', '$', '=', '^', '~', '?', '#',
-                                 '"', '`', ' ',
+                                 '"', '`',
                                 ]
     escape_dict = {c:f'_{prefix}-{hex(ord(c))}_' for c in invalid_replaceable_chars}
     reverse_escape_dict = {v:k for k,v in escape_dict.items()}
@@ -260,6 +262,9 @@ def build_iqtree(aln_file, out_file, substitution_model="GTR", clean_up=True, nt
         for line in ifile:
             if line.startswith(">"):
                 strain_name = line.lstrip('>').rstrip('\n')
+                # Modify the strain name to remove anything after a space (0x20)
+                # This preserves the behaviour of augur v28 but makes it explicit.
+                strain_name = strain_name.split(' ')[0]
                 input_sequence_names.add(strain_name)
                 for c,v in escape_dict.items():
                     strain_name = strain_name.replace(c,v)

--- a/tests/functional/tree/cram/generate-fasta.py
+++ b/tests/functional/tree/cram/generate-fasta.py
@@ -1,0 +1,28 @@
+import random
+
+def get_random_unicode(length):
+    """Adapted from <https://stackoverflow.com/a/21666621>"""
+
+    try:
+        get_char = unichr
+    except NameError:
+        get_char = chr
+
+    # code point ranges to be sampled
+    include_ranges = [
+        # ASCII non-control characters excluding single quote (0x27) and backslash (0x5c)
+        (0x20, 0x26), (0x28, 0x5b), (0x5d, 0x7e)
+    ]
+
+    alphabet = [
+        get_char(code_point) for current_range in include_ranges
+            for code_point in range(current_range[0], current_range[1] + 1)
+    ]
+    return ''.join(random.choice(alphabet) for _ in range(length))
+
+
+if __name__ == "__main__":
+    for i in range(10):
+        print('>' + get_random_unicode(5))
+        print("ATGC")
+

--- a/tests/functional/tree/cram/iqtree-name-modifications.t
+++ b/tests/functional/tree/cram/iqtree-name-modifications.t
@@ -1,0 +1,40 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+BACKGROUND: IQ tree modifies strain names to remove certain characters. We
+attempt to prevent this within augur tree (by replacing them on the way into
+IQ-TREE and switching them back on the way out). Beyond this certain characters
+can't be written by Bio.Phylo as newick strain names (without escaping).
+
+# Start with a trivial test
+
+  $ echo -e ">AAA\nATGC\n>BBB\nATGC\n>CCC\nATGC\n" > trivial.mfa
+
+  $ ${AUGUR} tree \
+  >  --method iqtree \
+  >  --alignment trivial.mfa \
+  >  --output trivial.new 1>/dev/null
+
+Test single quotes, which were the errors behind <https://github.com/nextstrain/augur/issues/1084>,
+<https://github.com/nextstrain/avian-flu/issues/122> 
+
+  $ echo -e ">Coted'Ivoire/IPCI-DVE-GR1901/2022\nATGC" > single-quotes.mfa
+  $ echo -e ">A/Geoffroy'sCat/WA/24-037410-004-original/2024\nATGC" >> single-quotes.mfa
+  $ echo -e ">need-three-taxa\nATGC" >> single-quotes.mfa
+
+  $ ${AUGUR} tree \
+  >  --method iqtree \
+  >  --alignment single-quotes.mfa \
+  >  --output single-quotes.new 1>/dev/null
+
+
+Test some other observed strain names to ensure they're not modified
+  $ echo -e ">A/PETFOOD/USA:OR/24-037325-011/2024\nATGC" > reported.mfa
+  $ echo -e ">[name>$!%]:1234\nATGC" >> reported.mfa
+  $ echo -e ">simple\nATGC" >> reported.mfa
+
+  $ ${AUGUR} tree \
+  >  --method iqtree \
+  >  --alignment reported.mfa \
+  >  --output reported.new 1>/dev/null

--- a/tests/functional/tree/cram/iqtree-name-modifications.t
+++ b/tests/functional/tree/cram/iqtree-name-modifications.t
@@ -48,3 +48,39 @@ Test some other observed strain names to ensure they're not modified
   >  --method iqtree \
   >  --alignment reported.mfa \
   >  --output reported.new 1>/dev/null
+
+
+Backslashes are problematic, but only some of the time. For instance (and assuming we replaced the
+character for the IQ-TREE building) the first three of these strains work and the others are
+escaped by `Bio.Phylo.write`. Erring on the side of caution we don't allow any backslashes,
+similar to single quotes.
+
+  $ echo '>sing\le' > backslashes.mfa
+  $ echo 'ATGC' >> backslashes.mfa
+  $ echo '>dou\\ble' >> backslashes.mfa
+  $ echo 'ATGC' >> backslashes.mfa
+  $ echo '>three\\\ee' >> backslashes.mfa
+  $ echo 'ATGC' >> backslashes.mfa
+  $ echo '>v~`,\' >> backslashes.mfa
+  $ echo 'ATGC' >> backslashes.mfa
+  $ echo '>wb)\o' >> backslashes.mfa
+  $ echo 'ATGC' >> backslashes.mfa
+
+  $ ${AUGUR} tree \
+  >  --method iqtree \
+  >  --alignment backslashes.mfa \
+  >  --output backslashes.new 1>/dev/null
+  ERROR: Certain strain names have characters which cannot be written in newick format (by Bio.Python, at least).
+  You should ensure these strain names are changed as early as possible in your analysis. The following
+  names are unescaped and surrounded by double quotes.
+  
+  Invalid strain names:
+    - .+ (re)
+    - .+ (re)
+    - .+ (re)
+    - .+ (re)
+    - .+ (re)
+  
+  Invalid characters: .* (re)
+  
+  [2]

--- a/tests/functional/tree/cram/iqtree-name-modifications.t
+++ b/tests/functional/tree/cram/iqtree-name-modifications.t
@@ -49,6 +49,20 @@ Test some other observed strain names to ensure they're not modified
   >  --alignment reported.mfa \
   >  --output reported.new 1>/dev/null
 
+Strain names with spaces are modified
+
+  $ echo -e ">space afterwards\nATGC" > spaces.mfa
+  $ echo -e ">name\nATGC" >> spaces.mfa
+  $ echo -e ">simple\nATGC" >> spaces.mfa
+
+  $ ${AUGUR} tree \
+  >  --method iqtree \
+  >  --alignment spaces.mfa \
+  >  --output spaces.new 1>/dev/null
+
+  $ grep 'afterwards' spaces.new
+  [1]
+
 
 Backslashes are problematic, but only some of the time. For instance (and assuming we replaced the
 character for the IQ-TREE building) the first three of these strains work and the others are

--- a/tests/functional/tree/cram/iqtree-name-modifications.t
+++ b/tests/functional/tree/cram/iqtree-name-modifications.t
@@ -84,3 +84,21 @@ similar to single quotes.
   Invalid characters: .* (re)
   
   [2]
+
+This test generates random ASCII names. It's disabled for CI as it's both
+stochastic and slow but you can easily toggle it back on (by uncommenting the
+function call) if you want to better test strain name handling in `augur tree`
+
+  $ random_ascii_names() {
+  >   python3 "$TESTDIR"/generate-fasta.py > random_${1}.mfa
+  >  
+  >   ${AUGUR} tree \
+  >    --method iqtree \
+  >    --alignment random_${1}.mfa \
+  >    --output random_${1}.new > /dev/null
+  > }
+
+  $ for iteration in $(seq 1 100); do
+  >    # random_ascii_names $iteration
+  >    :
+  > done

--- a/tests/functional/tree/cram/iqtree-name-modifications.t
+++ b/tests/functional/tree/cram/iqtree-name-modifications.t
@@ -27,7 +27,17 @@ Test single quotes, which were the errors behind <https://github.com/nextstrain/
   >  --method iqtree \
   >  --alignment single-quotes.mfa \
   >  --output single-quotes.new 1>/dev/null
-
+  ERROR: Certain strain names have characters which cannot be written in newick format (by Bio.Python, at least).
+  You should ensure these strain names are changed as early as possible in your analysis. The following
+  names are unescaped and surrounded by double quotes.
+  
+  Invalid strain names:
+    - .+ (re)
+    - .+ (re)
+  
+  Invalid characters: .* (re)
+  
+  [2]
 
 Test some other observed strain names to ensure they're not modified
   $ echo -e ">A/PETFOOD/USA:OR/24-037325-011/2024\nATGC" > reported.mfa


### PR DESCRIPTION
This PR increases the characters which `augur tree` will safely allow and adds a fatal error if single quotes or backslashes are in the strain name. See commit messages for details. As `augur tree` no longer modifies strain names this PR closes #1084, however ideally we would alert the user to the presence of those disallowed characters somewhere upstream of `augur tree`.

