### PR TITLE
Extract URLs from input metadata values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * support numpy v2 in addition to v1. [#1855][] (@corneliusroemer)
 * support for Python 3.13. [#1857][] (@corneliusroemer)
 * tree: Prefer `iqtree3` binary over `iqtree2` and `iqtree` when available. [#1875][] (@joverlee521)
+* export v2: URLs encoded in metadata (both TSV and node-data JSONs) will be associated with the value in the exported JSON. Given a column/key `<X>` then a valid URL in a column/key named `<X>__url` will be automatically used. This allows values to be a clickable link when viewed in Auspice. [#1852][] (@jameshadfield)
 
 ### Bug fixes
 
@@ -19,6 +20,7 @@
 [#1819]: https://github.com/nextstrain/augur/pull/1819
 [#1844]: https://github.com/nextstrain/augur/pull/1844
 [#1845]: https://github.com/nextstrain/augur/pull/1845
+[#1852]: https://github.com/nextstrain/augur/pull/1852
 [#1855]: https://github.com/nextstrain/augur/pull/1855
 [#1857]: https://github.com/nextstrain/augur/pull/1857
 [#1865]: https://github.com/nextstrain/augur/issues/1865

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -925,9 +925,11 @@ def register_parser(parent_subparsers):
     )
     optional_inputs.add_argument('--node-data', metavar="JSON", nargs='+', action=ExtendOverwriteDefault,
         help="JSON files containing metadata for nodes in the tree. " +
+             "Keys are automatically exported as colorings unless special-cased. " +
              "URLs for a key 'X' can be stored under key 'X__url' and will be automatically exported.")
     optional_inputs.add_argument('--metadata', metavar="FILE",
         help="Additional metadata for strains in the tree. " +
+             "Columns are not typically exported by default and must be specified via arguments or within the config JSON. "
              "URLs for a column 'X' can be stored in column 'X__url' and will be automatically exported.")
     optional_inputs.add_argument('--metadata-delimiters', default=DEFAULT_DELIMITERS, nargs="+", action=ExtendOverwriteDefault,
                                  help="delimiters to accept when reading a metadata file. Only one delimiter will be inferred.")

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -11,6 +11,7 @@ import math
 import re
 from Bio import Phylo
 from typing import Dict, Union, TypedDict, Any, Tuple
+from urllib.parse import urlparse
 
 from .argparse_ import ExtendOverwriteDefault, add_validation_arguments
 from .errors import AugurError
@@ -740,7 +741,17 @@ def attr_confidence(
     warn(f"[confidence] {key+'_confidence'!r} is of an unknown format. Skipping.")
     return {}
 
+def valid_url(url: str) -> bool:
+    # <https://stackoverflow.com/questions/7160737/how-to-validate-a-url-in-python-malformed-or-not>
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except AttributeError:
+        return False
 
+def url_name(name):
+    """For column/key *name* what column/key would the associated URL be found in?"""
+    return f"{name}__url"
 
 def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
     '''
@@ -759,8 +770,10 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
 
     def _transfer_additional_metadata_columns(node, raw_data):
         for col in additional_metadata_columns:
-            if is_valid(raw_data.get(col, None)):
-                node["node_attrs"][col] = {"value": raw_data[col]}
+            if is_valid(value:=raw_data.get(col, None)):
+                node["node_attrs"][col] = {"value": value}
+                if type(value) is str and valid_url(url:=raw_data.get(url_name(col), None)):
+                    node["node_attrs"][col]['url'] = url
 
     def _transfer_vaccine_info(node, raw_data):
         if raw_data.get("vaccine"):
@@ -807,7 +820,12 @@ def set_node_attrs_on_tree(data_json, node_attrs, additional_metadata_columns):
         for key in trait_keys:
             value = raw_data.get(key, None)
             if is_valid(value):
-                node["node_attrs"][key] = {"value": format_number(value) if is_numeric(value) else value}
+                if is_numeric(value):
+                    node["node_attrs"][key] = {"value": format_number(value)}
+                else:
+                    node["node_attrs"][key] = {"value": value}
+                    if valid_url(url:=raw_data.get(url_name(key), None)):
+                        node["node_attrs"][key]['url'] = url
                 node["node_attrs"][key].update(attr_confidence(node["name"], raw_data, key))
 
     def _transfer_author_data(node):
@@ -864,6 +882,9 @@ def node_data_prop_is_normal_trait(name):
     if '_confidence' in name or '_entropy' in name:
         return False
 
+    if name.endswith('__url'):
+        return False
+
     return True
 
 
@@ -902,8 +923,12 @@ def register_parser(parent_subparsers):
     optional_inputs = parser.add_argument_group(
         title="OPTIONAL INPUT FILES"
     )
-    optional_inputs.add_argument('--node-data', metavar="JSON", nargs='+', action=ExtendOverwriteDefault, help="JSON files containing metadata for nodes in the tree")
-    optional_inputs.add_argument('--metadata', metavar="FILE", help="Additional metadata for strains in the tree")
+    optional_inputs.add_argument('--node-data', metavar="JSON", nargs='+', action=ExtendOverwriteDefault,
+        help="JSON files containing metadata for nodes in the tree. " +
+             "URLs for a key 'X' can be stored under key 'X__url' and will be automatically exported.")
+    optional_inputs.add_argument('--metadata', metavar="FILE",
+        help="Additional metadata for strains in the tree. " +
+             "URLs for a column 'X' can be stored in column 'X__url' and will be automatically exported.")
     optional_inputs.add_argument('--metadata-delimiters', default=DEFAULT_DELIMITERS, nargs="+", action=ExtendOverwriteDefault,
                                  help="delimiters to accept when reading a metadata file. Only one delimiter will be inferred.")
     optional_inputs.add_argument('--metadata-id-columns', default=DEFAULT_ID_COLUMNS, nargs="+", action=ExtendOverwriteDefault,

--- a/tests/functional/export_v2/cram/metadata-urls.t
+++ b/tests/functional/export_v2/cram/metadata-urls.t
@@ -1,0 +1,90 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create files for testing.
+
+  $ cat >metadata.tsv <<~~
+  > strain	field_A	field_A__url
+  > tipA	nextstrain	https://nextstrain.org
+  > tipB	BB: not-a-url	
+  > tipC	github	https://github.com
+  > tipD	DD <not-a-url>	
+  > tipE	EE	invalid-url
+  > tipF	FF	
+  > ~~
+
+  $ cat >tree.nwk <<~~
+  > (tipA:1,(tipB:1,tipC:1)internalBC:2,(tipD:3,tipE:4,tipF:1)internalDEF:5)ROOT:0;
+  > ~~
+
+Check that URLs were extracted from metadata values when added as an "extra metadata column"
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata.tsv \
+  >  --metadata-columns "field_A" \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset.json
+  Validating schema of 'dataset.json'...
+  Validation of 'dataset.json' succeeded.
+  Validating produced JSON
+  Validating that the JSON is internally consistent...
+  
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-parsed-urls.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']"
+  {}
+
+
+Check that URLs were extracted from metadata values when used as a coloring
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --metadata metadata.tsv \
+  >  --color-by-metadata "field_A" \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset2.json
+  Validating schema of 'dataset2.json'...
+  Validation of 'dataset2.json' succeeded.
+  Trait 'field_A' was guessed as being type 'categorical'. Use a 'config' file if you'd like to set this yourself.
+  Validating produced JSON
+  Validating that the JSON is internally consistent...
+  
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-parsed-urls.json" dataset2.json \
+  >   --exclude-paths "root['meta']['updated']" "root['meta']['colorings']" "root['meta']['filters']"
+  {}
+
+Check that node-data JSONs, where non-special-case values are automatically used, are correctly handled.
+The data is essentially the same, but tipB & tipD have empty-string URLs and tipF is missing the URL key entirely.
+
+  $ cat >node-data.json <<~~
+  > {"nodes":
+  >   {
+  >     "tipA": {"field_A": "nextstrain", "field_A__url": "https://nextstrain.org"},
+  >     "tipB": {"field_A": "BB: not-a-url", "field_A__url": ""},
+  >     "tipC": {"field_A": "github", "field_A__url": "https://github.com"},
+  >     "tipD": {"field_A": "DD <not-a-url>", "field_A__url": ""},
+  >     "tipE": {"field_A": "EE", "field_A__url": "invalid-url"},
+  >     "tipF": {"field_A": "FF"}
+  >   }
+  > }
+  > ~~
+
+  $ ${AUGUR} export v2 \
+  >  --tree tree.nwk \
+  >  --node-data node-data.json \
+  >  --maintainers "Nextstrain Team" \
+  >  --output dataset3.json
+  Validating schema of 'dataset3.json'...
+  Validation of 'dataset3.json' succeeded.
+  Trait 'field_A' was guessed as being type 'categorical'. Use a 'config' file if you'd like to set this yourself.
+  Validating produced JSON
+  Validating that the JSON is internally consistent...
+  
+
+
+  $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" "$TESTDIR/../data/dataset-with-parsed-urls.json" dataset.json \
+  >   --exclude-paths "root['meta']['updated']"
+  {}

--- a/tests/functional/export_v2/data/dataset-with-parsed-urls.json
+++ b/tests/functional/export_v2/data/dataset-with-parsed-urls.json
@@ -1,0 +1,105 @@
+{
+  "version": "v2",
+  "meta": {
+    "updated": "2025-07-14",
+    "maintainers": [
+      {
+        "name": "Nextstrain Team"
+      }
+    ],
+    "colorings": [],
+    "filters": [],
+    "panels": [
+      "tree"
+    ]
+  },
+  "tree": {
+    "name": "ROOT",
+    "node_attrs": {
+      "div": 0
+    },
+    "branch_attrs": {},
+    "children": [
+      {
+        "name": "tipA",
+        "node_attrs": {
+          "div": 1.0,
+          "field_A": {
+            "value": "nextstrain",
+            "url": "https://nextstrain.org"
+          }
+        },
+        "branch_attrs": {}
+      },
+      {
+        "name": "internalBC",
+        "node_attrs": {
+          "div": 2.0
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipB",
+            "node_attrs": {
+              "div": 3.0,
+              "field_A": {
+                "value": "BB: not-a-url"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipC",
+            "node_attrs": {
+              "div": 3.0,
+              "field_A": {
+                "value": "github",
+                "url": "https://github.com"
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      },
+      {
+        "name": "internalDEF",
+        "node_attrs": {
+          "div": 5.0
+        },
+        "branch_attrs": {},
+        "children": [
+          {
+            "name": "tipD",
+            "node_attrs": {
+              "div": 8.0,
+              "field_A": {
+                "value": "DD <not-a-url>"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipE",
+            "node_attrs": {
+              "div": 9.0,
+              "field_A": {
+                "value": "EE"
+              }
+            },
+            "branch_attrs": {}
+          },
+          {
+            "name": "tipF",
+            "node_attrs": {
+              "div": 6.0,
+              "field_A": {
+                "value": "FF"
+              }
+            },
+            "branch_attrs": {}
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
As discussed this in last week's dev chat meeting, we want the ability for for metadata values (in TSV or node_data JSON) to be able to encode a URL which is parsed by `augur export v2`. The output structure for Auspice is `node_attrs.<field>: {value: <value>, url: <url>}`

This PR enables metadata fields to include URLs encoded like:
```
strain	field_A
tipA	nextstrain: https://nextstrain.org
tipC	github <https://github.com>
```

My reading of the related [RSV PPX PR](https://github.com/nextstrain/rsv/pull/93) is to have fields in Auspice like so:
* PPX_accession + URL 
* dataUseTerms + (optional) URL 
* (optional) restrictedUntil (value only)
* (optional) insdcAccession + NCBI Url

That PR is forced to use a script to generate a JSON (`create_accession_json.py`) and then an extra rule (`patch_exported_tree`) to add these to the exported JSON. Instead we should provision these fields in the curated metadata files [1] with fields encoded such that any URLs are in the field value, and then `augur export v2` should work without needing anything extra.

[1] This is also important if we are to share these intermediate files

Note: we discussed encoding URLs in the (input) metadata via two columns, `<name>` and `<name>_url` (etc), but I didn't pursue that here.
