### PR TITLE
feat: make float precision in json output an argument, make div more …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,12 @@
 * export v2: Improved the error message that is displayed when the metadata index column has duplicated values [#1791][] (@genehack)
 * tree: Improved help text for `--tree-builder-args` to explain some IQ-TREE options won't work because of defline rewriting [#875][] (@genehack)
 * export v2: Automatically rename fields within the `filters` and `colorings` configs of the provided auspice config file to match the renamed fields in the exported nodes. [#1804][] (@joverlee521)
+* export v2: Divergence values are now exported with increased precision, showing up to 6 significant digits instead of 3. [#1801][] (@rneher)
 
 [#875]: https://github.com/nextstrain/augur/issues/875
 [#945]: https://github.com/nextstrain/augur/issues/945
 [#1791]: https://github.com/nextstrain/augur/issues/1791
+[#1801]: https://github.com/nextstrain/augur/pull/1801
 [#1804]: https://github.com/nextstrain/augur/pull/1804
 
 ## 30.0.1 (28 April 2025)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -141,7 +141,7 @@ def convert_tree_to_json_structure(node, metadata, get_div, div=0):
     node_struct = {'name': node.name, 'node_attrs': {}, 'branch_attrs': {}}
 
     if get_div is not None: # Store the (cumulative) observed divergence prior to this node
-        node_struct["node_attrs"]["div"] = format_number(div)
+        node_struct["node_attrs"]["div"] = format_number(div, precision=6)
 
     if node.clades:
         node_struct["children"] = []
@@ -674,17 +674,17 @@ def is_numeric(n:Any) -> bool:
     # doesn't work nicely with type hints. See <https://stackoverflow.com/a/73186301>
     return isinstance(n, (int, float))
 
-def format_number(n: Union[int, float]) -> Union[int, float]:
+def format_number(n: Union[int, float], precision: int = 3) -> Union[int, float]:
     if isinstance(n, int) or n==0:
         return n
-    # We want to use three sig figs for the fractional part of the float, while
+    # We want to use {precision} sig figs for the fractional part of the float, while
     # preserving all the data in the integral (integer) part. We leverage the
     # fact that python floats (incl scientific notation) storing the shortest
     # decimal string that’s guaranteed to round back to x. Note that this means we
     # drop trailing zeros, so it's not _quite_ sig figs.
     integral = int(abs(n))
     significand = math.floor(math.log10(integral))+1 if integral!=0 else 0
-    return float(f"{n:.{significand+3}g}")
+    return float(f"{n:.{significand+precision}g}")
 
 
 class ConfidenceNumeric(TypedDict):


### PR DESCRIPTION
…precise

We currently limit the precision of floating point values on json output to three significant digits. This can generate problems in the divergence view. If for example a single mutation corresponds to 0.00003 (like in a 30k genome), divergence differences between 0.10000 and 0.10003 will be resolved. This results in branches with mutations having zero branch length. 

The PR makes the output precision an argument and outputs divergence with 6 significant digits instead of 3.  