### PR TITLE
Update tree docs to indicate some IQ-TREE options won't work [#875]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## __NEXT__
 
+* tree: Improved help text for `--tree-builder-args` to explain some IQ-TREE options won't work because of defline rewriting [#875][] (@genehack)
+
+[#875]: https://github.com/nextstrain/augur/issues/875
 
 ## 30.0.1 (28 April 2025)
 
@@ -1661,9 +1664,9 @@ Note that names with spaces in the FASTA header (description line) continue to b
 ### Features
 
 * improve testing by
-	* adding a simple shell script to run tests and improving pytest configuration and output [#463][]
-	* adding code coverage reports ([#486][], [#491][]) and integration with codecov.io [#508][]
-	* adding unit tests for align ([#477][]), filter ([#478][], [#479][], [#487][]), utils ([#501][])
+    * adding a simple shell script to run tests and improving pytest configuration and output [#463][]
+    * adding code coverage reports ([#486][], [#491][]) and integration with codecov.io [#508][]
+    * adding unit tests for align ([#477][]), filter ([#478][], [#479][], [#487][]), utils ([#501][])
 * align: reverse complement sequences when necessary using mafft’s autodirection flag [#467][]
 * align: speed up replacement of gaps with “ambiguous” bases [#474][]
 * mask: add support for FASTA input files [#493][]
@@ -1825,9 +1828,9 @@ Note that names with spaces in the FASTA header (description line) continue to b
   [Also part of PR 431](https://github.com/nextstrain/augur/pull/431)
 * traits: Allow input of `--weights` which references a `.tsv` file in the following format:
   ```
-  division	Hubei	10.0
-  division	Jiangxi	1.0
-  division	Chongqing	1.0
+  division  Hubei   10.0
+  division  Jiangxi 1.0
+  division  Chongqing   1.0
   ```
   where these weights represent equilibrium frequencies in the CTMC transition model. We imagine the
   primary use of user-specified weights to correct for strong sampling biases in available data.

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -472,6 +472,8 @@ def register_parser(parent_subparsers):
     FastTree defaults: "{DEFAULT_ARGS['fasttree']}".
     RAxML defaults: "{DEFAULT_ARGS['raxml']}".
     IQ-TREE defaults: "{DEFAULT_ARGS['iqtree']}".
+
+Note that IQ-TREE will rewrite certain characters in FASTA deflines. In order to prevent this from breaking downstream analysis steps, `augur tree` preemptively rewrites conflicting deflines, and then restores them later. Unfortunately, this breaks the use of certain IQ-TREE options (e.g., `-g`) which rely on matching names between the FASTA and other input files.
     """)
     parser.add_argument('--override-default-args', action="store_true", help="override default tree builder arguments with the values provided by the user in `--tree-builder-args` instead of augmenting the existing defaults.")
 


### PR DESCRIPTION
## Description of proposed changes

Updates `augur tree` docs for param `--tree-builder-args` to indicate some IQ-TREE options will be broken by defline rewriting. 

## Related issue(s)

Closes #875 

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
