### PR TITLE
CI: Simplify testing matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,9 +92,9 @@ jobs:
     - run: conda info
     - run: conda list
 
-    # Set coverage environment variables only for the coverage job
+    # Run with coverage on the earliest supported Python version
     - name: Set coverage environment variables
-      if: matrix.python-version == '3.11' && matrix.biopython-version == ''
+      if: matrix.python-version == '3.9'
       run: |
         echo "COVERAGE_FILE=${{ github.workspace }}/.coverage@python=${{ matrix.python-version }},biopython=${{ matrix.biopython-version || 'latest' }}" >> "$GITHUB_ENV"
         echo "COVERAGE_RCFILE=${{ github.workspace }}/.coveragerc" >> "$GITHUB_ENV"


### PR DESCRIPTION
With the introduction of numpy-version into the matrix¹, it became less clear what to do when adding or removing a Python version.

Instead of taking the cross product of (Python versions) x (Biopython versions) with some exclusions, test each Python version with the first Biopython version that supports it plus an extra combination to cover the latest Biopython version. This provides a wide range of coverage with a small amount of jobs.

The same goes for Numpy. The combination of (early Numpy) + (latest Biopython) is retained from the previous matrix.

The removed combinations are of earlier Python versions with later Biopython versions. Those only provided the ability to detect Biopython issues (either bugs or incompatibilities that should have been declared in python_requires), not Augur bugs. I don't recall seeing such detections over the last 4 years, so it should be fine to remove.

The result is a reduction from 18 to 7 jobs, less additional jobs when adding a new Python version, and simplified process when adding/removing Python versions.

¹ "feat: support numpy v2, add 2 test matrix entries to continue numpy v1 testing" (625d7885)

## Checklist

- [x] Automated checks pass
- [x] ~[Check][1] if you need to add a changelog message~ N/A, dev change
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
