### PR TITLE
Support numpy v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
     - run: npx pyright --stats
 
   pytest-cram:
-    name: test (python=${{ matrix.python-version }} biopython=${{ matrix.biopython-version || 'latest' }})
+    name: test (python=${{ matrix.python-version }} biopython=${{ matrix.biopython-version || 'latest' }} numpy=${{ matrix.numpy-version || 'latest' }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,6 +51,16 @@ jobs:
           - '1.80' # first to support Python 3.10 and 3.11
           - '1.82' # first to support Python 3.12
           - ''     # latest
+        numpy-version:
+          - ''        # latest (numpy 2.x) - test with all combinations
+        include:
+          # Python 3.9 automatically uses numpy v1, so no need to specify here
+          - python-version: '3.10'
+            biopython-version: '1.80'
+            numpy-version: '1.26.4'
+          - python-version: '3.12'
+            biopython-version: ''
+            numpy-version: '1.26.4'
         exclude:
           # some older Biopython versions are incompatible with later Python versions
           - { biopython-version: '1.80', python-version: '3.12' }
@@ -58,7 +68,7 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      COVERAGE_FILE: ${{ github.workspace }}/.coverage@python=${{ matrix.python-version }},biopython=${{ matrix.biopython-version || 'latest' }}
+      COVERAGE_FILE: ${{ github.workspace }}/.coverage@python=${{ matrix.python-version }},biopython=${{ matrix.biopython-version || 'latest' }},numpy=${{ matrix.numpy-version || 'latest' }}
       COVERAGE_RCFILE: ${{ github.workspace }}/.coveragerc
     steps:
     - uses: actions/checkout@v4
@@ -73,7 +83,11 @@ jobs:
     - name: Install dependencies from Conda
       uses: mamba-org/setup-micromamba@v2
       with:
-        create-args: mafft raxml fasttree iqtree vcftools seqkit sqlite tsv-utils biopython=${{ matrix.biopython-version }} python=${{ matrix.python-version }}
+        create-args: >-
+          mafft raxml fasttree iqtree vcftools seqkit sqlite tsv-utils
+          biopython=${{ matrix.biopython-version }}
+          numpy=${{ matrix.numpy-version }}
+          python=${{ matrix.python-version }}
         condarc: |
           channels:
             - conda-forge
@@ -92,7 +106,7 @@ jobs:
       env:
         AUGUR: coverage run -a ${{ github.workspace }}/bin/augur
     # Only upload coverage for one job
-    - if: matrix.python-version == '3.11' && matrix.biopython-version == ''
+    - if: matrix.python-version == '3.11' && matrix.biopython-version == '' && matrix.numpy-version == ''
       uses: actions/upload-artifact@v4
       with:
         name: coverage

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 * schema: Allow parentheses (`()`) in gene names. [#1819][] (@kimandrews)
 * geolocation rules: Add rules to define region per country to ensure that regions are labelled for all countries. This is especially useful for data sources that do not include region in the metadata. [#1844][] (@joverlee521)
+* Support numpy v2 in addition to v1. [#1855][] (@corneliusroemer)
 
 ### Bug fixes
 
@@ -14,6 +15,7 @@
 [#1819]: https://github.com/nextstrain/augur/pull/1819
 [#1844]: https://github.com/nextstrain/augur/pull/1844
 [#1845]: https://github.com/nextstrain/augur/pull/1845
+[#1855]: https://github.com/nextstrain/augur/pull/1855
 
 ## 31.3.0 (3 July 2025)
 

--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -351,8 +351,8 @@ def get_weighted_group_sizes(
     # Warn on any under-sampled groups
     for _, row in weights.iterrows():
         if row[INPUT_SIZE_COLUMN] < row[TARGET_SIZE_COLUMN]:
-            sequences = _n('sequence', 'sequences', row[TARGET_SIZE_COLUMN])
-            are = _n('is', 'are', row[INPUT_SIZE_COLUMN])
+            sequences = _n('sequence', 'sequences', int(row[TARGET_SIZE_COLUMN]))
+            are = _n('is', 'are', int(row[INPUT_SIZE_COLUMN]))
             group = list(f'{col}={value!r}' for col, value in row[group_by].items())
             print_err(f"WARNING: Targeted {row[TARGET_SIZE_COLUMN]} {sequences} for group {group} but only {row[INPUT_SIZE_COLUMN]} {are} available.")
 
@@ -493,7 +493,7 @@ def _handle_incomplete_weights(
         print_err(dedent(f"""\
             WARNING: The input metadata contains these values under the following columns that are not directly covered by {weights_file!r}:
             - {columns_with_values}
-            The default weight of {default_weight!r} will be used for all groups defined by those values."""))
+            The default weight of {default_weight} will be used for all groups defined by those values."""))
 
         missing_weights = pd.DataFrame(sorted(missing_groups), columns=group_by)
         missing_weights[WEIGHTS_COLUMN] = default_weight

--- a/augur/filter/weights_file.py
+++ b/augur/filter/weights_file.py
@@ -1,6 +1,9 @@
+from typing import List, Optional
+
+import numpy as np
 import pandas as pd
+
 from textwrap import dedent
-from typing import List
 from augur.errors import AugurError
 
 
@@ -47,7 +50,7 @@ def get_weighted_columns(weights_file):
     return columns
 
 
-def get_default_weight(weights: pd.DataFrame, weighted_columns: List[str]):
+def get_default_weight(weights: pd.DataFrame, weighted_columns: List[str]) -> Optional[np.number]:
     # Match weighted columns with 'default' value. Multiple values can be matched for 2 reasons:
     # 1. Repeated rows following additional permutation with unweighted columns.
     #    This is handled by unique() since the value should be the same.
@@ -57,7 +60,7 @@ def get_default_weight(weights: pd.DataFrame, weighted_columns: List[str]):
         weights[weighted_columns].eq(COLUMN_VALUE_FOR_DEFAULT_WEIGHT).all(axis=1) &
         weights[weighted_columns].notna().all(axis=1)
     )
-    default_weight_values = weights.loc[mask, WEIGHTS_COLUMN].unique()
+    default_weight_values = weights.loc[mask, WEIGHTS_COLUMN].unique()  # type: ignore[operator]
 
     if len(default_weight_values) > 1:
         # TODO: raise InvalidWeightsFile, not AugurError. This function takes
@@ -71,3 +74,4 @@ def get_default_weight(weights: pd.DataFrame, weighted_columns: List[str]):
         raise AugurError(f"Multiple default weights were specified: {', '.join(repr(weight) for weight in default_weight_values)}. Only one default weight entry can be accepted.")
     if len(default_weight_values) == 1:
         return default_weight_values[0]
+    return None

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setuptools.setup(
         # Sync this with 'types-jsonschema' dev dependency
         "jsonschema >=4.18.0, ==4.*",
         "networkx >= 2.5, <4",
-        "numpy ==1.*",
+        "numpy >=1, <3",
         "packaging >=19.2",
         # Sync this with 'pandas-stubs' dev dependency
         "pandas >=1.4.0, <3",


### PR DESCRIPTION
Recreation of #1533 (can't be reopened as branch was deleted)

resolves #1504

Changes:
- Relax version constraint in setup.py
- Add new entries in test matrix to keep testing numpy v1 (run on highest and lowest support Python/Biopython to prevent number of jobs from doubling)
- Remove `!r` in a log statement as numpy changes raw representation
- Fix newly occurring type errors with numpy v2

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
