### PR TITLE
Cache get_year_month_day

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,12 @@
 
 * schema: Allow full stop character (`.`) in gene names. [#955][] (@jameshadfield)
 
+### Bug fixes
+
+* filter: Improved speed of `--group-by` with `year` or `month` on large datasets. [#1792][] (@victorlin)
+
 [#955]: https://github.com/nextstrain/augur/pull/955
+[#1792]: https://github.com/nextstrain/augur/pull/1792
 
 ## 31.0.0 (19 May 2025)
 

--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 import isodate
 import pandas as pd
 import re
+from functools import cache
 from treetime.utils import numeric_date as tt_numeric_date, datetime_from_numeric
 from typing import Any, Dict, Optional, Tuple, Union
 from augur.errors import AugurError
@@ -229,6 +230,7 @@ def get_year_week(year, month, day):
     year, week = datetime.date(year, month, day).isocalendar()[:2]
     return f"{year}-{str(week).zfill(2)}"
 
+@cache
 def get_year_month_day(value: Any) -> Tuple[Optional[int], Optional[int], Optional[int]]:
     """
     Extract year, month, and day from a date value.


### PR DESCRIPTION
## Description of proposed changes

The shift to using this function during date inference for subsampling (041412c5) provides a good opportunity for a caching speedup: the function is applied to every date value in the metadata, and dates are likely to be highly repetitive in large datasets.

I tested this on the current full GISAID metadata which has ~17 million sequences. Time spent running that function drops from 8 minutes to 0.03 seconds.

## Related issue(s)

- Follow-up to https://github.com/nextstrain/augur/pull/1775#discussion_r2047899565
- #1573 

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] ~[Check][2] if you need to add tests~
- [x] ~[Check][3] if you need to update docs~
- [x] Tested on 17m row metadata file. cProfile results on 29.0.0 vs. 30.0.0 vs. this PR: [stats.zip](https://github.com/user-attachments/files/19785984/stats.zip)

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
