### PR TITLE
Update mumps CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,7 @@ jobs:
           - lassa
           - measles
           - mpox
+          - mumps
           - oropouche
           - rabies
           - seasonal-cov
@@ -245,7 +246,6 @@ jobs:
         include:
           - { pathogen: avian-flu, build-args: --snakefile segment-focused/Snakefile -pf test_target }
           - { pathogen: ebola }
-          - { pathogen: mumps }
           - {
               pathogen: ncov,
               build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci,


### PR DESCRIPTION
A la #1554, moves `mumps` from the "special case" CI list to the "regular" CI list. 