### PR TITLE
Aligner extra args

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## __NEXT__
 
+* align: Added `--alignment-args` options for passing arguments to the alignment program. [#1789] (@vbadelita)
 
 ## 30.0.0 (15 April 2025)
 

--- a/augur/align.py
+++ b/augur/align.py
@@ -138,7 +138,7 @@ def run(args):
 
         # generate alignment command & run
         log = args.output + ".log"
-        cmd = generate_alignment_cmd(args.method, args.alignment_args, args.nthreads, existing_aln_fname, seqs_to_align_fname, args.output, log)
+        cmd = generate_alignment_cmd(args.method, args.nthreads, existing_aln_fname, seqs_to_align_fname, args.output, log, alignment_args=args.alignment_args)
         success = run_shell_command(cmd)
         if not success:
             raise AlignmentError(f"Error during alignment: please see the log file {log!r} for more details")
@@ -254,7 +254,7 @@ def read_reference(ref_fname):
                 "\n\tmake sure the file %s contains one sequence in genbank or fasta format"%ref_fname)
     return ref_seq
 
-def generate_alignment_cmd(method, alignment_args, nthreads, existing_aln_fname, seqs_to_align_fname, aln_fname, log_fname):
+def generate_alignment_cmd(method, nthreads, existing_aln_fname, seqs_to_align_fname, aln_fname, log_fname, alignment_args):
     if method not in DEFAULT_ARGS:
         raise AlignmentError('ERROR: alignment method %s not implemented'%method)
     
@@ -265,7 +265,7 @@ def generate_alignment_cmd(method, alignment_args, nthreads, existing_aln_fname,
 
     if method=='mafft':
         if existing_aln_fname:
-            cmd = "mafft --add %s --keeplength %s %d %s 1> %s 2> %s"%(shquote(seqs_to_align_fname), args, nthreads, shquote(existing_aln_fname), shquote(aln_fname), shquote(log_fname))
+            cmd = "mafft --add %s --keeplength %s --thread %d %s 1> %s 2> %s"%(shquote(seqs_to_align_fname), args, nthreads, shquote(existing_aln_fname), shquote(aln_fname), shquote(log_fname))
         else:
             cmd = "mafft %s --thread %d %s 1> %s 2> %s"%(args, nthreads, shquote(seqs_to_align_fname), shquote(aln_fname), shquote(log_fname))
         print("\nusing mafft to align via:\n\t" + cmd +

--- a/augur/align.py
+++ b/augur/align.py
@@ -35,7 +35,7 @@ def register_arguments(parser):
     parser.add_argument('--nthreads', type=nthreads_value, default=1,
                                 help="number of threads to use; specifying the value 'auto' will cause the number of available CPU cores on your system, if determinable, to be used")
     parser.add_argument('--method', default='mafft', choices=["mafft"], help="alignment program to use")
-    parser.add_argument('--alignment-args', help="arguments to pass to the alignment program (except for number of threads), overriding defaults. " +
+    parser.add_argument('--alignment-args', help="arguments to pass to the alignment program (except for threads, keeplength if --existing-alignment is passed), overriding defaults. " +
                                                 f"mafft defaults: '{DEFAULT_ARGS['mafft']}'")
     parser.add_argument('--reference-name', metavar="NAME", type=str, help="strip insertions relative to reference sequence; use if the reference is already in the input sequences")
     parser.add_argument('--reference-sequence', metavar="PATH", type=str, help="Add this reference sequence to the dataset & strip insertions relative to this. Use if the reference is NOT already in the input sequences")

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -221,6 +221,39 @@ class TestAlign:
         expected = "mafft --reorder --anysymbol --nomemsave --adjustdirection --thread %d %s 1> %s 2> %s" % (1, quote(seqs_to_align_fname), quote(aln_fname), quote(log_fname))
         
         assert result == expected
+
+    def test_generate_alignment_cmd_mafft_custom_args_existing_aln_fname(self):
+        existing_aln_fname = "existing_aln"
+        seqs_to_align_fname = "seqs_to_align"
+        aln_fname = "aln_fname"
+        log_fname = "log_fname"
+        
+        result = align.generate_alignment_cmd("mafft", 1,
+                                              existing_aln_fname,
+                                              seqs_to_align_fname,
+                                              aln_fname,
+                                              log_fname,
+                                              alignment_args="--auto")
+        
+        expected = "mafft --add %s --keeplength --auto --thread %d %s 1> %s 2> %s" % (quote(seqs_to_align_fname), 1, quote(existing_aln_fname), quote(aln_fname), quote(log_fname))
+        
+        assert result == expected
+
+    def test_generate_alignment_cmd_mafft_custom_args_no_existing_aln_fname(self):
+        seqs_to_align_fname = "seqs_to_align"
+        aln_fname = "aln_fname"
+        log_fname = "log_fname"
+        
+        result = align.generate_alignment_cmd("mafft", 1,
+                                              None,
+                                              seqs_to_align_fname,
+                                              aln_fname,
+                                              log_fname,
+                                              alignment_args="--auto --anysymbol")
+        
+        expected = "mafft --auto --anysymbol --thread %d %s 1> %s 2> %s" % (1, quote(seqs_to_align_fname), quote(aln_fname), quote(log_fname))
+        
+        assert result == expected
         
     def test_read_alignment(self):
         data_file = pathlib.Path('tests/data/align/test_aligned_sequences.fasta')

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -187,7 +187,7 @@ class TestAlign:
 
     def test_generate_alignment_cmd_non_mafft(self):
         with pytest.raises(align.AlignmentError):
-            assert align.generate_alignment_cmd('no-mafft', 1, None, None, None, None)
+            assert align.generate_alignment_cmd('no-mafft', 1, None, None, None, None, alignment_args=None)
             
     def test_generate_alignment_cmd_mafft_existing_aln_fname(self):
         existing_aln_fname = "existing_aln"
@@ -199,7 +199,8 @@ class TestAlign:
                                               existing_aln_fname,
                                               seqs_to_align_fname,
                                               aln_fname,
-                                              log_fname)
+                                              log_fname,
+                                              alignment_args=None)
         
         expected = "mafft --add %s --keeplength --reorder --anysymbol --nomemsave --adjustdirection --thread %d %s 1> %s 2> %s" % (quote(seqs_to_align_fname), 1, quote(existing_aln_fname), quote(aln_fname), quote(log_fname))
         
@@ -214,7 +215,8 @@ class TestAlign:
                                               None,
                                               seqs_to_align_fname,
                                               aln_fname,
-                                              log_fname)
+                                              log_fname,
+                                              alignment_args=None)
         
         expected = "mafft --reorder --anysymbol --nomemsave --adjustdirection --thread %d %s 1> %s 2> %s" % (1, quote(seqs_to_align_fname), quote(aln_fname), quote(log_fname))
         


### PR DESCRIPTION
The new argument takes a list of arguments to pass to the alignment tool. This gives more flexibility in configuring mafft.

## Description of proposed changes

Added the new argument to `align.py`. If present, the arguments override the defaults (except threads which is passed separately).

## Related issue(s)

#1789 

## Checklist

- [X] Automated checks pass
  - Ran `./run_tests.sh -k test_align.py`
- [X] [Check][1] if you need to add a changelog message
  - Added changelog message
- [X] [Check][2] if you need to add tests
  - Added two unit tests
- [X] [Check][3] if you need to update docs
  - Docs should automatically get updated via argparse

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->