### PR TITLE
translate: Error when translating sequence lengths indivisible by 3

### DIFF
--- a/augur/translate.py
+++ b/augur/translate.py
@@ -51,25 +51,25 @@ def safe_translate(sequence):
     >>> safe_translate("")
     ''
     >>> safe_translate("ATGT")
-    'MX'
+    Traceback (most recent call last):
+    ...
+    ValueError: Sequence length 4 is not divisible by 3.
     """
     from Bio.Data.CodonTable import TranslationError
     from Bio.Seq import CodonTable
 
-    #sequences not mod 3 give messy BiopythonWarning, so avoid by padding.
     if len(sequence)%3:
-        sequence_padded = sequence + "N"*(3-len(sequence)%3)
-    else:
-        sequence_padded = sequence
+        raise ValueError(f"Sequence length {len(sequence)} is not divisible by 3.")
+
     try:
         # Attempt translation by extracting the sequence according to the
         # BioPhython SeqFeature in frame gaps of three will translate as '-'
-        translated_sequence = str(Seq.Seq(sequence_padded).translate(gap='-'))
+        translated_sequence = str(Seq.Seq(sequence).translate(gap='-'))
     except TranslationError:
         # Any other codon like '-AA' or 'NNT' etc will fail. Translate codons
         # one by one.
         codon_table  = CodonTable.ambiguous_dna_by_name['Standard'].forward_table
-        str_seq = str(sequence_padded)
+        str_seq = str(sequence)
         codons = np.frombuffer(str_seq[:len(str_seq) - len(str_seq) % 3].encode(), dtype='S3').astype("U")
         assert len(codons) > 0
         aas = []

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -4,6 +4,7 @@ Unit tests for nucleotide to acid translation
 from pathlib import Path
 import sys
 
+import pytest
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 
@@ -23,13 +24,28 @@ class TestTranslate:
                            (('ATG---',), 'M-'),
                            (('ATGTAG',), 'M*'),
                            (('',), ''),
-                           (('ATGT',), 'MX'),
                            (('ATGA-G',), 'MX')]
 
         # input each pair into the function and check
         for pair in params_and_outs:
             params, out = pair
             assert translate.safe_translate(*params) == out
+
+    def test_safe_translate_errors(self):
+        '''
+        Test that safe_translate raises ValueError when sequence length is not divisible by 3
+        '''
+        invalid_sequences = [
+            'A',
+            'AT',
+            'ATGT',
+            'ATGTA',
+            'ATGTAGA',
+        ]
+
+        for seq in invalid_sequences:
+            with pytest.raises(ValueError, match="not divisible by 3"):
+                translate.safe_translate(seq)
 
     def test_translate_feature(self):
         '''


### PR DESCRIPTION
> [!NOTE]
> Based on #1901

## Description of proposed changes

… instead of silently padding with N to translate to 'X', which became an unused code path after "Error when reference gene length is indivisible by 3" (0cdcaa8). Any usage of it now would be due to an internal error – a sequence with 1 or 2 extra bases indicates a problem with the input where translating to 'X' would wrongly imply 3 bases.

## Related issue(s)

Follow-up to https://github.com/nextstrain/augur/pull/1901#discussion_r2412126146

## Checklist

- [x] Automated checks pass (docs failure is unrelated)
- [x] [Check][1] if you need to add a changelog message (covered by base PR)
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
