### PR TITLE
Composable auspice config 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,16 @@
 
 ## __NEXT__
 
+### Major Changes
+
+* export v2: Allow multiple auspice config files (`--auspice-config`) which are merged together. Note that the merging of lists extends the original list, although elements representing the same data are overwritten instead. You can optionally write out this merged config via `--output-auspice-config` for debugging purposes. [#1756][] (@jameshadfield)
+
+
 ### Bug fixes
 
 * titers: Improve error messages when titer models do not have enough data. [#1769][] (@huddlej)
 
+[#1756]: https://github.com/nextstrain/augur/pull/1756
 [#1769]: https://github.com/nextstrain/augur/pull/1769
 
 ## 29.0.0 (26 February 2025)

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -13,7 +13,8 @@ from .argparse_ import ExtendOverwriteDefault
 from .errors import AugurError
 from .io.metadata import DEFAULT_DELIMITERS, InvalidDelimiter, read_metadata
 from .io.sequences import read_sequences, read_single_sequence
-from .utils import read_node_data, write_json, read_config, read_lat_longs, read_colors
+from .utils import read_node_data, write_json, read_lat_longs, read_colors
+from .util_support.auspice_config import read_json as read_config
 
 def convert_tree_to_json_structure(node, metadata, div=0, strains=None):
     """

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import sys
 import time
 from collections import defaultdict, deque, OrderedDict
-import warnings
 import numbers
 import math
 import re
@@ -19,40 +18,15 @@ from .io.file import open_file
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
 from .types import ValidationMode
 from .utils import read_node_data, write_json, json_size, read_config, read_lat_longs, read_colors
+from .util_support.warnings import configure_warnings, warn, deprecated, deprecationWarningsEmitted
 from .validate import export_v2 as validate_v2, auspice_config_v2 as validate_auspice_config_v2, ValidateError
 from .version import __version__
-
 
 MINIFY_THRESHOLD_MB = 5
 
 # Invalid metadata columns because they are used internally by Auspice
 INVALID_METADATA_COLUMNS = ("none")
 
-
-# Set up warnings & exceptions
-deprecationWarningsEmitted = False
-
-def deprecated(message):
-    warnings.warn(message, DeprecationWarning, stacklevel=2)
-    global deprecationWarningsEmitted
-    deprecationWarningsEmitted=True
-
-def warn(message):
-    warnings.warn(message, UserWarning, stacklevel=2)
-
-def configure_warnings():
-    # we must only set these when someone runs `augur export v2` (i.e. run_v2() is called)
-    # else they will apply to _all_ augur commands due to the way all commands are pulled
-    # in by the augur runner (augur/__init__.py)
-    def customformatwarning(message, category, filename, lineno, line=None):
-        if category.__name__ == "UserWarning":
-            return "WARNING: {}\n\n".format(message)
-        if category.__name__ == "DeprecationWarning":
-            return "DEPRECATED: {}\n\n".format(message)
-        return "{}\n".format(message)
-
-    warnings.formatwarning = customformatwarning
-    warnings.simplefilter("default") # show DeprecationWarnings by default
 
 class InvalidOption(Exception):
     pass
@@ -1350,7 +1324,7 @@ def run(args):
     # validate outputs
     validate_data_json(args.output, args.validation_mode)
 
-    if deprecationWarningsEmitted:
+    if deprecationWarningsEmitted():
         print("\n------------------------")
         print("There were deprecation warnings displayed. They have been fixed but these will likely become breaking errors in a future version of augur.")
         print("------------------------")

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -30,16 +30,15 @@ INVALID_METADATA_COLUMNS = ("none")
 
 
 # Set up warnings & exceptions
-warn = warnings.warn
 deprecationWarningsEmitted = False
 
 def deprecated(message):
-    warn(message, DeprecationWarning, stacklevel=2)
+    warnings.warn(message, DeprecationWarning, stacklevel=2)
     global deprecationWarningsEmitted
     deprecationWarningsEmitted=True
 
-def warning(message):
-    warn(message, UserWarning, stacklevel=2)
+def warn(message):
+    warnings.warn(message, UserWarning, stacklevel=2)
 
 def configure_warnings():
     # we must only set these when someone runs `augur export v2` (i.e. run_v2() is called)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -968,24 +968,6 @@ def register_parser(parent_subparsers):
     return parser
 
 
-def set_display_defaults(data_json, config):
-    defaults = config.get('display_defaults', {})
-
-    v1_v2_keys = [ # each item: [0] v2 key name. [1] deprecated v1 key name
-        ["geo_resolution", "geoResolution"],
-        ["color_by", "colorBy"],
-        ["distance_measure", "distanceMeasure"],
-        ["map_triplicate", "mapTriplicate"]
-    ]
-
-    for [v2_key, v1_key] in [x for x in v1_v2_keys if x[1] in defaults]:
-        deprecated("[config file] '{}' has been replaced with '{}'".format(v1_key, v2_key))
-        defaults[v2_key] = defaults[v1_key]
-        del defaults[v1_key]
-
-    if defaults:
-        data_json['meta']["display_defaults"] = defaults
-
 def set_maintainers(data_json, config, cmd_line_maintainers):
     # Command-line args overwrite the config file
     # They may or may not all have URLs
@@ -1209,7 +1191,8 @@ def run(args):
 
     # set metadata data structures
     set_title(data_json, config, args.title)
-    set_display_defaults(data_json, config)
+    if 'display_defaults' in config:
+        data_json['meta']["display_defaults"] = config['display_defaults']
     set_maintainers(data_json, config, args.maintainers)
     set_build_url(data_json, config, args.build_url)
     set_build_avatar(data_json, config)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -954,6 +954,8 @@ def register_parser(parent_subparsers):
         title="OTHER OPTIONAL SETTINGS"
     )
     add_validation_arguments(optional_settings)
+    optional_settings.add_argument('--output-auspice-config', metavar="JSON", type=str,
+        help="Write out the merged auspice configuration file for debugging purposes etc. File is only written if you provide multiple config files via --auspice-config.")
 
     return parser
 
@@ -1162,7 +1164,7 @@ def run(args):
     T = Phylo.read(args.tree, 'newick')
     node_data, node_attrs, node_data_names, metadata_names, branch_attrs = \
             parse_node_data_and_metadata(T, node_data_file, metadata_file)
-    config = read_auspice_configs(*args.auspice_config, validation_mode=args.validation_mode)
+    config = read_auspice_configs(*args.auspice_config, validation_mode=args.validation_mode, output_fname=args.output_auspice_config)
     additional_metadata_columns = get_additional_metadata_columns(config, args.metadata_columns, metadata_names)
 
     # set metadata data structures

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -41,10 +41,6 @@ def deprecated(message):
 def warning(message):
     warn(message, UserWarning, stacklevel=2)
 
-def fatal(message):
-    print("FATAL ERROR: {}".format(message))
-    sys.exit(2)
-
 def configure_warnings():
     # we must only set these when someone runs `augur export v2` (i.e. run_v2() is called)
     # else they will apply to _all_ augur commands due to the way all commands are pulled
@@ -1102,7 +1098,7 @@ def set_description(data_json, cmd_line_description_file):
             markdown_text = description_file.read()
         data_json['meta']['description'] = markdown_text
     except FileNotFoundError:
-        fatal("Provided desciption file {} does not exist".format(cmd_line_description_file))
+        raise AugurError("Provided description file {} does not exist".format(cmd_line_description_file))
 
 def set_warning(data_json, text_or_file):
     """
@@ -1349,7 +1345,7 @@ def run(args):
                 root_sequence_path = output_path.parent / Path(output_path.stem + "_root-sequence" + output_path.suffix)
                 write_json(data=node_data['reference'], file=root_sequence_path, include_version=False, **indent)
         else:
-            fatal("Root sequence output was requested, but the node data provided is missing a 'reference' key.")
+            raise AugurError("Root sequence output was requested, but the node data provided is missing a 'reference' key.")
     write_json(data=orderKeys(data_json), file=args.output, include_version=False, **indent)
 
     # validate outputs

--- a/augur/util_support/auspice_config.py
+++ b/augur/util_support/auspice_config.py
@@ -71,11 +71,26 @@ def _parse_color_options(options: Any) -> list[dict]:
         colorings.append({"key": key, **info})
     return colorings
 
+def _rename_display_keys(display: dict) -> dict:
+    defaults = {**display}
+    v1_v2_keys = [
+        # [ <old key>, <new key> ]
+        ["geoResolution", "geo_resolution"],
+        ["colorBy", "color_by"],
+        ["distanceMeasure", "distance_measure"],
+        ["mapTriplicate", "map_triplicate"]
+    ]
+    for [v1_key, v2_key] in [x for x in v1_v2_keys if x[0] in defaults]:
+        deprecated("[config file] '{}' has been replaced with '{}'".format(v1_key, v2_key))
+        defaults[v2_key] = defaults[v1_key]
+        del defaults[v1_key]
+    return defaults
+
 
 DEPRECATIONS = [
     {"old_name": 'vaccine_choices', "new_name": None}, # removed from config
     {"old_name": "updated", "new_name": None}, # removed from config
-    {"old_name": "defaults", "new_name": "display_defaults", "modify": None},
+    {"old_name": "defaults", "new_name": "display_defaults", "modify": _rename_display_keys},
     {"old_name": "maintainer", "new_name": "maintainers", "modify": lambda m: [{"name": m[0], "url": m[1]}]},
     {"old_name": "geo", "new_name": "geo_resolutions", "modify": lambda values: [{"key": v} for v in values]},
     {"old_name": "color_options", "new_name": "colorings", "modify": _parse_color_options},

--- a/augur/util_support/auspice_config.py
+++ b/augur/util_support/auspice_config.py
@@ -1,0 +1,92 @@
+import sys
+import os
+import json
+from ..io.file import open_file
+from ..errors import AugurError
+from .warnings import deprecated
+from collections import defaultdict
+from typing import Union, Any
+from collections.abc import Callable
+
+
+def read_json(fname):
+    if not (fname and os.path.isfile(fname)):
+        print("ERROR: config file %s not found."%fname)
+        return defaultdict(dict)
+
+    try:
+        with open_file(fname, 'rb') as ifile:
+            config = json.load(ifile)
+    except json.decoder.JSONDecodeError as err:
+        print("FATAL ERROR:")
+        print("\tCouldn't parse the JSON file {}".format(fname))
+        print("\tError message: '{}'".format(err.msg))
+        print("\tLine number: '{}'".format(err.lineno))
+        print("\tColumn number: '{}'".format(err.colno))
+        print("\tYou must correct this file in order to proceed.")
+        sys.exit(2)
+
+    return config
+
+def _replace_deprecated(config: dict[str,Any], old_name: str, new_name: Union[None,str], modify: Union[None, Callable]=None):
+    if old_name not in config:
+        return # NO-OP
+    elif new_name is None:
+        deprecated(f"[config file] key {old_name!r} is no longer used and has been dropped from your config")
+        del config[old_name]
+    elif new_name in config:
+        deprecated(f"[config file] top level keys {new_name!r} and {old_name!r} were both present, " \
+                   "however the latter is a deprecated version of the former and will be ignored.")
+        del config[old_name]
+    else:
+        deprecated(f"[config file] top level key {old_name!r} is deprecated. Renaming to {new_name!r}" +
+                   (" (with modifications)" if modify else ""))
+        config[new_name] = modify(config[old_name]) if modify else config[old_name]
+        del config[old_name]
+
+def _parse_color_options(options: Any) -> list[dict]:
+    # parse v1-style 'color_options' & convert to v2-style 'colorings'
+    if not isinstance(options, dict):
+        raise AugurError(f"[config file] The deprecated field 'color_options' must be a dictionary")
+    colorings = []
+    for key, info in options.items():
+        # note: if both legendTitle & menuItem are present then we use the latter. See https://github.com/nextstrain/auspice/issues/730
+        if "menuItem" in info:
+            deprecated("[config file] coloring '{}': 'menuItem' has been replaced with 'title'. Using 'menuItem' as 'title'.".format(key))
+            info["title"] = info["menuItem"]
+            del info["menuItem"]
+        if "legendTitle" in info:
+            if "title" in info: # this can only have been set via menuItem ^^^
+                deprecated("[config file] coloring '{}': 'legendTitle' has been replaced with 'title' & is unused since 'menuItem' is present.".format(key))
+            else:
+                deprecated("[config file] coloring '{}': 'legendTitle' has been replaced with 'title'. Using 'legendTitle' as 'title'.".format(key))
+                info["title"] = info["legendTitle"]
+            del info["legendTitle"]
+        if "key" in info:
+            del info["key"]
+        if info.get("type") == "discrete":
+            deprecated("[config file] coloring '{}': type 'discrete' is no longer valid. Please use 'ordinal', 'categorical' or 'boolean'. "
+                "This has been automatically changed to 'categorical'.".format(key))
+            info["type"] = "categorical"
+        colorings.append({"key": key, **info})
+    return colorings
+
+
+DEPRECATIONS = [
+    {"old_name": 'vaccine_choices', "new_name": None}, # removed from config
+    {"old_name": "updated", "new_name": None}, # removed from config
+    {"old_name": "defaults", "new_name": "display_defaults", "modify": None},
+    {"old_name": "maintainer", "new_name": "maintainers", "modify": lambda m: [{"name": m[0], "url": m[1]}]},
+    {"old_name": "geo", "new_name": "geo_resolutions", "modify": lambda values: [{"key": v} for v in values]},
+    {"old_name": "color_options", "new_name": "colorings", "modify": _parse_color_options},
+]
+
+
+def read_auspice_config(fname):
+
+    config = read_json(fname)
+
+    for data in DEPRECATIONS:
+        _replace_deprecated(config, **data)
+
+    return config

--- a/augur/util_support/warnings.py
+++ b/augur/util_support/warnings.py
@@ -1,0 +1,34 @@
+import warnings
+
+# Set up warnings & exceptions
+_deprecationWarningsEmitted = False
+
+def deprecated(message):
+    warnings.warn(message, DeprecationWarning, stacklevel=2)
+    global _deprecationWarningsEmitted
+    _deprecationWarningsEmitted=True
+
+def warn(message):
+    warnings.warn(message, UserWarning, stacklevel=2)
+
+def configure_warnings():
+    # This function must be run before any calls to `warn()` and `deprecated()`, however
+    # don't execute the code here since that would apply this configuration to _all_
+    # augur commands due to the way all commands are pulled in by the augur runner (augur/__init__.py)
+    #
+    # Intended usage: call this function at the top of the entry function for the augur (sub)command, e.g.
+    #       def run(args):
+    #           configure_warnings()
+    #           ...
+    def customformatwarning(message, category, filename, lineno, line=None):
+        if category.__name__ == "UserWarning":
+            return "WARNING: {}\n\n".format(message)
+        if category.__name__ == "DeprecationWarning":
+            return "DEPRECATED: {}\n\n".format(message)
+        return "{}\n".format(message)
+
+    warnings.formatwarning = customformatwarning
+    warnings.simplefilter("default") # show DeprecationWarnings by default
+
+def deprecationWarningsEmitted():
+    return _deprecationWarningsEmitted

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -4,7 +4,7 @@ import Bio.Phylo
 import numpy as np
 import os, json, sys
 import pandas as pd
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict
 from io import RawIOBase
 from .__version__ import __version__
 
@@ -434,25 +434,6 @@ def _read_genbank(reference, feature_names):
         print(f"WARNING: {features_skipped} CDS features skipped as they didn't have a locus_tag or gene qualifier.")
 
     return features
-
-def read_config(fname):
-    if not (fname and os.path.isfile(fname)):
-        print("ERROR: config file %s not found."%fname)
-        return defaultdict(dict)
-
-    try:
-        with open_file(fname, 'rb') as ifile:
-            config = json.load(ifile)
-    except json.decoder.JSONDecodeError as err:
-        print("FATAL ERROR:")
-        print("\tCouldn't parse the JSON file {}".format(fname))
-        print("\tError message: '{}'".format(err.msg))
-        print("\tLine number: '{}'".format(err.lineno))
-        print("\tColumn number: '{}'".format(err.colno))
-        print("\tYou must correct this file in order to proceed.")
-        sys.exit(2)
-
-    return config
 
 def read_lat_longs(overrides=None, use_defaults=True):
     coordinates = {}

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -17,6 +17,7 @@ from augur.io.file import open_file
 from augur.io.print import print_err
 from augur.io.json import shorten_as_json
 from .validate_export import verifyMainJSONIsInternallyConsistent, verifyMetaAndOrTreeJSONsAreInternallyConsistent
+from .types import ValidationMode
 
 def fatal(message):
     print("FATAL ERROR: {}".format(message))
@@ -25,6 +26,16 @@ def fatal(message):
 class ValidateError(Exception):
     pass
 
+def validation_failure(mode: ValidationMode):
+    if mode is ValidationMode.ERROR:
+        sys.exit(2)
+    elif mode is ValidationMode.WARN:
+        print(f"Continuing due to --validation-mode={mode.value} even though there were validation errors.")
+    elif mode is ValidationMode.SKIP:
+        # Shouldn't be doing validation under skip, but if we're called anyway just do nothing.
+        return
+    else:
+        raise ValueError(f"unknown validation mode: {mode!r}")
 
 def load_json_schema(path, refs=None):
     '''

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -196,9 +196,9 @@ def grouped(iterable, key):
 validate = validate_json  # TODO update uses and drop this alias
 
 
-def auspice_config_v2(config_json, **kwargs):
+def auspice_config_v2(config_json: Union[str,dict], **kwargs):
     schema = load_json_schema("schema-auspice-config-v2.json")
-    config = load_json(config_json)
+    config = config_json if isinstance(config_json, dict) else load_json(config_json)
     validate(config, schema, config_json)
 
 def export_v2(main_json, **kwargs):

--- a/docs/api/developer/augur.util_support.auspice_config.rst
+++ b/docs/api/developer/augur.util_support.auspice_config.rst
@@ -1,0 +1,7 @@
+augur.util\_support.auspice\_config module
+==========================================
+
+.. automodule:: augur.util_support.auspice_config
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/developer/augur.util_support.rst
+++ b/docs/api/developer/augur.util_support.rst
@@ -12,8 +12,10 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   augur.util_support.auspice_config
    augur.util_support.color_parser
    augur.util_support.color_parser_line
    augur.util_support.node_data
    augur.util_support.node_data_file
    augur.util_support.node_data_reader
+   augur.util_support.warnings

--- a/docs/api/developer/augur.util_support.warnings.rst
+++ b/docs/api/developer/augur.util_support.warnings.rst
@@ -1,0 +1,7 @@
+augur.util\_support.warnings module
+===================================
+
+.. automodule:: augur.util_support.warnings
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/tests/util_support/test_auspice_config.py
+++ b/tests/util_support/test_auspice_config.py
@@ -1,0 +1,174 @@
+from augur.util_support.auspice_config import merge_configs
+from augur.errors import AugurError
+from augur.types import ValidationMode
+
+import pytest
+
+SKIP = ValidationMode.SKIP
+
+class TestScalarMergeTitle:
+
+    def test_overwrite(self):
+        configs = [
+            {'title': 'FIRST',},
+            {'title': 'SECOND',},
+        ]
+        merged = merge_configs(configs, SKIP)
+        assert merged['title'] == 'SECOND'
+
+    def test_a_or_b(self):
+        merged = merge_configs([{'title': 'FIRST',}, {}], SKIP)
+        assert merged['title'] == 'FIRST'
+        merged = merge_configs([{}, {'title': 'SECOND',}], SKIP)
+        assert merged['title'] == 'SECOND'
+
+
+
+class TestListMergeColorings:
+
+    def test_simple_extend(self):
+        configs = [
+            {
+                'colorings': [
+                    {'key': 'a', 'title': 'A', 'type': 'categorical'},
+                ]
+            },
+            {
+                'colorings': [
+                    {'key': 'b', 'title': 'B', 'type': 'categorical'},
+                    {'key': 'c', 'title': 'C', 'type': 'categorical'},
+                ]
+            }
+        ]
+        merged = merge_configs(configs, SKIP)
+        assert len(merged['colorings']) == 3
+        assert [c['key'] for c in merged['colorings']] == ['a', 'b', 'c']
+
+    def test_a_or_b(self):
+        config = {
+            'colorings': [
+                {'key': 'a', 'title': 'A', 'type': 'categorical'},
+            ]
+        }
+        merged1 = merge_configs([config, {}], SKIP)
+        assert len(merged1['colorings']) == 1
+        assert [c['key'] for c in merged1['colorings']] == ['a']
+
+        merged2 = merge_configs([{}, config], SKIP)
+        assert merged1 == merged2
+
+    def test_overwrite(self):
+        configs = [
+            {
+                'colorings': [
+                    {'key': 'a', 'title': 'A', 'type': 'categorical'},
+                ]
+            },
+            {
+                'colorings': [
+                    {'key': 'b', 'title': 'B', 'type': 'categorical'},
+                    {'key': 'a', 'title': 'A_new', 'type': 'temporal'},
+                ]
+            }
+        ]
+        merged = merge_configs(configs, SKIP)
+        assert len(merged['colorings']) == 2
+        assert [c['key'] for c in merged['colorings']] == ['a', 'b']
+        assert merged['colorings'][0] == configs[1]['colorings'][1]
+
+
+class TestListMergeMetadataColumns:
+
+    def test_simple_extend(self):
+        configs = [
+            {
+                'metadata_columns': ['one', 'two', 'three']
+            },
+            {
+                'metadata_columns': ['four', 'five', 'six']
+            }
+        ]
+        merged = merge_configs(configs, SKIP)
+        assert len(merged['metadata_columns']) == 6
+        assert merged['metadata_columns'][3] == 'four'
+
+    def test_overwrite(self):
+        configs = [
+            {
+                'metadata_columns': ['one', 'two', 'three']
+            },
+            {
+                'metadata_columns': ['four', 'two', 'one']
+            }
+        ]
+        merged = merge_configs(configs, SKIP)
+        assert len(merged['metadata_columns']) == 4
+        assert merged['metadata_columns'] == ['one', 'two', 'three', 'four']
+
+
+class TestDictMergeDisplayDefaults:
+
+    def test_simple_extend(self):
+        configs = [
+            {
+                'display_defaults': {
+                    "map_triplicate": True
+                }
+            },
+            {
+                'display_defaults': {
+                    "color_by": "country"
+                }
+            }
+        ]
+        merged = merge_configs(configs, SKIP)
+        assert list(merged['display_defaults'].items()) == [('map_triplicate', True), ('color_by', 'country')] # order stable
+
+
+    def test_a_or_b(self):
+        config = {
+            'display_defaults': {
+                "map_triplicate": False
+            }
+        }
+        merged1 = merge_configs([config, {}], SKIP)
+        assert list(merged1['display_defaults'].items()) == [('map_triplicate', False)]
+
+        merged2 = merge_configs([{}, config], SKIP)
+        assert merged1==merged2
+
+
+    def test_overwrite(self):
+        configs = [
+            {
+                'display_defaults': {
+                    "panels": ['map', 'frequencies'],
+                    "map_triplicate": True,
+                }
+            },
+            {
+                'display_defaults': {
+                    "color_by": "country",
+                    "map_triplicate": False,
+                    "panels": ['tree'],
+                }
+            }
+        ]
+        merged = merge_configs(configs, SKIP)
+        assert list(merged['display_defaults'].keys()) == ['panels', 'map_triplicate', 'color_by']
+        assert merged['display_defaults']['map_triplicate'] is False
+        assert merged['display_defaults']['panels'] == ['tree'] # original list clobbered
+
+    def test_non_dicts_are_error(self):
+        configs = [
+            {
+                'display_defaults': {
+                    "map_triplicate": True
+                }
+            },
+            {
+                'display_defaults': 'country'
+            }
+        ]
+        with pytest.raises(AugurError):
+            merged = merge_configs(configs, SKIP)


### PR DESCRIPTION
Closes #298 

See commit messages for details, but there's a few parts I want to call out explicitly:

### Merging approach

Specifically, merging of lists is done by extending the original list, rather than simply replacing it. We use a custom approach to decide whether new elements should be added to the list or replace already-present elements. As an example:

```json
{
  "colorings": [
    {"key": "num_date", "title": "date", "type": "continuous"}
  ]
}
```

```json
{
  "colorings": [
    {"key": "country", "title": "Country", "type": "categorical"},
    {"key": "num_date", "title": "Sampling Date", "type": "continuous"}
  ]
}
```

Here the second JSON's `num_date` coloring replaces the first JSONs one, and the `country` coloring is added in, so we end up with:

```json
{
  "colorings": [
    {"key": "num_date", "title": "Sampling Date", "type": "continuous"}
    {"key": "country", "title": "Country", "type": "categorical"},
  ]
}
```

I think this is the only practical way to combine colorings in multiple configs, but we also use lists for many other options, e.g. 'panels', 'maintainers'. This PR still uses the same approach, but I'm less convinced for non-coloring options such as these whether we should extend lists or simply replace them.

Note that we don't really do deep merging here at all. This only applies in one situation as far as I can tell, [`config.display_defaults.panels: list[str]`](https://github.com/nextstrain/augur/blob/bbadca3cd42e0de67016a951759bad5579aa96f5/augur/data/schema-auspice-config-v2.json#L211-L219) where overlay configs will completely replace the original list, and this is different from how `config.panels` currently behaves.


### Refactoring of warnings code

This changed all usages of (export v2's) `warn()` to `warning()`, which in practice only changes [the stacklevel](https://docs.python.org/3/library/warnings.html#warnings.warn), which changes... nothing? The `warning()` helper function was added [years ago](https://github.com/nextstrain/augur/commit/b225bd00fe71330ae93f846e3991bdc66f434000) but saw ~no usage, so I think we should either use it consistently (as done here) or remove it and just use the default `warn()`. 

### Validate then merge

The approach here is to validate each config JSON independently, rather than merging then validating. (This works well since our schema has no required properties.) `augur validate auspice-config-v2` _hasn't_ been updated to allow multiple auspice configs, but we could do so if we want (requires a little refactoring to avoid circular imports). We could additionally validate the merged config if people want to, although the current implementation guarantees that valid configs produce a valid merged config.

### Long term direction

This work paves the way to merging in all config-related command line args within `auspice_config.py` which should help clean up `export_v2.py` quite a bit.

I didn't add an option to write out the merged config, but I know this is a subject that's been discussed quite a bit in the context of snakemake config merging so we could add this here if wanted.


### Still to do:
- [x] regenerate docs. I need to follow Jover's instructions here as with my setup (py 3.10) I introduce changes to every docs file.
- [x] changelog


