### PR TITLE
align: Remove insertion sequence print statements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,11 @@
 ### Bug fixes
 
 * titers: Improve error messages when titer models do not have enough data. [#1769][] (@huddlej)
+* align: Remove extra logs for insertions since the coordinates are output the *.insertions.csv. [#1772][] (@joverlee521)
 
 [#1756]: https://github.com/nextstrain/augur/pull/1756
 [#1769]: https://github.com/nextstrain/augur/pull/1769
+[#1772]: https://github.com/nextstrain/augur/pull/1772
 
 ## 29.0.0 (26 February 2025)
 

--- a/augur/align.py
+++ b/augur/align.py
@@ -356,16 +356,6 @@ def analyse_insertions(aln, ungapped, insertion_csv):
             if len(s):
                 insertions[idx][str(s)].append(seq.name)
 
-    for insertion_coord, data in zip(insertion_coords, insertions):
-        # GFF is 1-based & insertions are to the right of the base.
-        print("{}bp insertion at ref position {}".format(insertion_coord[1]-insertion_coord[0], insertion_coord[2]+1))
-        for k, v in data.items():
-            print("\t{}: {}".format(k, ", ".join(v)))
-        if not len(data.keys()):
-            # This happens when there _is_ an insertion, but it's an insertion of gaps
-            # We know that these are associated with poor alignments...
-            print("\tWARNING: this insertion was caused due to 'N's or '?'s in provided sequences")
-
     # output for auspice drag&drop -- GFF is 1-based & insertions are to the right of the base.
     header = ["strain"]+["insertion: {}bp @ ref pos {}".format(ic[1]-ic[0], ic[2]+1) for ic in insertion_coords]
     strain_data = defaultdict(lambda: ["" for _ in range(0, len(insertion_coords))])
@@ -373,6 +363,13 @@ def analyse_insertions(aln, ungapped, insertion_csv):
         for insertion_seq, strains in i_data.items():
             for strain in strains:
                 strain_data[strain][idx] = insertion_seq
+        if not len(i_data.keys()):
+            # This happens when there _is_ an insertion, but it's an insertion of gaps
+            # We know that these are associated with poor alignments...
+            # GFF is 1-based & insertions are to the right of the base.
+            insertion_coord = insertion_coords[idx]
+            print("WARNING: {}bp insertion at ref position {} was due to 'N's or '?'s in provided sequences"\
+                    .format(insertion_coord[1]-insertion_coord[0], insertion_coord[2]+1))
     with open_file(insertion_csv, 'w') as fh:
         print(",".join(header), file=fh)
         for strain in strain_data:


### PR DESCRIPTION
## Description of proposed changes

These print statements can flood the workflow logs with long insertion sequences that make it hard to parse. The same insertions are already output to the `insertion_csv` so there's no reason they need to be printed to stdout.

Note I opted to keep the warning logs for an insertion of gaps since that is not captured in the `insertion_csv`.

## Related issue(s)

Resolves <https://github.com/nextstrain/augur/issues/1737>

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
