### PR TITLE
docs: Redirect /envvars.html → /usage/envvars.html on RTD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* Added a missing redirect for the environment variables documentation page from its previous location. [#1812][] (@tsibley)
+
+[#1812]: https://github.com/nextstrain/augur/pull/1812
 
 ## 31.1.0 (27 May 2025)
 

--- a/docs/redirects.yaml
+++ b/docs/redirects.yaml
@@ -207,3 +207,7 @@
 - type: page
   from_url: /api/augur.version.html
   to_url: /api/developer/augur.version.html
+
+- type: page
+  from_url: /envvars.html
+  to_url: /usage/envvars.html


### PR DESCRIPTION
It was moved way back in "move docs sections into directories. Update CLI pages." (c65e2683) and recent linkchecking of an older changelog entry in Nextstrain CLI found it.  Might as well fix it now that we know about it.

## Checklist

- [ ] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
