### PR TITLE
Export ambiguous date strings for tips

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 
 * refine: Added a `--remove-outgroup` flag which can be used when rooting a tree on a single taxon. Rooting and removal of outgroup will be performed before any temporal inference, if applicable. [#1744][] (@jameshadfield)
 * Added standard geolocation rules in "augur/data/geolocation_rules.tsv" that can be used with `augur curate apply-geolocation-rules`. [#1744][] (@joverlee521)
+* [refine, export] Ambiguous dates (e.g. those with "XX" in the date string) are now exported in the Auspice JSON, and all tips now have an additional  "inferred" boolean property. These changes only apply to temporal trees. [#1760][] (@jameshadfield)
 
 ### Bug fixes
 
@@ -24,6 +25,7 @@ Note that names with spaces in the FASTA header (description line) continue to b
 [#1749]: https://github.com/nextstrain/augur/pull/1749
 [#1750]: https://github.com/nextstrain/augur/pull/1750
 [#1755]: https://github.com/nextstrain/augur/pull/1755
+[#1760]: https://github.com/nextstrain/augur/pull/1760
 
 ## 28.0.1 (10 February 2025)
 

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -167,6 +167,14 @@
                                         {"type": "number"},
                                         {"type": "number"}
                                     ]
+                                },
+                                "inferred": {
+                                    "type": "boolean",
+                                    "description": "[terminal nodes only] was the 'value' inferred or known?"
+                                },
+                                "raw_value": {
+                                    "type": "string",
+                                    "description": "[terminal nodes only, and only if inferred=true] the known (ambiguous) date string"
                                 }
                             }
                         },

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -859,6 +859,13 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
         if is_valid(raw_data.get("num_date", None)): # it's ok not to have temporal information
             node["node_attrs"]["num_date"] = {"value": format_number(raw_data["num_date"])}
             node["node_attrs"]["num_date"].update(attr_confidence(node["name"], raw_data, "num_date"))
+            # For tips, transfer information about whether the date was inferred or known
+            # and if it was inferred then store the underlying (ambiguous) date string
+            if len(node.get('children', []))==0 and 'date_inferred' in raw_data:
+                node["node_attrs"]["num_date"]["inferred"] = raw_data['date_inferred']
+                if raw_data['date_inferred'] and raw_data.get('raw_date', False):
+                    node["node_attrs"]["num_date"]["raw_value"] = raw_data['raw_date']
+
 
     def _transfer_url_accession(node, raw_data):
         for prop in ["url", "accession"]:
@@ -918,6 +925,7 @@ def node_data_prop_is_normal_trait(name):
         'clock_length',
         'mutation_length',
         'date',
+        'date_inferred',
         'muts',
         'aa_muts',
         'sequence',

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -346,7 +346,11 @@ def run(args):
                 )
                 return 1
 
-        attributes.extend(['numdate', 'clock_length', 'mutation_length', 'raw_date', 'date'])
+        for node in T.find_clades():
+            inferred = node.raw_date_constraint is None or isinstance(node.raw_date_constraint, list)
+            setattr(node, 'date_inferred', inferred)
+
+        attributes.extend(['numdate', 'clock_length', 'mutation_length', 'raw_date', 'date', 'date_inferred'])
         if args.date_confidence:
             attributes.append('num_date_confidence')
     else:


### PR DESCRIPTION
See commit messages for details.

This is the `num_date` case of the more general https://github.com/nextstrain/augur/issues/386

Auspice PR https://github.com/nextstrain/auspice/pull/1943 will read these exported values, and that PR has a visual summary of what it enables.

