### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,6 @@ jobs:
           # of Biopython¹ and Numpy²
           # ¹ <https://github.com/biopython/biopython/blob/master/NEWS.rst>
           # ² <https://numpy.org/doc/stable/release>
-          - { conda-args: 'python=3.9',  pip-args: 'biopython==1.80 numpy==1.19.4' }  # Biopython 1.79 is the first to support Python 3.9, but Augur requires >=1.80
           - { conda-args: 'python=3.10', pip-args: 'biopython==1.80 numpy==1.21.3' }
           - { conda-args: 'python=3.11', pip-args: 'biopython==1.80 numpy==1.23.4' }  # numpy 1.23.2-3 did not declare support in conda
           - { conda-args: 'python=3.12', pip-args: 'biopython==1.82 numpy==1.26.0' }
@@ -90,7 +89,7 @@ jobs:
     # ¹ <https://github.com/nextstrain/augur/pull/968>
     # ² <https://github.com/nextstrain/augur/pull/1861>
     - name: Set coverage environment variables
-      if: contains(matrix.conda-args, 'python=3.9')
+      if: contains(matrix.conda-args, 'python=3.10')
       run: |
         coverage_id="$(printf '%s' "${{ matrix.conda-args }}|${{ matrix.pip-args }}" | sha256sum | cut -d' ' -f1)"
         echo "COVERAGE_FILE=${{ github.workspace }}/.coverage@${coverage_id}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,16 +23,16 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v6
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
     - run: pip install .[dev]
     - run: mypy
 
   pyright:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v6
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
     - run: npx pyright --stats
 
   pytest-cram:
@@ -367,12 +367,12 @@ jobs:
   check-docs:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/setup-python@v6
         with:
           # This should match the python version in .readthedocs.yml
           python-version: '3.11'
-
-      - uses: actions/checkout@v6
 
       - run: pip install .[dev]
 
@@ -391,9 +391,9 @@ jobs:
   check-subsample-config-schema:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v6
-
       - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
 
       - run: pip install .[dev]
 

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,3 @@
+# Intended for use with actions/setup-python
+# Target the earliest supported Python version
+3.10

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Major Changes
 
+* Dropped support for Python 3.9. [#1938][] (@victorlin)
 * `augur.utils.write_json` is deprecated and will be removed in a future major version. Users should use `augur.io.write_json` instead. [#1943][] (@victorlin)
 
 ### Features
@@ -21,6 +22,7 @@
 [#1304]: https://github.com/nextstrain/augur/issues/1304
 [#1768]: https://github.com/nextstrain/augur/issues/1768
 [#1882]: https://github.com/nextstrain/augur/issues/1882
+[#1938]: https://github.com/nextstrain/augur/pull/1938
 [#1943]: https://github.com/nextstrain/augur/pull/1943
 [#1948]: https://github.com/nextstrain/augur/pull/1948
 

--- a/augur/data/__init__.py
+++ b/augur/data/__init__.py
@@ -11,7 +11,7 @@ Resource files.
 # backwards compatible with importers only providing the original path() /
 # ResourceReader API.  The PyPI backport, on the other hand, contains the full
 # adapter since 5.3.0, which we declare as our minimum version in setup.py, so
-# we use that even on 3.9 and 3.10.
+# we use that even on 3.10.
 #
 # We're using the new API at all because the original one is being deprecated
 # and we want to avoid warnings both from the stdlib implementation on 3.11 and

--- a/augur/filter/weights_file.py
+++ b/augur/filter/weights_file.py
@@ -57,7 +57,7 @@ def get_default_weight(weights: pd.DataFrame, weighted_columns: List[str]) -> Op
     # 2. Multiple default rows specified in the weights file.
     #    This is a user error.
     mask = (
-        weights[weighted_columns].eq(COLUMN_VALUE_FOR_DEFAULT_WEIGHT).all(axis=1) &
+        weights[weighted_columns].eq(COLUMN_VALUE_FOR_DEFAULT_WEIGHT).all(axis=1) &  # type: ignore[arg-type]
         weights[weighted_columns].notna().all(axis=1)
     )
     default_weight_values = weights.loc[mask, WEIGHTS_COLUMN].unique()  # type: ignore[operator]

--- a/augur/filter/weights_file.py
+++ b/augur/filter/weights_file.py
@@ -1,6 +1,5 @@
 from typing import List, Optional
 
-import numpy as np
 import pandas as pd
 
 from textwrap import dedent
@@ -50,7 +49,7 @@ def get_weighted_columns(weights_file):
     return columns
 
 
-def get_default_weight(weights: pd.DataFrame, weighted_columns: List[str]) -> Optional[np.number]:
+def get_default_weight(weights: pd.DataFrame, weighted_columns: List[str]) -> Optional[float]:
     # Match weighted columns with 'default' value. Multiple values can be matched for 2 reasons:
     # 1. Repeated rows following additional permutation with unweighted columns.
     #    This is handled by unique() since the value should be the same.

--- a/docs/contribute/DEV_DOCS.md
+++ b/docs/contribute/DEV_DOCS.md
@@ -17,7 +17,7 @@ Please see the [open issues list](https://github.com/nextstrain/augur/issues) fo
 
 ## Contributing code
 
-We currently target compatibility with Python 3.9 and higher. As Python releases new versions,
+We currently target compatibility with Python 3.10 and higher. As Python releases new versions,
 the minimum target compatibility may be increased in the future.
 
 ### Running local changes

--- a/docs/installation/installation.rst
+++ b/docs/installation/installation.rst
@@ -45,7 +45,7 @@ There are several ways to install Augur, ordered from least to most complex.
       .. warning::
          Installing other Python packages after Augur may cause dependency incompatibilities. If this happens, re-install Augur using the command in step 1.
 
-      Augur is written in Python 3 and requires at least Python 3.9. It's published on `PyPI <https://pypi.org>`__ as `nextstrain-augur <https://pypi.org/project/nextstrain-augur>`__.
+      Augur is written in Python 3 and requires at least Python 3.10. It's published on `PyPI <https://pypi.org>`__ as `nextstrain-augur <https://pypi.org/project/nextstrain-augur>`__.
 
       1. Install Augur along with Python dependencies.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 # Check against lowest compatible Python version
-python_version = 3.9
+python_version = 3.10
 
 # Don't set python_version. Instead, use the default behavior of checking for
 # compatibility against the version of Python used to run mypy.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,7 +1,7 @@
 {
   // Check against lowest compatible Python version
   // Sync this with python-version in .github/workflows/ci.yaml:jobs.pyright
-  "pythonVersion": "3.9",
+  "pythonVersion": "3.10",
 
   "include": ["augur/"],
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from pathlib    import Path
 import setuptools
 import sys
 
-py_min_version = (3, 9)  # minimal supported python version
-since_augur_version = (27, 0)  # py_min_version is required since this augur version
+py_min_version = (3, 10)  # minimal supported python version
+since_augur_version = (33, 0)  # py_min_version is required since this augur version
 
 if sys.version_info < py_min_version:
     error = """
@@ -108,7 +108,6 @@ setuptools.setup(
 
         # Python 3 only
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Python 3.9 reached end of life on 2025-10-31.

Assumes this will be released with Augur 33.0.0.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
