### PR TITLE
[refine] prune outgroup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 
 ### Features
 
+* refine: Added a `--remove-outgroup` flag which can be used when rooting a tree on a single taxon. Rooting and removal of outgroup will be performed before any temporal inference, if applicable. [#1744][] (@jameshadfield)
 * Added standard geolocation rules in "augur/data/geolocation_rules.tsv" that can be used with `augur curate apply-geolocation-rules`. [#1744][] (@joverlee521)
 
 [#1744]: https://github.com/nextstrain/augur/pull/1744
@@ -23,6 +24,7 @@
 
 [#1743]: https://github.com/nextstrain/augur/pull/1743
 [#1746]: https://github.com/nextstrain/augur/pull/1746
+[#1751]: https://github.com/nextstrain/augur/pull/1751
 
 ## 28.0.0 (30 January 2025)
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -112,7 +112,7 @@ def root_outside_of_treetime(T, root, is_timetree):
                 print("Warning: To root without inferring a timetree, you must specify an explicit outgroup.")
                 print("\tProceeding without re-rooting. To suppress this message, use '--keep-root'.\n")
             else:
-                raise TypeError("The rooting option '%s' is only available when inferring a timetree. Please specify an explicit outgroup."%root)
+                raise AugurError(f"The rooting option {root[0]!r} is only available when inferring a timetree. Please specify an explicit outgroup or 'mid_point'.")
     elif root[0]=="mid_point" and len(root)==1:
         T.root_at_midpoint()
     else:

--- a/tests/functional/refine/cram/rooting-invalid.t
+++ b/tests/functional/refine/cram/rooting-invalid.t
@@ -1,0 +1,22 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Attempt to root on a strain which is not in the tree is an error
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" --metadata "$TESTDIR/../data/metadata.tsv" --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --output-tree tree.nwk --output-node-data branch_lengths.json \
+  >  --root not-in-tree > /dev/null
+  ERROR: Rooting with the provided strain name(s) failed.
+  This is probably because the following names supplied to '--root' were not found in the tree:
+    - 'not-in-tree'
+  
+  [2]
+
+Check that rooting on multiple (valid) sequences + '--remove-outgroup' is an error
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" --metadata "$TESTDIR/../data/metadata.tsv" --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --output-tree tree.nwk --output-node-data branch_lengths.json \
+  >  --root 'Colombia/2016/ZC204Se' 'VEN/UF_1/2016' --remove-outgroup > /dev/null
+  ERROR: --remove-outgroup is not valid with 'multiple strains' rooting - you must supply a single strain (outgroup) to root the tree
+  [2]

--- a/tests/functional/refine/cram/rooting-outgroup.t
+++ b/tests/functional/refine/cram/rooting-outgroup.t
@@ -1,0 +1,24 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Check that rooting on an outgroup strain actually works
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" --metadata "$TESTDIR/../data/metadata.tsv" --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --output-tree tree1.nwk --output-node-data branch_lengths1.json \
+  >  --root 'Colombia/2016/ZC204Se' > /dev/null
+
+  $ python3 "$TESTDIR/../report-root.py" tree1.nwk
+  Tree root has a single terminal child 'Colombia/2016/ZC204Se'
+
+Check that rooting on an outgroup strain with '--remove-outgroup' does remove it 
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" --metadata "$TESTDIR/../data/metadata.tsv" --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --output-tree tree2.nwk --output-node-data branch_lengths2.json \
+  >  --root 'Colombia/2016/ZC204Se' --remove-outgroup > /dev/null
+
+  $ grep 'Colombia/2016/ZC204Se' tree2.nwk
+  [1]
+
+  $ python3 "$TESTDIR/../report-root.py" tree2.nwk
+  No children of the root were terminal nodes

--- a/tests/functional/refine/report-root.py
+++ b/tests/functional/refine/report-root.py
@@ -1,0 +1,12 @@
+import sys
+from augur.utils import read_tree
+
+if __name__ == "__main__":
+    T = read_tree(sys.argv[1])
+    root_child_tips = [c for c in T.root.clades if c.is_terminal()]
+    if len(root_child_tips)==0:
+        print("No children of the root were terminal nodes")
+    elif len(root_child_tips)>1:
+        print("Multiple children of the root were terminal nodes")
+    else:
+        print(f"Tree root has a single terminal child {root_child_tips[0].name!r}")


### PR DESCRIPTION
Refactors `augur refine` to root trees before TreeTime is called, where possible. This allows us to easily add a `--remove-outgroup` flag which works only when the tree is rooted on a single strain, and the pruning of the root is performed before any temporal inference (if applicable). This approach is the one recommended by @rneher, @emmahodcroft and @huddlej in #340. 

@joverlee521 I explored patching seasonal-flu to incorporate this however the structure there is a little complicated. Specifically, if the `prune_reference` rule is dropped in lieu of `--remove-outgroup` in the `refine` step then the reference sequences may/will be removed via the `sanitize_trees` step (which is before `refine`) as the references (often? always?) differ across segments. 

Closes #340 