### PR TITLE
Update condition for `date_inferred`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,11 @@
 
 * curate format-dates: Removed redundant warning messages that were previously displayed when using `--failure-reporting "warn"`. [#1816][] (@victorlin)
 * merge: Fixed a performance bug where input sequence file validation unnecessarily loaded file contents into device memory. [#1820][] (@victorlin)
+* refine: Fixed a bug where inferred dates were being wrongly marked as not inferred. [#1829][] (@victorlin)
 
 [#1816]: https://github.com/nextstrain/augur/pull/1816
 [#1820]: https://github.com/nextstrain/augur/pull/1820
+[#1829]: https://github.com/nextstrain/augur/issues/1829
 
 ## 31.2.0 (5 June 2025)
 

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -353,7 +353,7 @@ def run(args):
                 return 1
 
         for node in T.find_clades():
-            inferred = node.raw_date_constraint is None or isinstance(node.raw_date_constraint, list)
+            inferred = not isinstance(node.raw_date_constraint, float)
             setattr(node, 'date_inferred', inferred)
 
         attributes.extend(['numdate', 'clock_length', 'mutation_length', 'raw_date', 'date', 'date_inferred'])

--- a/tests/functional/refine/cram/year-bounds.t
+++ b/tests/functional/refine/cram/year-bounds.t
@@ -65,3 +65,13 @@ Run the same check as above.
 
   $ python3 -c 'import json, sys; print(json.load(sys.stdin)["nodes"]["PAN/CDC_259359_V1_V3/2015"]["date"])' < branch_lengths.json
   2020-12-31
+
+Check that the date is marked as inferred.
+
+  $ python3 -c 'import json, sys; print(json.load(sys.stdin)["nodes"]["PAN/CDC_259359_V1_V3/2015"]["date_inferred"])' < branch_lengths.json
+  True
+
+Check that another date is not marked as inferred.
+
+  $ python3 -c 'import json, sys; print(json.load(sys.stdin)["nodes"]["Colombia/2016/ZC204Se"]["date_inferred"])' < branch_lengths.json
+  False


### PR DESCRIPTION
## Description of proposed changes

`node.raw_date_constraint` is derived from the return value of `augur.dates.get_numerical_date_from_value`. "Clarify return types of date parsing functions" (f2a199e) updated that function to return a tuple instead of list for ambiguous dates, which broke the condition for `date_inferred`.

Update the condition to mark any value that's not a single float as an inferred date.

## Related issue(s)

Closes #1829

## Checklist

- [x] Automated checks pass ([fail](https://github.com/nextstrain/augur/actions/runs/15596475332/job/43927911192) on newly added test, [success](https://github.com/nextstrain/augur/actions/runs/15596478709) on new fix)
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
