### PR TITLE
docs: Fix typing.Union warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,9 @@ intersphinx_mapping = {
     'Bio': ('https://biopython.org/docs/latest/', None),
     'docs.nextstrain.org': ('https://docs.nextstrain.org/en/latest/', None),
     'cli': ('https://docs.nextstrain.org/projects/cli/en/stable', None),
-    'python': ('https://docs.python.org/3', None),
+    # Use Python 3.13 to prevent typing.Union warnings
+    # <https://github.com/nextstrain/augur/issues/1903>
+    'python': ('https://docs.python.org/3.13', None),
     'numpy': ('https://numpy.org/doc/stable', None),
     'pandas': ('https://pandas.pydata.org/docs', None),
     'treetime': ('https://treetime.readthedocs.io/en/stable/', None),


### PR DESCRIPTION
## Description of proposed changes

Fix the warning by pinning the `intersphinx_mapping` for Python to 3.13. I did  not dig into why the Python 3.14 changes for typing causes the warning.¹

I had tried to pin to 3.9 which is our minimal supported Python version, but  that led to other warnings:

```
/Users/joverlee/Repos/nextstrain/augur/augur/io/shell_command_runner.py:docstring of augur.io.shell_command_runner.ShellCommandRunner.signal_from_error:1: WARNING: py:class reference target not found: signal.Signals [ref.class]
/Users/joverlee/Repos/nextstrain/augur/augur/types.py:docstring of augur.types.ArgparseEnum:4: WARNING: py:class reference target not found: enum.StrEnum [ref.class]
```

¹ <https://docs.python.org/3.14/whatsnew/3.14.html#typing>

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/1903

## Checklist

- [x] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
