### PR TITLE
Allow parentheses in gene names

### DIFF
--- a/augur/data/schema-annotations.json
+++ b/augur/data/schema-annotations.json
@@ -26,7 +26,7 @@
     "required": ["nuc"],
     "additionalProperties": false,
     "patternProperties": {
-        "^(?!nuc$)[a-zA-Z0-9*_.-]+$": {
+        "^(?!nuc$)[a-zA-Z0-9*_.()-]+$": {
             "$comment": "Each object here defines a single CDS",
             "type": "object",
             "oneOf": [{ "$ref": "#/$defs/startend" }, { "$ref": "#/$defs/segments" }],

--- a/augur/data/schema-export-v2.json
+++ b/augur/data/schema-export-v2.json
@@ -336,7 +336,7 @@
                                 }
                             },
                             "patternProperties": {
-                                "^(?!nuc$)[a-zA-Z0-9*_.-]+$": {
+                                "^(?!nuc$)[a-zA-Z0-9*_.()-]+$": {
                                     "description": "Amino acid mutations for this CDS",
                                     "$comment": "properties must exist in the meta.JSON -> annotation object",
                                     "type": "array",


### PR DESCRIPTION
## Description of proposed changes

Allow parentheses characters in gene names.

This PR was inspired by the presence of a gene name with parentheses in the gff file from NCBI for the tuberculosis RefSeq assembly GCF_000195955.2. These changes follows those [made to allow full stop characters in gene names](https://github.com/nextstrain/augur/pull/955#event-17761003183).


## Checklist

- [ ] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
