### PR TITLE
CI: Replace broken URL with last Internet Archive capture

### DIFF
--- a/augur/curate/normalize_strings.py
+++ b/augur/curate/normalize_strings.py
@@ -2,7 +2,7 @@
 Normalize strings to a Unicode normalization form and strip leading and trailing whitespaces.
 
 Strings need to be normalized for predictable string comparisons, especially
-in cases where strings contain diacritics (see https://unicode.org/faq/normalization.html).
+in cases where strings contain diacritics (see https://web.archive.org/web/20250922031915/https://unicode.org/faq/normalization.html).
 """
 import unicodedata
 


### PR DESCRIPTION
## Description of proposed changes

The URL currently redirects to itself in an endless loop. I couldn't find another web page that has similar content, so I've replaced it with an Internet Archive capture from September.

## Related issue(s)

Closes #1932

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
