### PR TITLE
Update schemas with build_avatar #818

### DIFF
--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -148,7 +148,7 @@
           "type": "string"
         },
         "build_avatar": {
-            "description": "The custom avatar image URL allows users to include a group-specific logo, even if it is hosted outside of GitHub.",
+            "description": "The custom avatar image URL allows users to include a logo, even if it is hosted outside of GitHub.",
             "$comment": "Auspice displays this at the top of the page as part of a byline",
             "type": "string"
         },

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -147,6 +147,11 @@
           "$comment": "Auspice displays this at the top of the page as part of a byline",
           "type": "string"
         },
+        "build_avatar": {
+            "description": "The custom avatar image URL allows users to include a group-specific logo, even if it is hosted outside of GitHub.",
+            "$comment": "Auspice displays this at the top of the page as part of a byline",
+            "type": "string"
+        },
         "filters": {
           "description": "These appear as filters in the footer of Auspice (which populates the displayed values based upon the tree)",
           "$comment": "These values must be present as keys on a tree node -> trait",

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -29,6 +29,11 @@
                 "build_url" : {
                     "$ref": "https://nextstrain.org/schemas/auspice/config/v2#/properties/build_url"
                 },
+                "build_avatar": {
+                    "description": "The custom avatar image URL allows users to include a group-specific logo, even if it is hosted outside of GitHub.",
+                    "$comment": "Auspice displays this at the top of the page as part of a byline",
+                    "type": "string"
+                },
                 "description" : {
                     "description": "Auspice displays this currently in the footer.",
                     "$comment": "Generally a description of the phylogeny and/or acknowledgements in Markdown format.",

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -30,7 +30,7 @@
                     "$ref": "https://nextstrain.org/schemas/auspice/config/v2#/properties/build_url"
                 },
                 "build_avatar": {
-                    "description": "The custom avatar image URL allows users to include a group-specific logo, even if it is hosted outside of GitHub.",
+                    "description": "The custom avatar image URL allows users to include a logo, even if it is hosted outside of GitHub.",
                     "$comment": "Auspice displays this at the top of the page as part of a byline",
                     "type": "string"
                 },

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -29,10 +29,8 @@
                 "build_url" : {
                     "$ref": "https://nextstrain.org/schemas/auspice/config/v2#/properties/build_url"
                 },
-                "build_avatar": {
-                    "description": "The custom avatar image URL allows users to include a logo, even if it is hosted outside of GitHub.",
-                    "$comment": "Auspice displays this at the top of the page as part of a byline",
-                    "type": "string"
+                "build_avatar" : {
+                    "$ref": "https://nextstrain.org/schemas/auspice/config/v2#/properties/build_avatar"
                 },
                 "description" : {
                     "description": "Auspice displays this currently in the footer.",

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -104,7 +104,7 @@ def orderKeys(data):
     od = CustomOrderedDict(data)
     od.set_order("version", "meta", "tree")
     if "meta" in od:
-        od["meta"].set_order("title", "updated", "build_url", "data_provenance", "maintainers")
+        od["meta"].set_order("title", "updated", "build_url", "build_avatar", "data_provenance", "maintainers")
         for coloring in od['meta'].get('colorings', []):
             coloring.set_order("key", "title", "type", "scale", "legend")
     def order_nodes(node):

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -1079,6 +1079,11 @@ def set_build_url(data_json, config, cmd_line_build_url):
     elif config.get("build_url"):
         data_json['meta']['build_url'] = config.get("build_url")
 
+def set_build_avatar(data_json, config):
+    # build_avatar is not necessary. No cmd line args handling
+    if config.get("build_avatar"):
+        data_json['meta']['build_avatar'] = config.get("build_avatar")
+
 def set_description(data_json, cmd_line_description_file):
     """
     Read Markdown file provided by *cmd_line_description_file* and set
@@ -1271,6 +1276,7 @@ def run(args):
     set_display_defaults(data_json, config)
     set_maintainers(data_json, config, args.maintainers)
     set_build_url(data_json, config, args.build_url)
+    set_build_avatar(data_json, config)
     set_annotations(data_json, node_data)
     if args.description:
         set_description(data_json, args.description)


### PR DESCRIPTION
## Description of proposed changes

Schema information added for build_avatar in schema-annotations.json and schema-export-v2.json file. 

## Related issue(s)
#818 

## Checklist

- [ ] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
