### PR TITLE
Update formatting of pathogen-repo-ci-v0 matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,16 +263,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - { pathogen: avian-flu, build-args: --snakefile segment-focused/Snakefile -pf test_target }
-          - {
-              pathogen: ncov,
-              build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci,
-            }
+          - { pathogen: avian-flu,       build-args: --snakefile segment-focused/Snakefile -pf test_target }
+          - { pathogen: ncov,            build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci }
           - { pathogen: rsv,             build-args: --configfile config/ci.yaml }
-          - {
-              pathogen: seasonal-flu,
-              build-args: --configfile profiles/ci/builds.yaml -p,
-            }
+          - { pathogen: seasonal-flu,    build-args: --configfile profiles/ci/builds.yaml -p }
           - { pathogen: tb }
 
     name: pathogen-repo-ci-v0 (${{ matrix.pathogen }})


### PR DESCRIPTION
## Description of proposed changes

Previous formatting had no consistency within itself and compared to copies of the same matrix in [conda-base](https://github.com/nextstrain/conda-base/blob/ba0bd36e2f6e40f78f8cc8c2698af8eec3e7edeb/.github/workflows/ci.yaml#L146-L149) and [docker-base](https://github.com/nextstrain/docker-base/blob/06c736637bf21533306565e2b3eed8021ca5a494/.github/workflows/ci.yml#L217-L220).

Update to match the formatting used by the other copies.

## Related issue(s)

Follow-up to #1898

## Checklist

- [ ] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
