### PR TITLE
Consider XXXX-XX-XX as missing date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,14 @@
 
 ### Bug fixes
 
+* filter, frequencies, subsample: A date value of `XXXX-XX-XX` is now treated the same as no value (empty string). [#1894][] @victorlin
 * filter, merge: Fixed formatting of the error message shown when there are duplicate sequence ids. [#1954][] @victorlin
 * filter: Adjusted the error message shown when there are missing weights to mention the option of updating values in metadata. [#1956][] @victorlin
 * frequencies: Added a proper error message for missing or invalid dates. [#1960][] @victorlin
 * merge: Added a workaround for a bug in SQLite version 3.52.0. [#1969][] @victorlin
 * merge: Improved error messages from SQLite. [#1969][] @victorlin
 
+[#1894]: https://github.com/nextstrain/augur/issues/1894
 [#1954]: https://github.com/nextstrain/augur/pull/1954
 [#1956]: https://github.com/nextstrain/augur/pull/1956
 [#1960]: https://github.com/nextstrain/augur/issues/1960

--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -192,6 +192,12 @@ Matches an Augur-style ambiguous date with 'XX' used to mask unknown parts of th
 Note that this can support any date format, not just YYYY-MM-DD.
 """
 
+RE_AUGUR_MISSING_DATE = re.compile(r'^XXXX-XX-XX$')
+"""
+Matches an Augur-style ambiguous date with all parts masked.
+This only supports YYYY-MM-DD format.
+"""
+
 RE_DATE_RANGE = re.compile(r'^\d{4}-\d{2}-\d{2}/\d{4}-\d{2}-\d{2}$')
 """
 Matches a date range in YYYY-MM-DD/YYYY-MM-DD format.
@@ -201,6 +207,10 @@ Note that this is a subset of the ISO 8601 time interval format.
 @cache
 def get_numerical_date_from_value(value, fmt, min_max_year=None) -> Union[float, Tuple[float, float], None]:
     value = str(value)
+
+    # Check if value is a missing date.
+    if RE_AUGUR_MISSING_DATE.match(value):
+        return None
 
     # Check if value is an exact date in the specified format (fmt).
     try:

--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -202,23 +202,22 @@ Note that this is a subset of the ISO 8601 time interval format.
 def get_numerical_date_from_value(value, fmt, min_max_year=None) -> Union[float, Tuple[float, float], None]:
     value = str(value)
 
-    # 1. Check if value is an exact date in the specified format (fmt).
-
+    # Check if value is an exact date in the specified format (fmt).
     try:
         return date_to_numeric(datetime.datetime.strptime(value, fmt))
     except:
         pass
     
-    # 2. Check if value is an ambiguous date in the specified format (fmt).
-
+    # Check if value is an ambiguous date in the specified format (fmt).
     if RE_AUGUR_AMBIGUOUS_DATE.match(value):
         start, end = AmbiguousDate(value, fmt=fmt).range(min_max_year=min_max_year)
         return (date_to_numeric(start), date_to_numeric(end))
 
-    # 3. Check formats that are always supported.
-
+    # Check if value is a numeric date.
     if RE_NUMERIC_DATE.match(value):
         return float(value)
+
+    # Check if value is an ISO 8601-like date.
 
     if RE_YEAR_ONLY.match(value):
         start, end = AmbiguousDate(f"{value}-XX-XX", fmt="%Y-%m-%d").range(min_max_year=min_max_year)
@@ -237,6 +236,8 @@ def get_numerical_date_from_value(value, fmt, min_max_year=None) -> Union[float,
             # closest in-bound value.
             raise InvalidDate(value, str(error)) from error
 
+    # Check if value is a date range.
+
     if RE_DATE_RANGE.match(value):
         start, end = value.split("/")
         
@@ -248,7 +249,7 @@ def get_numerical_date_from_value(value, fmt, min_max_year=None) -> Union[float,
 
         return (date_to_numeric(start), date_to_numeric(end))
 
-    # 4. Return none (silent error) if the date does not match any of the checked formats.
+    # Return none (silent error) if the date does not match any of the checked formats.
 
     return None
 

--- a/tests/functional/filter/cram/filter-missing-date.t
+++ b/tests/functional/filter/cram/filter-missing-date.t
@@ -1,0 +1,31 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Create metadata TSV file with two date values that should be functionally equivalent.
+
+  $ cat >metadata.tsv <<~~
+  > strain	date
+  > SEQ_1	
+  > SEQ_2	XXXX-XX-XX
+  > ~~
+
+BUG: SEQ_2 passes for --min-date and --max-date.
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --min-date 2025 \
+  >  --output-strains filtered_strains.txt
+  2 strains were dropped during filtering
+  	2 were dropped because they were earlier than 2025.0 or missing a date
+  ERROR: All samples have been dropped! Check filter rules and metadata file format.
+  [2]
+
+  $ ${AUGUR} filter \
+  >  --metadata metadata.tsv \
+  >  --max-date 2025 \
+  >  --output-strains filtered_strains.txt
+  2 strains were dropped during filtering
+  	2 were dropped because they were later than 2025.0 or missing a date
+  ERROR: All samples have been dropped! Check filter rules and metadata file format.
+  [2]

--- a/tests/functional/frequencies/cram/missing-date.t
+++ b/tests/functional/frequencies/cram/missing-date.t
@@ -31,6 +31,7 @@ Error on missing dates.
   ERROR: The following sequence ids are missing valid dates:
   
     'COL/FLR_00008/2015' has date 'invalid'
+    'Colombia/2016/ZC204Se' has date 'XXXX-XX-XX'
     'PAN/CDC_259359_V1_V3/2015' has date ''
     'PRVABC59' has date 'NA'
   


### PR DESCRIPTION
## Description of proposed changes

Previously, this was considered an ambiguous date with a range of '[0001-01-01, present]'. That may be somewhat correct, but it has the side effect of passing min/max date filters. Other missing dates such as empty string are dropped by those date filters, and it seems more reasonable to consider XXXX-XX-XX the same way.

## Related issue(s)

Closes #1894

## Checklist

- [x] Automated checks pass ([blocked](https://github.com/nextstrain/augur/pull/1913#discussion_r2453394839))
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update
