### PR TITLE
subsample: Support defaults

### DIFF
--- a/augur/data/schema-subsample-config.json
+++ b/augur/data/schema-subsample-config.json
@@ -9,6 +9,126 @@
         "samples"
     ],
     "$defs": {
+        "defaultProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclude": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "File(s) with list of strains to exclude. Paths must be relative to the\nworking directory."
+                },
+                "exclude_all": {
+                    "type": "boolean",
+                    "description": "Exclude all strains by default. Use this with the include arguments to\nselect a specific subset of strains."
+                },
+                "exclude_ambiguous_dates_by": {
+                    "type": "string",
+                    "enum": [
+                        "any",
+                        "day",
+                        "month",
+                        "year"
+                    ],
+                    "description": "Exclude ambiguous dates by day (e.g., 2020-09-XX), month (e.g.,\n2020-XX-XX), year (e.g., 200X-10-01), or any date fields. An ambiguous\nyear makes the corresponding month and day ambiguous, too, even if those\nfields have unambiguous values (e.g., \"201X-10-01\"). Similarly, an\nambiguous month makes the corresponding day ambiguous (e.g.,\n\"2010-XX-01\")."
+                },
+                "exclude_where": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "Exclude sequences matching these conditions. Ex: \"host=rat\" or\n\"host!=rat\". Multiple values are processed as OR (matching any of those\nspecified will be excluded), not AND."
+                },
+                "include": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "File(s) with list of strains to include regardless of priorities,\nsubsampling, or absence of an entry in sequences. Paths must be relative\nto the working directory."
+                },
+                "include_where": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "Include sequences with these values. ex: host=rat. Multiple values are\nprocessed as OR (having any of those specified will be included), not\nAND. This rule is applied last and ensures any strains matching these\nrules will be included regardless of priorities, subsampling, or absence\nof an entry in sequences."
+                },
+                "min_date": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "Minimal cutoff for date (inclusive). Supported formats:\n\n1. an Augur-style numeric date with the year as the integer part (e.g.\n   2020.42) or\n2. a date in ISO 8601 date format (i.e. YYYY-MM-DD) (e.g. '2020-06-04') or\n3. a backwards-looking relative date in ISO 8601 duration format with\n   optional P prefix (e.g. '1W', 'P1W')"
+                },
+                "max_date": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "Maximal cutoff for date (inclusive). Supported formats:\n\n1. an Augur-style numeric date with the year as the integer part (e.g.\n   2020.42) or\n2. a date in ISO 8601 date format (i.e. YYYY-MM-DD) (e.g. '2020-06-04') or\n3. a backwards-looking relative date in ISO 8601 duration format with\n   optional P prefix (e.g. '1W', 'P1W')"
+                },
+                "min_length": {
+                    "type": "integer",
+                    "description": "Minimal length of the sequences, only counting standard nucleotide\ncharacters A, C, G, or T (case-insensitive)."
+                },
+                "max_length": {
+                    "type": "integer",
+                    "description": "Maximum length of the sequences, only counting standard nucleotide\ncharacters A, C, G, or T (case-insensitive)."
+                },
+                "non_nucleotide": {
+                    "type": "boolean",
+                    "description": "Exclude sequences that contain illegal characters."
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Filter sequences by attribute. Uses `Pandas DataFrame query syntax`__.\n(e.g., \"country == 'Colombia'\" or \"(country == 'USA' & (division ==\n'Washington'))\")\n\n__ https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query"
+                },
+                "query_columns": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "description": "Use alongside query to specify columns and data types in the format\n'column:type', where type is one of\n(bool,float,int,str). Automatic type inference will be\nattempted on all unspecified columns used in the query. Example:\nregion:str coverage:float."
+                }
+            }
+        },
         "sampleProperties": {
             "type": "object",
             "additionalProperties": false,
@@ -161,6 +281,9 @@
         }
     },
     "properties": {
+        "defaults": {
+            "$ref": "#/$defs/defaultProperties"
+        },
         "samples": {
             "type": "object",
             "minProperties": 1,

--- a/augur/subsample.py
+++ b/augur/subsample.py
@@ -153,6 +153,7 @@ def run(args: argparse.Namespace) -> None:
 
     # 2. Construct argument lists for augur filter.
 
+    defaults = config.get("defaults")
     samples: List[Sample] = []
     global_filter_args: FilterArgs = {}
     for cli_option, filter_option in GLOBAL_CLI_OPTIONS.items():
@@ -160,6 +161,7 @@ def run(args: argparse.Namespace) -> None:
             _add_to_args(global_filter_args, filter_option, value)
 
     for name, options in config.get("samples", {}).items():
+        options = _merge_options(options, defaults)
         sample = Sample(name, options, global_filter_args)
         samples.append(sample)
 
@@ -246,6 +248,16 @@ def _parse_config(filename: str, config_section: Optional[List[str]] = None) -> 
     except ValidateError as e:
         raise AugurError(e)
     return config
+
+
+def _merge_options(sample_options: Dict[str, Any], defaults: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Merge sample options with default options, with sample options taking precedence.
+    """
+    if defaults is None:
+        return sample_options
+
+    return {**defaults, **sample_options}
 
 
 class Sample:

--- a/devel/regenerate-subsample-schema
+++ b/devel/regenerate-subsample-schema
@@ -43,11 +43,8 @@ def create_schema():
         "required": ["samples"],
     }
 
-    # Define sample options as properties in the schema.
-    # Note: these map directly to augur filter options¹, but that is an
-    # implementation detail that may change in the future.
-    # ¹ augur/subsample.py:SAMPLE_CONFIG
-    sample_options = {
+    # Define default options that can be used at top-level or sample-level.
+    default_options = {
         "exclude": {
             "oneOf": [
                 {"type": "string"},
@@ -130,7 +127,15 @@ def create_schema():
                 }
             ],
             "description": descriptions["query_columns"]
-        },
+        }
+    }
+
+    # Define sample options as properties in the schema.
+    # Note: these map directly to augur filter options¹, but that is an
+    # implementation detail that may change in the future.
+    # ¹ augur/subsample.py:SAMPLE_CONFIG
+    sample_options = {
+        **default_options,
         "group_by": {
             "oneOf": [
                 {"type": "string"},
@@ -161,8 +166,13 @@ def create_schema():
 
     validate(sample_options)
 
-    # Add a definition for sample options.
+    # Add definitions for default and sample options.
     schema["$defs"] = {
+        "defaultProperties": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": default_options
+        },
         "sampleProperties": {
             "type": "object",
             "additionalProperties": False,
@@ -172,6 +182,7 @@ def create_schema():
 
     # Define the schema structure.
     schema["properties"] = {
+        "defaults": {"$ref": "#/$defs/defaultProperties"},
         "samples": {
             "type": "object",
             "minProperties": 1,

--- a/docs/usage/cli/subsample.rst
+++ b/docs/usage/cli/subsample.rst
@@ -41,26 +41,46 @@ Configuration
 The ``--config`` option expects a YAML-formatted configuration file. This
 section describes how the file should be structured.
 
+.. code:: yaml
+
+   defaults:
+     # default sample options
+   samples:
+     <sample 1>:
+       # sample options
+     <sample 2>:
+       # sample options
+     …
+
 .. tip::
 
     Use ``--config-section`` to read from a configuration file that puts these
     options under a specific section.
 
+
+defaults
+--------
+
+The ``defaults`` section is optional and allows you to specify common options
+that apply to all samples. This reduces repetition when multiple samples share
+the same criteria.
+
+Options specified in the ``defaults`` section can be overridden by individual
+samples. If both defaults and a specific sample define the same option, the
+sample-specific value takes precedence.
+
+Note that some options are only available at the sample level and cannot be
+specified in defaults.
+
+.. schema-options-table:: augur/data/schema-subsample-config.json defaultProperties
+
 samples
 -------
 
-``samples`` must contain at least one sample.
+``samples`` must contain at least one sample. Sample-specific options override
+any values set in the ``defaults`` section.
 
-.. code:: yaml
-
-   samples:
-     <sample 1>:
-       # sample options (see below)
-     <sample 2>:
-       # sample options (see below)
-     …
-
-.. sample-options-schema-table:: augur/data/schema-subsample-config.json
+.. schema-options-table:: augur/data/schema-subsample-config.json sampleProperties
 
 Implementation details
 ======================

--- a/tests/functional/subsample/cram/advanced-yaml.t
+++ b/tests/functional/subsample/cram/advanced-yaml.t
@@ -4,6 +4,9 @@ Setup
 
 YAML anchors and aliases are supported.
 
+Note: this example is an old workaround before adding support for defaults.
+Keeping it around as a valid test for advanced YAML syntax.
+
   $ cat >include.txt <<~~
   > ZKC2/2016
   > VEN/UF_1/2016

--- a/tests/functional/subsample/cram/config-defaults.t
+++ b/tests/functional/subsample/cram/config-defaults.t
@@ -1,0 +1,90 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Defaults are applied to all samples.
+
+  $ cat >config.yaml <<~~
+  > defaults:
+  >   min_date: 2016
+  > samples:
+  >   focal:
+  >     query: region == 'North America'
+  >   contextual:
+  >     query: region != 'North America'
+  > ~~
+
+  $ ${AUGUR} subsample \
+  >   --metadata "$TESTDIR"/../../filter/data/metadata.tsv \
+  >   --config config.yaml \
+  >   --output-metadata subsampled.tsv
+  Validating schema of 'config.yaml'...
+  [focal] 9 strains were dropped during filtering
+  [focal] 	8 were filtered out by the query: "region == 'North America'"
+  [focal] 	1 was dropped because it was earlier than 2016.0 or missing a date
+  [focal] 3 strains passed all filters
+  [contextual] 6 strains were dropped during filtering
+  [contextual] 	4 were filtered out by the query: "region != 'North America'"
+  [contextual] 	2 were dropped because they were earlier than 2016.0 or missing a date
+  [contextual] 6 strains passed all filters
+  3 strains were dropped during filtering
+  	12 were dropped by `--exclude-all`
+  \\t3 were added back because they were in .*sample_focal.* (re)
+  \\t6 were added back because they were in .*sample_contextual.* (re)
+  9 strains passed all filters
+
+Defaults can be overridden by samples.
+
+  $ cat >config.yaml <<~~
+  > defaults:
+  >   min_date: 2016
+  > samples:
+  >   focal:
+  >     query: region == 'North America'
+  >     min_date: 2016-05-01
+  >   contextual:
+  >     query: region != 'North America'
+  > ~~
+
+  $ ${AUGUR} subsample \
+  >   --metadata "$TESTDIR"/../../filter/data/metadata.tsv \
+  >   --config config.yaml \
+  >   --output-metadata subsampled.tsv
+  Validating schema of 'config.yaml'...
+  [focal] 11 strains were dropped during filtering
+  [focal] 	8 were filtered out by the query: "region == 'North America'"
+  [focal] 	3 were dropped because they were earlier than 2016.33 or missing a date
+  [focal] 1 strain passed all filters
+  [contextual] 6 strains were dropped during filtering
+  [contextual] 	4 were filtered out by the query: "region != 'North America'"
+  [contextual] 	2 were dropped because they were earlier than 2016.0 or missing a date
+  [contextual] 6 strains passed all filters
+  5 strains were dropped during filtering
+  	12 were dropped by `--exclude-all`
+  \\t1 was added back because it was in .*sample_focal.* (re)
+  \\t6 were added back because they were in .*sample_contextual.* (re)
+  7 strains passed all filters
+
+Some sample options are not supported under defaults.
+This is flagged during config validation.
+
+  $ cat >config.yaml <<~~
+  > defaults:
+  >   min_date: 2016
+  >   group_by: year
+  > samples:
+  >   focal:
+  >     query: region == 'North America'
+  >     min_date: 2016-05-01
+  >   contextual:
+  >     query: region != 'North America'
+  > ~~
+
+  $ ${AUGUR} subsample \
+  >   --metadata "$TESTDIR"/../../filter/data/metadata.tsv \
+  >   --config config.yaml \
+  >   --output-metadata subsampled.tsv
+  Validating schema of 'config.yaml'...
+    .defaults failed: Unexpected property 'group_by'
+  ERROR: Validation of 'config.yaml' failed.
+  [2]


### PR DESCRIPTION
## Description of proposed changes

This can help reduce duplication across samples.

I chose to only allow a subset of options to be set as default, specifically just the selection options (not subsampling). The primary reason is that there are two mutually exclusive options to configure sample size: sequences_per_group and max_sequences. While it's possible to handle cases where one is set in defaults and the other is set in a sample, I figured it's easier to simply not allow that, at least in the initial release.

## Related issue(s)

Closes #1887

## Checklist

- [x] Automated checks pass
- [x] ~[Check][1] if you need to add a changelog message~ N/A, `augur subsample` unreleased
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
