### PR TITLE
Relax search pattern for 'year-month[-day]' dates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,20 @@
 
 ## __NEXT__
 
+### Major Changes
+
+*Note: The following breaking changes were effective as of version 29.1.0.*
+
+* filter: Date values in `<year>-<month>` format with more than 4 digits in the year (e.g. `02025-04`) or more than 2 digits in the month (e.g. `2025-004`) are no longer supported. Support for these was unintentional, but it worked in practice. [#1786][] (@victorlin)
+* filter: Date values in `<year>-<month>-<day>` format that fall outside of valid date boundaries now fail with an error. For example, `2025-00-01` is invalid. Previously, all date parts were treated categorically without date validation so `month=0` was its own category. [#1786][] (@victorlin)
+* filter: Date values in `<year>-<month>` format that fall outside of valid date boundaries are now auto-converted to the closest date. For example, `2025-00` will be auto-converted to `2025-01`. Previously, all date parts were treated categorically without date validation so `month=0` was its own category. It will now be treated as `month=1`. This is a side-effect of the change in 29.1.0 that switched to the same internal date parsing function that is used by other commands. A future major version may change behavior to fail with an error to better align with handling of `<year>-<month>-<day>`. [#1774][] (@victorlin)
+
+### Bug fixes
+
+* filter: version 29.1.0 inadvertently dropped support for date values in `<year>-<month>` or `<year>-<month>-<day>` format that are not in `YYYY-MM` or `YYYY-MM-DD` format. Support for some values has been restored. See the "Major Changes" section for details on which values are explicitly no longer supported. [#1785][] (@victorlin)
+
+[#1785]: https://github.com/nextstrain/augur/issues/1785
+[#1786]: https://github.com/nextstrain/augur/pull/1786
 
 ## 29.1.0 (10 April 2025)
 

--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -146,6 +146,7 @@ def get_numerical_date_from_value(value, fmt, min_max_year=None) -> Union[float,
     value = str(value)
 
     if RE_NUMERIC_DATE.match(value):
+        # Note: format (fmt) is ignored.
         return float(value)
 
     if RE_YEAR_ONLY.match(value):


### PR DESCRIPTION
## Description of proposed changes

Prior to #1775, this would simply split a date string on `-` to get numbers corresponding to year/month/day. While there was no explicit documentation of support for this format, which is a superset of the explicitly supported ISO 8601 format, it was supported in practice. #1775 broke support for that format. It has been restored for backwards compatibility in most situations (see below for caveats).

There are still some restrictions of the new relaxed search pattern that did not exist with the former string splitting:

1. Date parts must be within valid date bounds. Prior to [#1775](https://github.com/nextstrain/augur/pull/1775), date parts in values such as '2010-13' were simply treated categorically with month=13. The values are now run through a date conversion function which will fail to parse out of bounds values, or in the case of AmbiguousDate used in `<year>-<month>`, auto-convert them to the closest in-bound value.
2. For `<year>-<month>`, year must be at most 4 digits, and month at most 2 digits. Prior to [#1775](https://github.com/nextstrain/augur/pull/1775), values such as `2014-001` mapped to a categorical month=1. Values are now subject to maximum digits imposed by AmbiguousDate.regex. We could relax this regex as well, but I think it's better to limit rather expand support for these nonstandard values.

## Related issue(s)

Closes #1785

## Checklist

- [x] Automated checks pass
- [x] add a changelog message
- [x] add tests
- [x] update docs
- [x] ran on full latest GISAID metadata with `--group-by year month`

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
