### PR TITLE
CI: Change `tb` to `vcf-input-tutorial`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,7 +273,7 @@ jobs:
               pathogen: seasonal-flu,
               build-args: --configfile profiles/ci/builds.yaml -p,
             }
-          - { pathogen: tb }
+          - { pathogen: vcf-input-tutorial }
 
     name: pathogen-repo-ci-v0 (${{ matrix.pathogen }})
     defaults:


### PR DESCRIPTION
## Description of proposed changes

The [vcf-input-tutorial repo](https://github.com/nextstrain/vcf-input-tutorial) now has the original tb workflow where the tb CI originally ran. The tb repo will soon be updated to an analysis that we don't currently plan to run with CI.

## Related issue(s)

https://github.com/nextstrain/tb/issues/15

## Checklist

- [ ] Automated checks pass
- [ ] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
