### PR TITLE
Improve the error message from `augur export v2` when duplicate index values are seen [#1791]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,13 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* export v2: Improved the error message that is displayed when the metadata index column has duplicated values [#1791][] (@genehack)
 * tree: Improved help text for `--tree-builder-args` to explain some IQ-TREE options won't work because of defline rewriting [#875][] (@genehack)
 
 [#875]: https://github.com/nextstrain/augur/issues/875
+[#1791]: https://github.com/nextstrain/augur/issues/1791
 
 ## 30.0.1 (28 April 2025)
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -1154,6 +1154,15 @@ def run(args):
                 f"Valid delimiters are: {args.metadata_delimiters!r}. "
                 "This can be changed with --metadata-delimiters."
             )
+        except ValueError as error:
+            if len(metadata_df.index) > len(set(metadata_df.index)):
+                raise AugurError(
+                    f"The following {metadata_df.index.name} values are duplicated in '{args.metadata}':\n"
+                    + "\n".join(sorted(metadata_df.index[metadata_df.index.duplicated()]))
+                    + "\n\nYou can fix this by either de-duplicating the metadata, or setting a different unique index column via --metadata-id-columns.")
+            else:
+                print(f"ERROR: {error}", file=sys.stderr)
+                sys.exit(1)
         except Exception as error:
             print(f"ERROR: {error}", file=sys.stderr)
             sys.exit(1)

--- a/tests/functional/export_v2/cram/metadata-columns.t
+++ b/tests/functional/export_v2/cram/metadata-columns.t
@@ -14,6 +14,16 @@ Create files for testing.
   > tipF	FF	FFF
   > ~~
 
+  $ cat >metadata_with_duplicates.tsv <<~~
+  > strain	field_A	field_B
+  > tipA	AA	AAA
+  > tipA	BB	BBB
+  > tipC	CC	CCC
+  > tipC	DD	DDD
+  > tipE	EE	EEE
+  > tipE	FF	FFF
+  > ~~
+
   $ cat >tree.nwk <<~~
   > (tipA:1,(tipB:1,tipC:1)internalBC:2,(tipD:3,tipE:4,tipF:1)internalDEF:5)ROOT:0;
   > ~~
@@ -112,3 +122,20 @@ Specifying additional metadata columns via command line overrides the Auspice co
   $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-additional-metadata-columns.json" dataset.json \
   >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
   {}
+
+Duplicated index values are properly detected
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata_with_duplicates.tsv \
+  >  --auspice-config auspice-config-overridden.json \
+  >  --metadata-columns "field_A" "field_B" \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset.json > /dev/null
+  ERROR: The following strain values are duplicated in 'metadata_with_duplicates.tsv':
+  tipA
+  tipC
+  tipE
+  
+  You can fix this by either de-duplicating the metadata, or setting a different unique index column via --metadata-id-columns.
+  [2]


### PR DESCRIPTION
## Description of proposed changes

Displays a better error message when non-unique index values are present in the metadata; wording of the message based on suggestion in the original issue.

## Related issue(s)

Closes #1791 

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
