### PR TITLE
refine: Add option to ignore clock filter for certain ids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,14 @@
 ### Features
 
 * filter, frequencies, refine: Added support in metadata for precise date ranges in `YYYY-MM-DD/YYYY-MM-DD` format. [#1304][] (@victorlin)
+* refine: Added a new option `--keep-ids` to keep certain tips in the tree regardless of clock filtering. This allows force-inclusion similar to `augur filter`'s `--include` option, and the same file can be used for both. [#1768][] (@victorlin)
 
 ### Bug fixes
 
 * export v2: Improved the error message that is displayed when a deprecated coloring key is used. [#1882][] (@corneliusroemer)
 
 [#1304]: https://github.com/nextstrain/augur/issues/1304
+[#1768]: https://github.com/nextstrain/augur/issues/1768
 [#1882]: https://github.com/nextstrain/augur/issues/1882
 
 ## 32.1.0 (18 November 2025)

--- a/tests/functional/refine/cram/keep-ids.t
+++ b/tests/functional/refine/cram/keep-ids.t
@@ -1,0 +1,38 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+'KX369547.1' is removed with --clock-filter-iqd 2.
+
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" \
+  >  --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
+  >  --output-tree tree.nwk \
+  >  --timetree \
+  >  --clock-filter-iqd 2 \
+  >  --seed 314159 2>&1 | grep "pruning leaf" || echo "Nothing pruned"
+  pruning leaf  KX369547.1
+
+  $ grep -q -F 'KX369547.1' tree.nwk && echo 'Present' || echo 'Pruned'
+  Pruned
+
+Use --keep-ids to force-include it.
+
+  $ cat > include.txt <<~~
+  > KX369547.1  # Keep me
+  > ~~
+
+  $ ${AUGUR} refine \
+  >  --tree "$TESTDIR/../data/tree_raw.nwk" \
+  >  --alignment "$TESTDIR/../data/aligned.fasta" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
+  >  --output-tree tree.nwk \
+  >  --timetree \
+  >  --clock-filter-iqd 2 \
+  >  --keep-ids include.txt \
+  >  --seed 314159 2>&1 | grep "pruning leaf" || echo "Nothing pruned"
+  Nothing pruned
+
+  $ grep -q -F 'KX369547.1' tree.nwk && echo 'Present' || echo 'Pruned'
+  Present


### PR DESCRIPTION
## Description of proposed changes

Previously, the only way to keep such ids was to change the clock filter, which is not always desirable.

## Related issue(s)

Closes #1768

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update
