### PR TITLE
[curate] warn for unnecessary annotations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## __NEXT__
 
+* `augur curate apply-record-annotations` will now warn if an annotation was unnecessary, often indicative of the upstream data being updated. [#1893][] (@jameshadfield)
+
+[#1893]: https://github.com/nextstrain/augur/pull/1893
 
 ## 31.5.0 (17 September 2025)
 

--- a/augur/curate/apply_record_annotations.py
+++ b/augur/curate/apply_record_annotations.py
@@ -45,12 +45,13 @@ def run(args, records):
         if record_id is None:
             raise AugurError(f"ID field {args.id_field!r} does not exist in record")
 
-        record_annotations = annotations.get(record_id, {})
-        for field in list(record_annotations.keys()):
+        for field, new_value in annotations.get(record_id, {}).items():
             if field not in record:
                 print_err(f"WARNING: Skipping annotation for field {field!r} that does not exist in record")
-                del record_annotations[field]
-
-        record.update(record_annotations)
+                continue
+            if record[field] == new_value:
+                print_err(f"WARNING: Unnecessary annotation for {record_id!r} field {field!r}: value was already {new_value!r}")
+                continue
+            record[field] = new_value
 
         yield record

--- a/tests/functional/curate/cram/apply-record-annotations/unnecessary-annotation-warnings.t
+++ b/tests/functional/curate/cram/apply-record-annotations/unnecessary-annotation-warnings.t
@@ -1,0 +1,19 @@
+Setup
+
+  $ export AUGUR="${AUGUR:-$TESTDIR/../../../../../bin/augur}"
+
+Using unnecessary annotations results in warning messages.
+Valid annotations are still applied.
+
+  $ cat >annotations.tsv <<~~
+  > record_1	field_1	annotation_1
+  > record_1	field_2	annotation_2
+  > record_1	field_3	annotation_3
+  > ~~
+
+  $ echo '{"accession": "record_1", "field_1": "annotation_1", "field_2": "annotation_2", "field_3": "value_3"}' \
+  >   |  ${AUGUR} curate apply-record-annotations \
+  >       --annotations annotations.tsv
+  WARNING: Unnecessary annotation for 'record_1' field 'field_1': value was already 'annotation_1'
+  WARNING: Unnecessary annotation for 'record_1' field 'field_2': value was already 'annotation_2'
+  {"accession": "record_1", "field_1": "annotation_1", "field_2": "annotation_2", "field_3": "annotation_3"}


### PR DESCRIPTION
It's useful to know when our manual annotations are unnecessary. This can happen when our fixes make it to the upstream source, e.g. PPX.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update
