### PR TITLE
fix: don't count mutations at masked sites towards branch length

### DIFF
--- a/augur/refine.py
+++ b/augur/refine.py
@@ -362,6 +362,17 @@ def run(args):
     if args.divergence_units=='mutations-per-site': #default
         pass
     elif args.divergence_units=='mutations':
+        # find column of the compressed alignment that maps to masked positions of all N
+        compressed_alignment = np.array([x for x in tt.data.compressed_alignment.values()]).T
+        ambiguous_positions = []
+        for ci, col in enumerate(compressed_alignment):
+            if np.unique(col).size==1 and col[0]==tt.gtr.ambiguous:
+                # the column with all Ns has only one unique value, and the first value is N
+                ambiguous_positions.extend(tt.data.compressed_to_full_sequence_map[ci])
+                break
+        # convert to set for faster lookup
+        ambiguous_positions = set(ambiguous_positions)
+
         if not args.timetree:
             # infer ancestral sequence for the purpose of counting mutations
             # sample mutations from the root profile, otherwise use most likely state.
@@ -385,7 +396,7 @@ def run(args):
             n_muts = len([
                 position
                 for ancestral, position, derived in node.mutations
-                if are_sequence_states_different(ancestral, derived)
+                if are_sequence_states_different(ancestral, derived) and position not in ambiguous_positions
             ])
 
             if args.timetree:


### PR DESCRIPTION
`augur refine` has the mode `--divergence-units mutations` in which case branch length are given as number of mutations in an ancestral reconstruction. We ignore gaps and ambiguous sites in this calculation as we should, but in the edge case when there is no information at all (site is `N` everywhere), we count a large number of spurious mutations. This happens when the root state is picked by from the probability distribution at random, and other states are set to the most likely state. @corneliusroemer  discovered this in the case of mpox where about 10k sites are masked. The probability distribution for these 10k states in `[0.2, 0.2, 0.2, 0.2, 0.2]`. The root was picked at random, other states via `np.argmax([0.2, 0.2, 0.2, 0.2, 0.2])`. If these differed, this generated 10k unwanted mutations. 

This PR excludes those sites from the branch length calculation. A list of all these sites is anyway available within treetime. 