### PR TITLE
dev: ignore potential mask output file from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tests/functional/tree/data/full_aligned-delim.fasta.splits.nex
 tests/functional/tree/data/full_aligned-delim.fasta.ufboot
 tests/functional/tree/data/masked_aligned-delim.iqtree.log.xz
 tests/functional/tree/data/masked_aligned.fasta.xz
+tests/functional/mask/variants.vcf.gz_maskTemp
 
 # Transient error outputs from tests
 /tests/**/*.t.err


### PR DESCRIPTION
## Description of proposed changes

I briefly considered putting a try/finally block in mask.py to _always_ cleanup  files, but I think it's generally helpful to have the output logs if the  command fails for any reason so I'm just adding the tmp file to .gitignore.

Resolves https://github.com/nextstrain/augur/issues/1863

## Checklist

- [ ] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
