### PR TITLE
validate: don't print merged config to stderr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 * filter: Improved speed of using `--group-by month` on large datasets. [#1845][] (@victorlin)
 * merge: Added validation to require at least two sequence inputs for merging, consistent with metadata merging behavior. [#1865][] (@victorlin)
 * validate: Send all log messages to `stderr`. [#1869][] (@victorlin)
+* validate: only print the entire merged Auspice config to `stderr` when there's a validation error. [#1878][](@joverlee521)
 
 [#1819]: https://github.com/nextstrain/augur/pull/1819
 [#1844]: https://github.com/nextstrain/augur/pull/1844
@@ -24,6 +25,7 @@
 [#1865]: https://github.com/nextstrain/augur/issues/1865
 [#1869]: https://github.com/nextstrain/augur/pull/1869
 [#1875]: https://github.com/nextstrain/augur/pull/1875
+[#1878]: https://github.com/nextstrain/augur/pull/1878
 
 ## 31.3.0 (3 July 2025)
 

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -53,7 +53,7 @@ def load_json_schema(path, refs=None):
         Validator.check_schema(schema)
     except jsonschema.exceptions.SchemaError as err:
         raise ValidateError(f"Schema {path} is not a valid JSON Schema ({Validator.META_SCHEMA['$schema']}). Error: {err}")
-    
+
     if refs:
         # Make the validator aware of additional schemas
         schema_store = dict()
@@ -234,8 +234,14 @@ validate = validate_json  # TODO update uses and drop this alias
 
 def auspice_config_v2(config_json: Union[str,dict], **kwargs):
     schema = load_json_schema("schema-auspice-config-v2.json")
-    config = config_json if isinstance(config_json, dict) else load_json(config_json)
-    validate(config, schema, config_json)
+    if isinstance(config_json, dict):
+        config = config_json
+        filename = "merged config"
+    else:
+        config = load_json(config_json)
+        filename = config_json
+
+    validate(config, schema, filename)
 
 def export_v2(main_json, **kwargs):
     # The main_schema uses references to other schemas, and the suggested use is


### PR DESCRIPTION
## Description of proposed changes

Noticed during review of https://github.com/nextstrain/rsv/pull/94 that the entire merged Auspice config is printed out to stderr at the start of the validation.

This seems unintentional to me since the merged config is purposely printed out when there's a validation error.

<https://github.com/nextstrain/augur/blob/41570124e050344ca826e7647ea656aa2366e460/augur/util_support/auspice_config.py#L250-L252>

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [ ] ~[Check][2] if you need to add tests~ 
- [ ] ~[Check][3] if you need to update docs~

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
