### PR TITLE
Update linkcheck_ignore

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,6 +162,7 @@ linkcheck_ignore = [
      r'^http://www\.microbesonline\.org/fasttree/',
      r'^https://academic\.oup\.com/ve/article/4/1/vex042/4794731',
      r'https://www\.gnu\.org/software/bash/manual/bash\.html#ANSI_002dC-Quoting',
+     r'https://stackoverflow\.com/',
 ]
 linkcheck_anchors_ignore_for_url = [
      # Github uses anchor-looking links for highlighting lines but


### PR DESCRIPTION
## Description of proposed changes

Add StackOverflow to the list of links to ignore since it's now returning 403 during linkcheck.

First noticed in failed test for https://github.com/nextstrain/augur/pull/1804, but it has been failing in our scheduled CI workflow since 2025-05-02

<https://github.com/nextstrain/augur/actions/runs/14800411624>

## Checklist

- [x] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
