### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,15 +45,20 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
         biopython-version:
           # list of Biopython versions with support for a new Python version
           # from https://github.com/biopython/biopython/blob/master/NEWS.rst
           - '1.80' # first to support Python 3.10 and 3.11
           - '1.82' # first to support Python 3.12
+          - '1.85' # first to support Python 3.13
           - ''     # latest
         exclude:
           # some older Biopython versions are incompatible with later Python versions
           - { biopython-version: '1.80', python-version: '3.12' }
+          - { biopython-version: '1.80', python-version: '3.13' }
+          - { biopython-version: '1.82', python-version: '3.13' }
+          - { biopython-version: '', python-version: '3.9' } # once 1.86 is released, 3.9 not supported
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 * schema: Allow parentheses (`()`) in gene names. [#1819][] (@kimandrews)
 * geolocation rules: Add rules to define region per country to ensure that regions are labelled for all countries. This is especially useful for data sources that do not include region in the metadata. [#1844][] (@joverlee521)
-* support for Python 3.13. [#TKTK][] @corneliusroemer)
+* support for Python 3.13. [#1857][] (@corneliusroemer)
 
 ### Bug fixes
 
@@ -15,7 +15,7 @@
 [#1819]: https://github.com/nextstrain/augur/pull/1819
 [#1844]: https://github.com/nextstrain/augur/pull/1844
 [#1845]: https://github.com/nextstrain/augur/pull/1845
-[#TKTK]: https://github.com/nextstrain/augur/pull/TKTK
+[#1857]: https://github.com/nextstrain/augur/pull/1857
 
 ## 31.3.0 (3 July 2025)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 * schema: Allow parentheses (`()`) in gene names. [#1819][] (@kimandrews)
 * geolocation rules: Add rules to define region per country to ensure that regions are labelled for all countries. This is especially useful for data sources that do not include region in the metadata. [#1844][] (@joverlee521)
+* support for Python 3.13. [#TKTK][] @corneliusroemer)
 
 ### Bug fixes
 
@@ -14,6 +15,7 @@
 [#1819]: https://github.com/nextstrain/augur/pull/1819
 [#1844]: https://github.com/nextstrain/augur/pull/1844
 [#1845]: https://github.com/nextstrain/augur/pull/1845
+[#TKTK]: https://github.com/nextstrain/augur/pull/TKTK
 
 ## 31.3.0 (3 July 2025)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-import sys
-from pathlib import Path
-
+from pathlib    import Path
 import setuptools
+import sys
 
 py_min_version = (3, 9)  # minimal supported python version
 since_augur_version = (27, 0)  # py_min_version is required since this augur version

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from pathlib    import Path
-import setuptools
 import sys
+from pathlib import Path
+
+import setuptools
 
 py_min_version = (3, 9)  # minimal supported python version
 since_augur_version = (27, 0)  # py_min_version is required since this augur version
@@ -109,6 +110,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     # Install an "augur" program which calls augur.__main__.main()
     #   https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation

--- a/tests/functional/mask/variants.vcf.gz_maskTemp
+++ b/tests/functional/mask/variants.vcf.gz_maskTemp
@@ -1,5 +1,0 @@
-MTB_anc	1199
-MTB_anc	1200
-MTB_anc	8321
-MTB_anc	8322
-MTB_anc	8323

--- a/tests/functional/parse.t
+++ b/tests/functional/parse.t
@@ -9,13 +9,7 @@ This should fail.
   $ ${AUGUR} parse \
   >   --sequences parse/zika.fasta \
   >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv"
-  usage: .* (re)
-  .* (re)
-  .* (re)
-  .* (re)
-  .* (re)
-  .* (re)
+  >   --output-metadata "$TMP/metadata.tsv" 2>&1 | tail -1
   augur parse: error: the following arguments are required: --fields
   [2]
 


### PR DESCRIPTION
Resolves #1679

- Upgrade PR based on most recent version bump PR #1678
- Making a cram test less overspecific (no longer asserting on exact line count of usage output) to make it pass with Python 3.13
- Removing a test file that seems to have been accidentally committed 


## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

