### PR TITLE
Pin flake8

### DIFF
--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -970,7 +970,6 @@ def _replace_backtick_quoting(pandas_query: str):
     name_counter = 1
 
     def replace(match: re.Match):
-        nonlocal replacements
         nonlocal name_counter
         original_value = match.group(1)
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
         'dev': [
             "cram >=0.7",
             "deepdiff >=4.3.2, <8.0.0",
-            "flake8 >=7.0.0, <7.2.0",
+            "flake8 >=7.0.0, <8",
             "freezegun >=0.3.15",
             "mypy",
             "nextstrain-sphinx-theme >=2022.5",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
         'dev': [
             "cram >=0.7",
             "deepdiff >=4.3.2, <8.0.0",
-            "flake8",
+            "flake8 >=7.0.0, <7.2.0",
             "freezegun >=0.3.15",
             "mypy",
             "nextstrain-sphinx-theme >=2022.5",


### PR DESCRIPTION
## Description of proposed changes

Flake8 was previously unpinned which led to a linting error in the latest 7.2.0 release, as noted in https://github.com/nextstrain/augur/pull/1756#issuecomment-2774401930. This PR initially pins to <7.2.0, then since there is only one linting error, I went ahead and fixed it, relaxing the pin. It should still be beneficial to use new flake8 versions. We can always tighten the pin to not install a specific version if new errors become annoying.

## Checklist

- [ ] Automated checks pass
- [x] ~[Check][1] if you need to add a changelog message~ dev change
- [x] ~[Check][2] if you need to add tests~
- [x] ~[Check][3] if you need to update docs~

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
