### PR TITLE
subsample: Add simple --output-log support

### DIFF
--- a/augur/subsample.py
+++ b/augur/subsample.py
@@ -59,6 +59,7 @@ These are sent to both intermediate and final augur filter calls.
 FINAL_CLI_OPTIONS: Dict[str, AugurFilterOption] = {
     "output_metadata": "--output-metadata",
     "output_sequences": "--output-sequences",
+    "output_log": "--output-log",
     "skip_checks": ("--skip-checks", None),
 }
 """
@@ -116,6 +117,7 @@ def register_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.A
     output_group = parser.add_argument_group("Output options", "options related to output files")
     output_group.add_argument("--output-metadata", metavar="FILE", help="output metadata file" + SKIP_AUTO_DEFAULT_IN_HELP)
     output_group.add_argument("--output-sequences", metavar="FILE", help="output sequences file" + SKIP_AUTO_DEFAULT_IN_HELP)
+    output_group.add_argument('--output-log', help="Tab-delimited file to debug sequence inclusion in samples. All sequences have a row with filter=filter_by_exclude_all. The sequences included in the output each have an additional row per sample that included it (there may be multiple). These rows have filter=force_include_strains with kwargs pointing to a temporary file that hints at the intermediate sample it came from." + SKIP_AUTO_DEFAULT_IN_HELP)
     return parser
 
 

--- a/docs/usage/cli/subsample.rst
+++ b/docs/usage/cli/subsample.rst
@@ -95,7 +95,6 @@ Implementation details
    Note that the following ``augur filter`` options are not supported:
 
    - ``--priority``
-   - ``--output-log``
    - ``--output-group-by-sizes``
    - ``--output-strains``
    - ``--empty-output-reporting``

--- a/tests/functional/subsample/cram/output-log.t
+++ b/tests/functional/subsample/cram/output-log.t
@@ -1,0 +1,60 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Test two overlapping samples with an output log.
+
+  $ cat >samples.yaml <<~~
+  > samples:
+  >   A:
+  >     max_sequences: 4
+  >   B:
+  >     max_sequences: 5
+  > ~~
+
+  $ ${AUGUR} subsample \
+  >   --metadata "$TESTDIR"/../../filter/data/metadata.tsv \
+  >   --sequences "$TESTDIR"/../../filter/data/sequences.fasta \
+  >   --config samples.yaml \
+  >   --output-metadata subsampled.tsv \
+  >   --output-sequences subsampled.fasta \
+  >   --output-log log.tsv \
+  >   --seed 0
+  Validating schema of 'samples.yaml'...
+  [A] 8 strains were dropped during filtering
+  [A] 	8 were dropped because of subsampling criteria
+  [A] 4 strains passed all filters
+  [B] 7 strains were dropped during filtering
+  [B] 	7 were dropped because of subsampling criteria
+  [B] 5 strains passed all filters
+  8 strains were dropped during filtering
+  	1 had no metadata
+  	12 were dropped by `--exclude-all`
+  \\t4 were added back because they were in .*sample_A.* (re)
+  \\t5 were added back because they were in .*sample_B.* (re)
+  5 strains passed all filters
+
+Show the output log.
+
+  $ tail -n +2 log.tsv | sort
+  BRA/2016/FC_6706	filter_by_exclude_all	[]
+  COL/FLR_00008/2015	filter_by_exclude_all	[]
+  COL/FLR_00024/2015	filter_by_exclude_all	[]
+  Colombia/2016/ZC204Se	filter_by_exclude_all	[]
+  DOM/2016/BB_0059	filter_by_exclude_all	[]
+  DOM/2016/BB_0059\\tforce_include_strains\\t"\[\[""include_file"", .*sample_A.* (re)
+  DOM/2016/BB_0059\\tforce_include_strains\\t"\[\[""include_file"", .*sample_B.* (re)
+  DOM/2016/BB_0183	filter_by_exclude_all	[]
+  DOM/2016/BB_0183\\tforce_include_strains\\t"\[\[""include_file"", .*sample_A.* (re)
+  DOM/2016/BB_0183\\tforce_include_strains\\t"\[\[""include_file"", .*sample_B.* (re)
+  EcEs062_16	filter_by_exclude_all	[]
+  HND/2016/HU_ME59	filter_by_exclude_all	[]
+  HND/2016/HU_ME59\\tforce_include_strains\\t"\[\[""include_file"", .*sample_B.* (re)
+  PRVABC59	filter_by_exclude_all	[]
+  SG_018	filter_by_exclude_all	[]
+  SG_018\\tforce_include_strains\\t"\[\[""include_file"", .*sample_A.* (re)
+  SG_018\\tforce_include_strains\\t"\[\[""include_file"", .*sample_B.* (re)
+  VEN/UF_1/2016	filter_by_exclude_all	[]
+  VEN/UF_1/2016\\tforce_include_strains\\t"\[\[""include_file"", .*sample_A.* (re)
+  VEN/UF_1/2016\\tforce_include_strains\\t"\[\[""include_file"", .*sample_B.* (re)
+  ZKC2/2016	filter_by_exclude_all	[]


### PR DESCRIPTION
## Description of proposed changes

This simple change adds an option to write the output log file of the final augur filter call as-is. It exposes implementation details, but could be useful for debugging.

## Related issue(s)

#1886

## Checklist

- [x] Automated checks pass
- [x] ~[Check][1] if you need to add a changelog message~ N/A, `augur subsample` unreleased
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
