### PR TITLE
docs: Fix zika link

### DIFF
--- a/docs/faq/translate_ref.md
+++ b/docs/faq/translate_ref.md
@@ -30,7 +30,7 @@ Augur will only translate genes which have 'CDS' as the feature name, and have a
                      /gene="ENV"
 ```
 
-Compare the [original Zika reference on Genbank](https://www.ncbi.nlm.nih.gov/nuccore/KX369547) to the [one used on Nextstrain](https://github.com/nextstrain/zika/blob/-/phylogenetic/defaults/zika_reference.gb). Notice that the genes are designated by `CDS` instead of `mat_peptide` and have an entry for `/gene=` as well as `/product=`.
+Compare the [original Zika reference on Genbank](https://www.ncbi.nlm.nih.gov/nuccore/KX369547) to the [one used on Nextstrain](https://github.com/nextstrain/zika/blob/-/phylogenetic/defaults/reference.gb). Notice that the genes are designated by `CDS` instead of `mat_peptide` and have an entry for `/gene=` as well as `/product=`.
 
 ### VCF
 


### PR DESCRIPTION
## Description of proposed changes

Zika reference file was renamed in 
<https://github.com/nextstrain/zika/pull/85>

The borked link was found in a separate CI workflow for nextstrain/.github <https://github.com/nextstrain/.github/actions/runs/15545922707/job/43767244145?pr=134>

## Checklist

- [x] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
