### PR TITLE
Rename deprecated fields in Auspice config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,11 @@
 
 * export v2: Improved the error message that is displayed when the metadata index column has duplicated values [#1791][] (@genehack)
 * tree: Improved help text for `--tree-builder-args` to explain some IQ-TREE options won't work because of defline rewriting [#875][] (@genehack)
+* export v2: Automatically rename fields within the `filters` and `colorings` configs of the provided auspice config file to match the renamed fields in the exported nodes. [#1804][] (@joverlee521)
 
 [#875]: https://github.com/nextstrain/augur/issues/875
 [#1791]: https://github.com/nextstrain/augur/issues/1791
+[#1804]: https://github.com/nextstrain/augur/pull/1804
 
 ## 30.0.1 (28 April 2025)
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -19,7 +19,7 @@ from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimite
 from .types import ValidationMode
 from .utils import read_node_data, write_json, json_size, read_lat_longs, read_colors
 from .util_support.warnings import configure_warnings, warn, deprecated, deprecationWarningsEmitted
-from .util_support.auspice_config import read_auspice_configs, remove_unused_metadata_columns
+from .util_support.auspice_config import read_auspice_configs, remove_unused_metadata_columns, update_deprecated_names
 from .validate import export_v2 as validate_v2, ValidateError, validation_failure
 from .version import __version__
 
@@ -164,15 +164,6 @@ def is_node_attr_defined(node_attrs, attr_name):
         if data.get(attr_name):
             return True
     return False
-
-
-def update_deprecated_names(name):
-    # correct deprecated keys
-    change = {
-        "authors": "author",
-        "numdate": "num_date"
-    }
-    return change.get(name, name)
 
 def get_values_across_nodes(node_attrs, key):
     vals = set()

--- a/augur/util_support/auspice_config.py
+++ b/augur/util_support/auspice_config.py
@@ -11,13 +11,16 @@ from typing import Union, Any
 from collections.abc import Callable
 
 
+# Deprecated attr keys that are automatically updated during `augur export`
+# old_key: new_key
+DEPRECATED_KEYS = {
+    "authors": "author",
+    "numdate": "num_date"
+}
+
 def update_deprecated_names(name):
     # correct deprecated keys
-    change = {
-        "authors": "author",
-        "numdate": "num_date"
-    }
-    return change.get(name, name)
+    return DEPRECATED_KEYS.get(name, name)
 
 def read_json(fname):
     if not (fname and os.path.isfile(fname)):

--- a/augur/util_support/auspice_config.py
+++ b/augur/util_support/auspice_config.py
@@ -167,6 +167,9 @@ def _rename_display_keys(display: dict) -> dict:
         del defaults[v1_key]
     return defaults
 
+def _rename_deprecated_filters(filters: list) -> list:
+    return [update_deprecated_names(f) for f in filters]
+
 def remove_unused_metadata_columns(columns: list) -> list:
     # 1. Remove any occurrences of 'author' and 'num_date' as it's a no-op - author
     #    and numerical date information is always exported on nodes if it's available.
@@ -182,6 +185,7 @@ DEPRECATIONS = [
     {"old_name": "geo", "new_name": "geo_resolutions", "modify": lambda values: [{"key": v} for v in values]},
     {"old_name": "color_options", "new_name": "colorings", "modify": _parse_color_options},
     {"old_name": "colorings", "new_name": "colorings", "modify": _rename_deprecated_authors_coloring},
+    {"old_name": "filters", "new_name": "filters", "modify": _rename_deprecated_filters},
     {"old_name": "metadata_columns", "new_name": "metadata_columns", "modify": remove_unused_metadata_columns},
 ]
 

--- a/augur/util_support/auspice_config.py
+++ b/augur/util_support/auspice_config.py
@@ -142,17 +142,17 @@ def _parse_color_options(options: Any) -> list[dict]:
         colorings.append({"key": key, **info})
     return colorings
 
-def _rename_deprecated_authors_coloring(colorings: list):
-    # The 'authors' coloring (plural) is now called 'author' (singular)
-    author  = next(iter([{'index': idx, 'coloring': c} for [idx, c] in enumerate(colorings) if c['key']=='author'] or [None]))
-    authors = next(iter([{'index': idx, 'coloring': c} for [idx, c] in enumerate(colorings) if c['key']=='authors'] or [None]))
-    if authors:
-        if author:
-            deprecated("[config file] ignoring deprecated 'authors' because a coloring for 'author' already exists")
-            colorings = [c for [idx, c] in enumerate(colorings) if idx!=authors['index']]
-        else:
-            deprecated("[config file] renaming coloring 'authors' to 'author'")
-            colorings[authors['index']]['key'] = "author"
+def _rename_deprecated_colorings(colorings: list):
+    for old_key, new_key in DEPRECATED_KEYS.items():
+        new_coloring  = next(iter([{'index': idx, 'coloring': c} for [idx, c] in enumerate(colorings) if c['key']==new_key] or [None]))
+        old_coloring  = next(iter([{'index': idx, 'coloring': c} for [idx, c] in enumerate(colorings) if c['key']==old_key] or [None]))
+        if old_coloring:
+            if new_coloring:
+                deprecated(f"[config file] ignoring deprecated {old_key!r} because a coloring for {new_key!r} already exists")
+                colorings = [c for [idx, c] in enumerate(colorings) if idx!=old_coloring['index']]
+            else:
+                deprecated(f"[config file] renaming coloring {old_key!r} to {new_key!r}")
+                colorings[old_coloring['index']]['key'] = new_key
     return colorings
 
 def _rename_display_keys(display: dict) -> dict:
@@ -187,7 +187,7 @@ DEPRECATIONS = [
     {"old_name": "maintainer", "new_name": "maintainers", "modify": lambda m: [{"name": m[0], "url": m[1]}]},
     {"old_name": "geo", "new_name": "geo_resolutions", "modify": lambda values: [{"key": v} for v in values]},
     {"old_name": "color_options", "new_name": "colorings", "modify": _parse_color_options},
-    {"old_name": "colorings", "new_name": "colorings", "modify": _rename_deprecated_authors_coloring},
+    {"old_name": "colorings", "new_name": "colorings", "modify": _rename_deprecated_colorings},
     {"old_name": "filters", "new_name": "filters", "modify": _rename_deprecated_filters},
     {"old_name": "metadata_columns", "new_name": "metadata_columns", "modify": remove_unused_metadata_columns},
 ]

--- a/augur/util_support/auspice_config.py
+++ b/augur/util_support/auspice_config.py
@@ -11,6 +11,14 @@ from typing import Union, Any
 from collections.abc import Callable
 
 
+def update_deprecated_names(name):
+    # correct deprecated keys
+    change = {
+        "authors": "author",
+        "numdate": "num_date"
+    }
+    return change.get(name, name)
+
 def read_json(fname):
     if not (fname and os.path.isfile(fname)):
         print("ERROR: config file %s not found."%fname)

--- a/tests/functional/export_v2/cram/auspice_config5.t
+++ b/tests/functional/export_v2/cram/auspice_config5.t
@@ -1,0 +1,16 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Run export with metadata and auspice config that include deprecated field names.
+
+  $ ${AUGUR} export v2 \
+  >   --tree "$TESTDIR/../data/tree.nwk" \
+  >   --node-data "$TESTDIR/../data/div_node-data.json" \
+  >   --auspice-config "$TESTDIR/../data/auspice_config5.json" \
+  >   --metadata "$TESTDIR/../data/deprecated_metadata.tsv" \
+  >   --output dataset.json &> /dev/null
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset5.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['maintainers']"
+  {}

--- a/tests/functional/export_v2/data/auspice_config5.json
+++ b/tests/functional/export_v2/data/auspice_config5.json
@@ -1,0 +1,18 @@
+{
+    "colorings": [
+      {
+        "key": "authors",
+        "title": "Authors",
+        "type": "categorical"
+      },
+      {
+        "key": "numdate",
+        "title": "Date",
+        "type": "continuous"
+      }
+    ],
+    "filters": [
+      "authors",
+      "numdate"
+    ]
+  }

--- a/tests/functional/export_v2/data/dataset5.json
+++ b/tests/functional/export_v2/data/dataset5.json
@@ -1,0 +1,136 @@
+{
+  "version": "v2",
+  "meta": {
+    "updated": "2025-05-02",
+    "colorings": [
+      {
+        "key": "author",
+        "title": "Authors",
+        "type": "categorical"
+      },
+      {
+        "key": "num_date",
+        "title": "Date",
+        "type": "continuous"
+      }
+    ],
+    "filters": [
+      "author",
+      "num_date"
+    ],
+    "panels": [
+      "tree"
+    ]
+  },
+  "tree": {
+    "name": "ROOT",
+    "node_attrs": {
+      "div": 0
+    },
+    "branch_attrs": {},
+    "children": [
+      {
+        "name": "tipA",
+        "node_attrs": {
+          "div": 1,
+          "num_date": {
+            "value": 2025.0
+          },
+          "author": {
+            "author": "Test et al.",
+            "value": "Test et al."
+          }
+        },
+        "branch_attrs": {}
+      },
+      {
+        "name": "internalBC",
+        "node_attrs": {
+          "div": 2
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipB",
+            "node_attrs": {
+              "div": 3,
+              "num_date": {
+                "value": 2025.0
+              },
+              "author": {
+                "author": "Test et al.",
+                "value": "Test et al."
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipC",
+            "node_attrs": {
+              "div": 3,
+              "num_date": {
+                "value": 2025.0
+              },
+              "author": {
+                "author": "Test et al.",
+                "value": "Test et al."
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      },
+      {
+        "name": "internalDEF",
+        "node_attrs": {
+          "div": 5
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipD",
+            "node_attrs": {
+              "div": 8,
+              "num_date": {
+                "value": 2025.0
+              },
+              "author": {
+                "author": "Test et al.",
+                "value": "Test et al."
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipE",
+            "node_attrs": {
+              "div": 9,
+              "num_date": {
+                "value": 2025.0
+              },
+              "author": {
+                "author": "Test et al.",
+                "value": "Test et al."
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipF",
+            "node_attrs": {
+              "div": 6,
+              "num_date": {
+                "value": 2025.0
+              },
+              "author": {
+                "author": "Test et al.",
+                "value": "Test et al."
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/functional/export_v2/data/deprecated_metadata.tsv
+++ b/tests/functional/export_v2/data/deprecated_metadata.tsv
@@ -1,0 +1,7 @@
+name	authors	numdate
+tipA	Test et al.	2025.0
+tipB	Test et al.	2025.0
+tipC	Test et al.	2025.0
+tipD	Test et al.	2025.0
+tipE	Test et al.	2025.0
+tipF	Test et al.	2025.0


### PR DESCRIPTION
## Description of proposed changes

Renames all deprecated fields that are provided in the filters and colorings configs of the auspice_config.json so that they match the renamed keys from `augur export`. 

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/1803

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
