### PR TITLE
filter: Error on empty indexes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Major Changes
 
 * `augur mask --mask`, `augur tree --exclude-sites`: BED files with inconsistent CHROM values (i.e., values in the first column of data lines) will throw an error, as Augur (implicitly) expects to be working on a single piece of DNA (chromosome, segment, etc), and multiple CHROM values in a BED file indicate a violation of this expectation. This is a breaking change. [#945][] (@genehack)
+* filter: Empty values in the metadata id column will result in an error that can only be resolved by editing the metadata file or by specifying a different id column with `--metadata-id-columns`. [#1807][] (@joverlee521)
 
 ### Bug fixes
 
@@ -20,6 +21,7 @@
 [#1791]: https://github.com/nextstrain/augur/issues/1791
 [#1801]: https://github.com/nextstrain/augur/pull/1801
 [#1804]: https://github.com/nextstrain/augur/pull/1804
+[#1807]: https://github.com/nextstrain/augur/pull/1807
 
 ## 30.0.1 (28 April 2025)
 

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -173,6 +173,11 @@ def run(args):
         dtype="string",
     )
     for metadata in metadata_reader:
+        if len(metadata.loc[metadata.index == '']):
+            cleanup_outputs(args)
+            raise AugurError(f"Found rows with empty values in id column {metadata.index.name!r} in {args.metadata!r}\n" + \
+                             "Please remove the rows with empty ids or use a different id column via --metadata-id-columns.")
+
         duplicate_strains = (
             set(metadata.index[metadata.index.duplicated()]) |
             (set(metadata.index) & metadata_strains)

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -179,7 +179,7 @@ def run(args):
         )
         if len(duplicate_strains) > 0:
             cleanup_outputs(args)
-            raise AugurError(f"The following strains are duplicated in '{args.metadata}':\n" + "\n".join(sorted(duplicate_strains)))
+            raise AugurError(f"The following strains are duplicated in '{args.metadata}':\n" + "\n".join(repr(x) for x in sorted(duplicate_strains)))
 
         # Maintain list of all strains seen.
         metadata_strains.update(set(metadata.index.values))
@@ -396,7 +396,7 @@ def run(args):
 
         if duplicates:
             cleanup_outputs(args)
-            raise AugurError(f"The following strains are duplicated in '{args.sequences}':\n" + "\n".join(sorted(duplicates)))
+            raise AugurError(f"The following strains are duplicated in '{args.sequences}':\n" + "\n".join(repr(x) for x in sorted(duplicates)))
 
         if sequence_strains != observed_sequence_strains:
             # Warn the user if the expected strains from the sequence index are

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,6 +164,7 @@ linkcheck_ignore = [
      r'https://www\.gnu\.org/software/bash/manual/bash\.html#ANSI_002dC-Quoting',
      r'https://stackoverflow\.com/',
      r'https://github\.com/',
+     r'https://www.merriam-webster\.com/',
 ]
 linkcheck_anchors_ignore_for_url = [
      # Github uses anchor-looking links for highlighting lines but

--- a/tests/functional/filter/cram/filter-duplicates-error.t
+++ b/tests/functional/filter/cram/filter-duplicates-error.t
@@ -20,7 +20,7 @@ Error on duplicates in metadata within same chunk.
   >   --metadata-chunk-size 10 \
   >   --output-metadata metadata-filtered.tsv > /dev/null
   ERROR: The following strains are duplicated in .* (re)
-  a
+  'a'
   [2]
   $ cat metadata-filtered.tsv
   cat: .*: No such file or directory (re)
@@ -36,7 +36,7 @@ Error on duplicates in metadata in separate chunks.
   >   --metadata-chunk-size 1 \
   >   --output-metadata metadata-filtered.tsv > /dev/null
   ERROR: The following strains are duplicated in .* (re)
-  a
+  'a'
   [2]
   $ cat metadata-filtered.tsv
   cat: .*: No such file or directory (re)
@@ -68,8 +68,8 @@ Error on duplicates in sequences.
   >   --sequences sequences.fasta \
   >   --output-sequences sequences-filtered.fasta
   ERROR: The following strains are duplicated in 'sequences.fasta':
-  a
-  c
+  'a'
+  'c'
   [2]
 
 Error even if the corresponding output is not used.
@@ -79,6 +79,6 @@ Error even if the corresponding output is not used.
   >   --sequences sequences.fasta \
   >   --output-strains filtered.txt
   ERROR: The following strains are duplicated in 'sequences.fasta':
-  a
-  c
+  'a'
+  'c'
   [2]

--- a/tests/functional/filter/cram/filter-empty-index-error.t
+++ b/tests/functional/filter/cram/filter-empty-index-error.t
@@ -2,7 +2,7 @@ Setup
 
   $ source "$TESTDIR"/_setup.sh
 
-Records with empty indexes show up as error on duplicates in metadata .
+Error on empty indexes in metadata.
 
   $ cat >metadata-empty-indexes.tsv <<~~
   > strain	date
@@ -19,8 +19,8 @@ Records with empty indexes show up as error on duplicates in metadata .
   >   --subsample-seed 0 \
   >   --metadata-chunk-size 10 \
   >   --output-metadata metadata-filtered.tsv > /dev/null
-  ERROR: The following strains are duplicated in .* (re)
-  ''
+  ERROR: Found rows with empty values in id column 'strain' in .* (re)
+  Please remove the rows with empty ids or use a different id column via --metadata-id-columns.
   [2]
   $ cat metadata-filtered.tsv
   cat: .*: No such file or directory (re)

--- a/tests/functional/filter/cram/filter-empty-index-error.t
+++ b/tests/functional/filter/cram/filter-empty-index-error.t
@@ -1,0 +1,27 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Records with empty indexes show up as error on duplicates in metadata .
+
+  $ cat >metadata-empty-indexes.tsv <<~~
+  > strain	date
+  > 	2010-10-10
+  > 	2010-10-10
+  > b	2010-10-10
+  > c	2010-10-10
+  > d	2010-10-10
+  > ~~
+  $ ${AUGUR} filter \
+  >   --metadata metadata-empty-indexes.tsv \
+  >   --group-by year \
+  >   --sequences-per-group 2 \
+  >   --subsample-seed 0 \
+  >   --metadata-chunk-size 10 \
+  >   --output-metadata metadata-filtered.tsv > /dev/null
+  ERROR: The following strains are duplicated in .* (re)
+  ''
+  [2]
+  $ cat metadata-filtered.tsv
+  cat: .*: No such file or directory (re)
+  [1]


### PR DESCRIPTION
## Description of proposed changes

Previously, empty indexes were only flagged when there were multiple entries and they were reported as duplicate strains. This changes the behavior to always error when there's an empty index value so that users are aware of the issue and don't run into unexpected errors later.

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/1806

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
