### PR TITLE
More filter speedups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,10 +8,11 @@
 
 ### Bug fixes
 
-* filter: Improved speed of `--group-by` with `year` or `month` on large datasets. [#1792][] (@victorlin)
+* filter: Improved speed of using `--group-by`, `--min-date`, and `--max-date` on large datasets. [#1792][], [#1811][] (@victorlin)
 
 [#955]: https://github.com/nextstrain/augur/pull/955
 [#1792]: https://github.com/nextstrain/augur/pull/1792
+[#1811]: https://github.com/nextstrain/augur/pull/1811
 
 ## 31.0.0 (19 May 2025)
 

--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -160,6 +160,7 @@ Matches an Augur-style ambiguous date with 'XX' used to mask unknown parts of th
 Note that this can support any date format, not just YYYY-MM-DD.
 """
 
+@cache
 def get_numerical_date_from_value(value, fmt, min_max_year=None) -> Union[float, Tuple[float, float], None]:
     value = str(value)
 
@@ -223,9 +224,11 @@ def get_numerical_dates(
 
     return dict(zip(strains, dates))
 
+@cache
 def get_year_month(year, month):
     return f"{year}-{str(month).zfill(2)}"
 
+@cache
 def get_year_week(year, month, day):
     year, week = datetime.date(year, month, day).isocalendar()[:2]
     return f"{year}-{str(week).zfill(2)}"

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -255,7 +255,7 @@ def run(args):
                         )
 
                     queues_by_group[group].add(
-                        metadata.loc[strain],
+                        strain,
                         priorities[strain],
                     )
 
@@ -333,7 +333,7 @@ def run(args):
             for strain in sorted(group_by_strain.keys()):
                 group = group_by_strain[strain]
                 queues_by_group[group].add(
-                    metadata.loc[strain],
+                    strain,
                     priorities[strain],
                 )
 
@@ -344,14 +344,8 @@ def run(args):
         # Populate the set of strains to keep from the records in queues.
         subsampled_strains = set()
         for group, queue in queues_by_group.items():
-            records = []
-            for record in queue.get_items():
-                # Each record is a pandas.Series instance. Track the name of the
-                # record, so we can output its sequences later.
-                subsampled_strains.add(record.name)
-
-                # Construct a data frame of records to simplify metadata output.
-                records.append(record)
+            for strain in queue.get_items():
+                subsampled_strains.add(strain)
 
         # Count and optionally log strains that were not included due to
         # subsampling.

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -297,6 +297,12 @@ def run(args):
             dtype="string",
         )
 
+        # This conversion is necessary because the value is passed as a
+        # parameter to a date function using functools.cache, which only works
+        # with hashable parameters.
+        if args.year_bounds is not None:
+            args.year_bounds = tuple(args.year_bounds)
+
         try:
             dates = get_numerical_dates(metadata, fmt=args.date_format,
                                         min_max_year=args.year_bounds)

--- a/tests/functional/refine/cram/year-bounds-error.t
+++ b/tests/functional/refine/cram/year-bounds-error.t
@@ -22,7 +22,7 @@ Check that invalid --year-bounds provides useful error messages.
   >  --timetree \
   >  --year-bounds 1950 1960 1970 \
   >  --divergence-units mutations > /dev/null
-  ERROR: Invalid value for --year-bounds: The year bounds [1950, 1960, 1970] must have only one (lower) or two (lower, upper) bounds.
+  ERROR: Invalid value for --year-bounds: The year bounds (1950, 1960, 1970) must have only one (lower) or two (lower, upper) bounds.
   [2]
 
   $ ${AUGUR} refine \


### PR DESCRIPTION
Probably the last of the low-hanging fruits for #1573.

I tested this on the current full GISAID metadata which has ~17 million
sequences using the following command:

    augur filter \
      --metadata metadata.tsv.zst \
      --min-date 2025 \
      --group-by country year month \
      --subsample-max-sequences 100 \
      --output-strains test.txt

Total run time drops from 641s to 493s (determined by Snakeviz on [stats.zip](https://github.com/user-attachments/files/20401678/stats.zip)). Note: not comparable to numbers in #1792 since that was a different command on a different machine.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests: coverage should be sufficient
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
