### PR TITLE
filter: Improve concurrent run times

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,16 @@
 
 ### Features
 
+* filter, merge: Added a new option `--nthreads` to configure parallelism. Right now, it is only passed to SeqKit, but it may be used for other internal optimizations in the future. [#1833][] (@victorlin)
+* filter: Added a new option `--skip-checks` to bypass checks for duplicates in sequences and whether ids in metadata have a sequence entry. Mainly useful when working with larger files. [#1833][] (@victorlin)
 * Added a new `AUGUR_PROFILE` environment variable. If set, Augur will run with Python's cProfile profiler and save results to the value which should be a file path. This may result in slightly slower run times, and should only be used for debugging purposes. [#1835][] (@victorlin)
 
+### Bug fixes
+
+* filter, merge: Improved run time of sequence I/O operations, especially in the common use case of having a workflow manager run multiple invocations simultaneously. [#1833][] (@victorlin)
+* filter, merge: Previously, SeqKit was hardcoded to use its default of 4 threads per command, which could have resulted in oversubscription of resources in the common use case of having a workflow manager run multiple invocations simultaneously. The default behavior has been updated to use 1 thread per command to discourage oversubscription of resources. It is configurable with the new `--nthreads` option described above. [#1833][] (@victorlin)
+
+[#1833]: https://github.com/nextstrain/augur/issues/1833
 [#1835]: https://github.com/nextstrain/augur/pull/1835
 
 ## 31.2.1 (12 June 2025)

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -125,6 +125,9 @@ def register_arguments(parser):
         default=EmptyOutputReportingMethod.ERROR,
         help="How should empty outputs be reported when no strains pass filtering and/or subsampling.")
 
+    other_group = parser.add_argument_group("other", "other options")
+    other_group.add_argument('--nthreads', metavar="N", type=int, default=4, help="Number of CPUs/cores/threads/jobs to utilize at once. Default of 4 is taken from SeqKit's default for --threads." + SKIP_AUTO_DEFAULT_IN_HELP)
+
     deprecated_group = parser.add_argument_group("deprecated", "options to be removed in a future major version")
     deprecated_group.add_argument('--output', metavar="FILE", help="alias to --output-sequences" + SKIP_AUTO_DEFAULT_IN_HELP)
     deprecated_group.add_argument('-o', metavar="FILE", help="alias to --output-sequences" + SKIP_AUTO_DEFAULT_IN_HELP)

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -33,6 +33,7 @@ def register_arguments(parser):
     input_group.add_argument('--metadata-chunk-size', type=int, default=100000, help="maximum number of metadata records to read into memory at a time. Increasing this number can speed up filtering at the cost of more memory used.")
     input_group.add_argument('--metadata-id-columns', default=DEFAULT_ID_COLUMNS, nargs="+", action=ExtendOverwriteDefault, help="names of possible metadata columns containing identifier information, ordered by priority. Only one ID column will be inferred.")
     input_group.add_argument('--metadata-delimiters', default=DEFAULT_DELIMITERS, nargs="+", action=ExtendOverwriteDefault, help="delimiters to accept when reading a metadata file. Only one delimiter will be inferred.")
+    input_group.add_argument('--skip-checks', action='store_true', help="use this option to skip checking for duplicates in sequences and whether ids in metadata have a sequence entry. Can improve performance on large files. Note that this should only be used if you are sure there are no duplicate sequences or mismatched ids since they can lead to errors in downstream Augur commands.")
 
     metadata_filter_group = parser.add_argument_group("metadata filters", "filters to apply to metadata")
     metadata_filter_group.add_argument(

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -126,7 +126,7 @@ def register_arguments(parser):
         help="How should empty outputs be reported when no strains pass filtering and/or subsampling.")
 
     other_group = parser.add_argument_group("other", "other options")
-    other_group.add_argument('--nthreads', metavar="N", type=int, default=4, help="Number of CPUs/cores/threads/jobs to utilize at once. Default of 4 is taken from SeqKit's default for --threads." + SKIP_AUTO_DEFAULT_IN_HELP)
+    other_group.add_argument('--nthreads', metavar="N", type=int, default=1, help="Number of CPUs/cores/threads/jobs to utilize at once.")
 
     deprecated_group = parser.add_argument_group("deprecated", "options to be removed in a future major version")
     deprecated_group.add_argument('--output', metavar="FILE", help="alias to --output-sequences" + SKIP_AUTO_DEFAULT_IN_HELP)

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -84,7 +84,7 @@ def run(args):
         print_debug(f"Reading sequences from {args.sequences!r}…")
 
         try:
-            sequence_strains = read_sequence_ids(args.sequences, error_on_duplicates=True)
+            sequence_strains = read_sequence_ids(args.sequences)
         except AugurError as e:
             cleanup_outputs(args)
             raise e

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -84,7 +84,7 @@ def run(args):
         print_debug(f"Reading sequences from {args.sequences!r}…")
 
         try:
-            sequence_strains = read_sequence_ids(args.sequences)
+            sequence_strains = read_sequence_ids(args.sequences, args.nthreads)
         except AugurError as e:
             cleanup_outputs(args)
             raise e
@@ -416,7 +416,7 @@ def run(args):
             dropped_samps = list(sequence_strains - valid_strains)
             write_vcf(args.sequences, args.output_sequences, dropped_samps)
         else:
-            subset_fasta(args.sequences, args.output_sequences, strains_file)
+            subset_fasta(args.sequences, args.output_sequences, strains_file, args.nthreads)
             if not args.output_strains:
                 os.remove(strains_file)
 

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -80,7 +80,9 @@ def run(args):
         sequence_index_ids = set(sequence_index.index.values)
 
     # Check ids for duplicates and compare against sequence index.
-    if args.sequences:
+    if args.skip_checks:
+        print_debug(f"Skipping first pass of sequence file due to --skip-checks.")
+    elif args.sequences:
         print_debug(f"Reading sequences from {args.sequences!r}…")
 
         try:

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -624,7 +624,7 @@ def construct_filters(args, sequence_index, sequence_ids: Set[str]) -> Tuple[Lis
         exclude_by.append((filter_by_exclude_all, {}))
 
     # Filter by sequence index.
-    if sequence_ids is not None:
+    if sequence_ids is not None and not args.skip_checks:
         exclude_by.append((
             filter_by_sequence_ids,
             {

--- a/augur/io/sequences.py
+++ b/augur/io/sequences.py
@@ -176,8 +176,7 @@ def write_records_to_fasta(records, fasta, seq_id_field='strain', seq_field='seq
 
 def subset_fasta(input_filename: str, output_filename: str, ids_file: str, nthreads: int):
     command = f"""
-        {augur()} read-file {shquote(input_filename)} |
-        {seqkit()} --threads {nthreads} grep -f {ids_file} |
+        {seqkit()} --threads {nthreads} grep -f {ids_file} {shquote(input_filename)} |
         {augur()} write-file {shquote(output_filename)}
     """
 
@@ -481,8 +480,7 @@ def read_sequence_ids(file: str, nthreads: int):
             """
         else:
             command = f"""
-                {augur()} read-file {shquote(file)} |
-                {seqkit()} --threads {nthreads} fx2tab --name --only-id > {shquote(temp_file.name)}
+                {seqkit()} --threads {nthreads} fx2tab --name --only-id {shquote(file)} > {shquote(temp_file.name)}
             """
 
         try:

--- a/augur/io/sequences.py
+++ b/augur/io/sequences.py
@@ -174,10 +174,10 @@ def write_records_to_fasta(records, fasta, seq_id_field='strain', seq_field='seq
             }
 
 
-def subset_fasta(input_filename: str, output_filename: str, ids_file: str):
+def subset_fasta(input_filename: str, output_filename: str, ids_file: str, nthreads: int):
     command = f"""
         {augur()} read-file {shquote(input_filename)} |
-        {seqkit()} grep -f {ids_file} |
+        {seqkit()} --threads {nthreads} grep -f {ids_file} |
         {augur()} write-file {shquote(output_filename)}
     """
 
@@ -468,7 +468,7 @@ def _read_genbank(reference, feature_names):
 
 # TODO: consider consolidating with augur.io.metadata.read_metadata_with_sequences
 # <https://github.com/nextstrain/augur/pull/1821#discussion_r2138629823>
-def read_sequence_ids(file: str):
+def read_sequence_ids(file: str, nthreads: int):
     """Get unique identifiers from a sequence file."""
     unique = set()
     duplicates = set()
@@ -482,7 +482,7 @@ def read_sequence_ids(file: str):
         else:
             command = f"""
                 {augur()} read-file {shquote(file)} |
-                {seqkit()} fx2tab --name --only-id > {shquote(temp_file.name)}
+                {seqkit()} --threads {nthreads} fx2tab --name --only-id > {shquote(temp_file.name)}
             """
 
         try:

--- a/augur/io/sequences.py
+++ b/augur/io/sequences.py
@@ -468,7 +468,7 @@ def _read_genbank(reference, feature_names):
 
 # TODO: consider consolidating with augur.io.metadata.read_metadata_with_sequences
 # <https://github.com/nextstrain/augur/pull/1821#discussion_r2138629823>
-def read_sequence_ids(file: str, error_on_duplicates = True):
+def read_sequence_ids(file: str):
     """Get unique identifiers from a sequence file."""
     unique = set()
     duplicates = set()
@@ -499,7 +499,7 @@ def read_sequence_ids(file: str, error_on_duplicates = True):
             else:
                 unique.add(identifier)
 
-    if duplicates and error_on_duplicates:
+    if duplicates:
         raise AugurError(dedent(f"""\
             Sequence ids must be unique.
 

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -384,7 +384,7 @@ def merge_sequences(args):
     if not args.skip_input_sequences_validation:
         for s in args.sequences:
             print_info(f"Validating {s!r}…")
-            read_sequence_ids(s, error_on_duplicates=True)
+            read_sequence_ids(s)
 
     print_info(f"Merging sequences and writing to {args.output_sequences!r}…")
 

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -117,7 +117,7 @@ def register_parser(parent_subparsers):
     output_group.add_argument('--quiet', action="store_true", default=False, help="Suppress informational and warning messages normally written to stderr. (default: disabled)" + SKIP_AUTO_DEFAULT_IN_HELP)
 
     other_group = parser.add_argument_group("other", "other options")
-    other_group.add_argument('--nthreads', metavar="N", type=int, default=4, help="Number of CPUs/cores/threads/jobs to utilize at once. Default of 4 is taken from SeqKit's default for --threads." + SKIP_AUTO_DEFAULT_IN_HELP)
+    other_group.add_argument('--nthreads', metavar="N", type=int, default=1, help="Number of CPUs/cores/threads/jobs to utilize at once.")
 
     return parser
 

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -394,8 +394,7 @@ def merge_sequences(args):
     # Reversed because seqkit rmdup keeps the first entry but this command
     # should keep the last entry.
     command = f"""
-        {augur()} read-file {" ".join(shquote(s) for s in reversed(args.sequences))} |
-        {seqkit()} --threads {args.nthreads} rmdup |
+        {seqkit()} --threads {args.nthreads} rmdup {" ".join(shquote(s) for s in reversed(args.sequences))} |
         {augur()} write-file {shquote(args.output_sequences)}
     """
 

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -116,6 +116,9 @@ def register_parser(parent_subparsers):
 
     output_group.add_argument('--quiet', action="store_true", default=False, help="Suppress informational and warning messages normally written to stderr. (default: disabled)" + SKIP_AUTO_DEFAULT_IN_HELP)
 
+    other_group = parser.add_argument_group("other", "other options")
+    other_group.add_argument('--nthreads', metavar="N", type=int, default=4, help="Number of CPUs/cores/threads/jobs to utilize at once. Default of 4 is taken from SeqKit's default for --threads." + SKIP_AUTO_DEFAULT_IN_HELP)
+
     return parser
 
 
@@ -384,7 +387,7 @@ def merge_sequences(args):
     if not args.skip_input_sequences_validation:
         for s in args.sequences:
             print_info(f"Validating {s!r}…")
-            read_sequence_ids(s)
+            read_sequence_ids(s, args.nthreads)
 
     print_info(f"Merging sequences and writing to {args.output_sequences!r}…")
 
@@ -392,7 +395,7 @@ def merge_sequences(args):
     # should keep the last entry.
     command = f"""
         {augur()} read-file {" ".join(shquote(s) for s in reversed(args.sequences))} |
-        {seqkit()} rmdup |
+        {seqkit()} --threads {args.nthreads} rmdup |
         {augur()} write-file {shquote(args.output_sequences)}
     """
 

--- a/tests/functional/filter/cram/filter-duplicates-error.t
+++ b/tests/functional/filter/cram/filter-duplicates-error.t
@@ -90,3 +90,27 @@ Error even if the corresponding output is not used.
     c
   
   [2]
+
+If the error is bypassed with --skip-checks, the output will contain duplicates.
+
+  $ AUGUR_DEBUG=1 ${AUGUR} filter \
+  >   --metadata metadata.tsv \
+  >   --sequences sequences.fasta \
+  >   --skip-checks \
+  >   --output-sequences sequences-filtered.fasta
+  Skipping first pass of sequence file due to --skip-checks.
+  Reading metadata from 'metadata.tsv'…
+  Writing strains to .* (re)
+  Reading sequences from 'sequences.fasta' and writing to 'sequences-filtered.fasta'…
+  0 strains were dropped during filtering
+  4 strains passed all filters
+
+  $ cat sequences-filtered.fasta
+  >a
+  AAAA
+  >a
+  GGGG
+  >c
+  CCCC
+  >c
+  TTTT

--- a/tests/functional/merge/cram/merge-sequences-errors.t
+++ b/tests/functional/merge/cram/merge-sequences-errors.t
@@ -24,7 +24,6 @@ Seqkit errors messages are shown directly.
   Merging sequences and writing to '-'…
   
   ERROR: Shell exited 255 when running: 
-  .*augur read-file y.fasta x.fasta | (re)
   .*rmdup | (re)
   .*augur write-file - (re)
   
@@ -43,12 +42,11 @@ A missing input file shows a meaningful error during validation…
   Validating 'x.fasta'…
   Validating 'z.fasta'…
   
-  ERROR: Shell exited 2 when running: 
-  .*augur read-file z.fasta | (re)
+  ERROR: Shell exited 255 when running: 
   .*fx2tab --name.* (re)
   
   Command output was:
-    ERROR: No such file or directory: 'z.fasta'
+    \x1b[31m[ERRO]\x1b[0m stat z.fasta: no such file or directory (esc)
   
   WARNING: Metadata merge was successful but sequence merge has failed, so --output-metadata has no corresponding sequence output.
   ERROR: Unable to read 'z.fasta'. See error above.
@@ -62,14 +60,12 @@ A missing input file shows a meaningful error during validation…
   >   --output-sequences -
   Merging sequences and writing to '-'…
   
-  ERROR: Shell exited 2 when running: 
-  .*augur read-file z.fasta x.fasta | (re)
+  ERROR: Shell exited 255 when running: 
   .*rmdup | (re)
   .*augur write-file - (re)
   
   Command output was:
-    ERROR: No such file or directory: 'z.fasta'
-    [INFO]\x1b[0m 0 duplicated records removed (esc)
+    \x1b[31m[ERRO]\x1b[0m stat z.fasta: no such file or directory (esc)
   
   WARNING: Metadata merge was successful but sequence merge has failed, so --output-metadata has no corresponding sequence output.
   ERROR: Merging failed, see error(s) above. The command may have already written data to stdout. You may want to clean up any partial outputs.

--- a/tests/functional/merge/cram/merge-sequences-errors.t
+++ b/tests/functional/merge/cram/merge-sequences-errors.t
@@ -25,7 +25,7 @@ Seqkit errors messages are shown directly.
   
   ERROR: Shell exited 255 when running: 
   .*augur read-file y.fasta x.fasta | (re)
-  .*seqkit rmdup | (re)
+  .*rmdup | (re)
   .*augur write-file - (re)
   
   Command output was:
@@ -45,7 +45,7 @@ A missing input file shows a meaningful error during validation…
   
   ERROR: Shell exited 2 when running: 
   .*augur read-file z.fasta | (re)
-  .*seqkit fx2tab --name.* (re)
+  .*fx2tab --name.* (re)
   
   Command output was:
     ERROR: No such file or directory: 'z.fasta'
@@ -64,7 +64,7 @@ A missing input file shows a meaningful error during validation…
   
   ERROR: Shell exited 2 when running: 
   .*augur read-file z.fasta x.fasta | (re)
-  .*seqkit rmdup | (re)
+  .*rmdup | (re)
   .*augur write-file - (re)
   
   Command output was:


### PR DESCRIPTION
## Description of proposed changes

Avoid oversubscribing in Snakemake workflows with a new option `--nthreads`, add an option to skip the first pass through `--sequences`, and avoid using `augur read-file`.

## Related issue(s)

Closes #1833

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [x] [Tested on ncov](https://github.com/nextstrain/augur/issues/1833#issuecomment-3011435623)

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
