### PR TITLE
filter: Vectorize string concatenation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* filter: Improved speed of using `--group-by month` on large datasets. [#1845][] (@victorlin)
+
+[#1845]: https://github.com/nextstrain/augur/pull/1845
 
 ## 31.3.0 (3 July 2025)
 

--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -225,10 +225,6 @@ def get_numerical_dates(
     return dict(zip(strains, dates))
 
 @cache
-def get_year_month(year, month):
-    return f"{year}-{str(month).zfill(2)}"
-
-@cache
 def get_year_week(year, month, day):
     year, week = datetime.date(year, month, day).isocalendar()[:2]
     return f"{year}-{str(week).zfill(2)}"

--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -7,7 +7,7 @@ import pandas as pd
 from textwrap import dedent
 from typing import Collection, Dict, Iterable, List, Optional, Set, Tuple, Union
 
-from augur.dates import get_year_month, get_year_week, get_year_month_day
+from augur.dates import get_year_week, get_year_month_day
 from augur.errors import AugurError
 from augur.io.metadata import METADATA_DATE_COLUMN
 from augur.io.print import print_err, _n
@@ -144,10 +144,9 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
             if constants.DATE_YEAR_COLUMN in generated_columns_requested:
                 metadata[constants.DATE_YEAR_COLUMN] = metadata[f'{temp_prefix}year'].astype('string')
             if constants.DATE_MONTH_COLUMN in generated_columns_requested:
-                metadata[constants.DATE_MONTH_COLUMN] = metadata.apply(lambda row: get_year_month(
-                    row[f'{temp_prefix}year'],
-                    row[f'{temp_prefix}month']
-                    ), axis=1
+                metadata[constants.DATE_MONTH_COLUMN] = (
+                    metadata[f'{temp_prefix}year'].astype(str) + '-' +
+                    metadata[f'{temp_prefix}month'].astype(str).str.zfill(2)
                 )
             if constants.DATE_WEEK_COLUMN in generated_columns_requested:
                 # Note that week = (year, week) from the date.isocalendar().


### PR DESCRIPTION
## Description of proposed changes

All the operations done in the `get_year_month` function have a vectorized equivalent in pandas which is significantly faster.

In local testing of the ncov/open/100k dataset with `--group-by month`, this change brings the statement's run time from 11 seconds down to .16 seconds.

Side note: the addition of caching to this function in "Cache other date functions" (361cb441) was short-sighted. Caching has little benefit with simple operations such as string concatenation.

## Related issue(s)

#1573

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
