### PR TITLE
Move auto-minify logic into write_json()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,12 @@
 ### Bug fixes
 
 * export v2: Improved the error message that is displayed when a deprecated coloring key is used. [#1882][] (@corneliusroemer)
+* export v2: `--no-minify-json` now properly overrides any truthy value in `AUGUR_MINIFY_JSON`. [#1943][] (@victorlin)
 
 [#1304]: https://github.com/nextstrain/augur/issues/1304
 [#1768]: https://github.com/nextstrain/augur/issues/1768
 [#1882]: https://github.com/nextstrain/augur/issues/1882
+[#1943]: https://github.com/nextstrain/augur/pull/1943
 
 ## 32.1.0 (18 November 2025)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,15 @@
 
 ## __NEXT__
 
+### Major Changes
+
+* `augur.utils.write_json` is deprecated and will be removed in a future major version. Users should use `augur.io.write_json` instead. [#1943][] (@victorlin)
+
 ### Features
 
 * filter, frequencies, refine: Added support in metadata for precise date ranges in `YYYY-MM-DD/YYYY-MM-DD` format. [#1304][] (@victorlin)
 * refine: Added a new option `--keep-ids` to keep certain tips in the tree regardless of clock filtering. This allows force-inclusion similar to `augur filter`'s `--include` option, and the same file can be used for both. [#1768][] (@victorlin)
+* `augur.io.write_json` is a new function serving as a replacement for `augur.utils.write_json`. Output minification is controlled by two new parameters `minify` and `minify_threshold_mb`. [#1943][] (@victorlin)
 
 ### Bug fixes
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -49,6 +49,16 @@ to formalize Augur's Python API.
 We recognize the existing usage of this function, so it has been moved to
 `augur.io.read_strains`.
 
+## `augur.utils.write_json`
+
+*Deprecated in version 33.0.0 (January 2026). Planned for removal July 2026 or after.*
+
+This is part of a [larger effort](https://github.com/nextstrain/augur/issues/1011)
+to formalize Augur's Python API.
+
+We recognize the existing usage of this function, so it has been moved to
+`augur.io.write_json`.
+
 ## `augur export v1`
 
 *Deprecated in version 22.2.0 (July 2023). Planned for [removal](https://github.com/nextstrain/augur/issues/1266)

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -29,7 +29,7 @@ import numpy as np
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from .utils import parse_genes_argument, read_tree, InvalidTreeError, write_json, get_json_name, \
+from .utils import parse_genes_argument, read_tree, InvalidTreeError, write_augur_json, get_json_name, \
     genome_features_to_auspice_annotation
 from .io.file import open_file
 from .io.sequences import read_single_sequence, is_vcf as is_filename_vcf
@@ -482,7 +482,7 @@ def run(args):
     # use NodeDataObject to perform validation on the file before it's written
     NodeDataObject(anc_seqs, out_name, args.validation_mode)
 
-    write_json(anc_seqs, out_name)
+    write_augur_json(anc_seqs, out_name)
     print("ancestral mutations written to", out_name, file=sys.stdout)
 
     if args.output_sequences:

--- a/augur/clades.py
+++ b/augur/clades.py
@@ -22,7 +22,7 @@ from .argparse_ import ExtendOverwriteDefault
 from .errors import AugurError
 from .io.file import PANDAS_READ_CSV_OPTIONS
 from argparse import SUPPRESS
-from .utils import get_parent_name_by_child_name_for_tree, read_node_data, write_json, get_json_name
+from .utils import get_parent_name_by_child_name_for_tree, read_node_data, write_augur_json, get_json_name
 from .argparse_ import add_validation_arguments
 
 UNASSIGNED = 'unassigned'
@@ -383,5 +383,5 @@ def run(args):
         print(f"Clade labels stored on branches → <node_name> → labels → {label_key}", file=sys.stdout)
 
     out_name = get_json_name(args)
-    write_json(node_data_json, out_name)
+    write_augur_json(node_data_json, out_name)
     print(f"Clades written to {out_name}", file=sys.stdout)

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -189,7 +189,7 @@ from .argparse_ import ExtendOverwriteDefault
 from .frequency_estimators import timestamp_to_float
 from .io.file import open_file
 from .reconstruct_sequences import load_alignments
-from .utils import annotate_parents_for_tree, first_line, read_node_data, write_json
+from .utils import annotate_parents_for_tree, first_line, read_node_data, write_augur_json
 
 
 def read_distance_map(map_file):
@@ -785,4 +785,4 @@ def run(args):
     }
 
     # Export distances to JSON.
-    write_json({"params": params, "nodes": final_distances_by_node}, args.output)
+    write_augur_json({"params": params, "nodes": final_distances_by_node}, args.output)

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -11,9 +11,10 @@ from argparse import SUPPRESS
 from collections import defaultdict
 from .argparse_ import ExtendOverwriteDefault
 from .errors import AugurError
+from .io.json import write_json
 from .io.metadata import DEFAULT_DELIMITERS, InvalidDelimiter, read_metadata
 from .io.sequences import read_sequences, read_single_sequence
-from .utils import read_node_data, write_json, read_lat_longs, read_colors
+from .utils import read_node_data, read_lat_longs, read_colors
 from .util_support.auspice_config import read_json as read_config
 
 def convert_tree_to_json_structure(node, metadata, div=0, strains=None):

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -368,7 +368,7 @@ def run(args):
         else:
             root_sequence = {}
 
-        write_json(root_sequence, args.output_sequence, include_version=False)
+        write_json(root_sequence, args.output_sequence)
 
     meta_json = read_config(args.auspice_config)
     ensure_config_is_v1(meta_json)
@@ -401,7 +401,7 @@ def run(args):
         tree_decorations.append({"key": trait, "is_attr": True})
 
     recursively_decorate_tree_json_v1_schema(tree_json, nodes, decorations=tree_decorations)
-    write_json(tree_json, args.output_tree, indent=json_indent, include_version=False)
+    write_json(tree_json, args.output_tree, indent=json_indent)
 
     # Export the metadata JSON
     lat_long_mapping = read_lat_longs(args.lat_longs)
@@ -420,5 +420,5 @@ def run(args):
         meta_json["annotations"] = annotations
     meta_json["panels"] = process_panels(None, meta_json)
 
-    write_json(meta_json, args.output_meta, indent=json_indent, include_version=False)
+    write_json(meta_json, args.output_meta, indent=json_indent)
     return 0

--- a/augur/export_v1.py
+++ b/augur/export_v1.py
@@ -352,11 +352,6 @@ def run(args):
     node_data = read_node_data(args.node_data) # args.node_data is an array of multiple files (or a single file)
     nodes = node_data["nodes"] # this is the per-node metadata produced by various augur modules
 
-    if args.minify_json:
-        json_indent = None
-    else:
-        json_indent = 2
-
     # export reference sequence data including translations. This is either the
     # inferred sequence of the root, or the reference sequence with respect to
     # which mutations are made on the tree (including possible mutations leading
@@ -368,7 +363,7 @@ def run(args):
         else:
             root_sequence = {}
 
-        write_json(root_sequence, args.output_sequence)
+        write_json(root_sequence, args.output_sequence, minify=args.minify_json)
 
     meta_json = read_config(args.auspice_config)
     ensure_config_is_v1(meta_json)
@@ -401,7 +396,7 @@ def run(args):
         tree_decorations.append({"key": trait, "is_attr": True})
 
     recursively_decorate_tree_json_v1_schema(tree_json, nodes, decorations=tree_decorations)
-    write_json(tree_json, args.output_tree, indent=json_indent)
+    write_json(tree_json, args.output_tree, minify=args.minify_json)
 
     # Export the metadata JSON
     lat_long_mapping = read_lat_longs(args.lat_longs)
@@ -420,5 +415,5 @@ def run(args):
         meta_json["annotations"] = annotations
     meta_json["panels"] = process_panels(None, meta_json)
 
-    write_json(meta_json, args.output_meta, indent=json_indent)
+    write_json(meta_json, args.output_meta, minify=args.minify_json)
     return 0

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -1262,10 +1262,10 @@ def run(args):
                 # "auspice/zika_root-sequence.json".
                 output_path = Path(args.output)
                 root_sequence_path = output_path.parent / Path(output_path.stem + "_root-sequence" + output_path.suffix)
-                write_json(data=node_data['reference'], file=root_sequence_path, include_version=False, **indent)
+                write_json(data=node_data['reference'], file=root_sequence_path, **indent)
         else:
             raise AugurError("Root sequence output was requested, but the node data provided is missing a 'reference' key.")
-    write_json(data=orderKeys(data_json), file=args.output, include_version=False, **indent)
+    write_json(data=orderKeys(data_json), file=args.output, **indent)
 
     # validate outputs
     validate_data_json(args.output, args.validation_mode)

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -16,9 +16,10 @@ from urllib.parse import urlparse
 from .argparse_ import SKIP_AUTO_DEFAULT_IN_HELP, ExtendOverwriteDefault, add_validation_arguments
 from .errors import AugurError
 from .io.file import open_file
+from .io.json import MINIFY_THRESHOLD_MB, write_json
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
 from .types import ValidationMode
-from .utils import read_node_data, write_json, read_lat_longs, read_colors, MINIFY_THRESHOLD_MB
+from .utils import read_node_data, read_lat_longs, read_colors
 from .util_support.warnings import configure_warnings, warn, deprecated, deprecationWarningsEmitted
 from .util_support.auspice_config import read_auspice_configs, remove_unused_metadata_columns, update_deprecated_names
 from .validate import export_v2 as validate_v2, ValidateError, validation_failure

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -18,13 +18,11 @@ from .errors import AugurError
 from .io.file import open_file
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
 from .types import ValidationMode
-from .utils import read_node_data, write_json, json_size, read_lat_longs, read_colors
+from .utils import read_node_data, write_json, read_lat_longs, read_colors, MINIFY_THRESHOLD_MB
 from .util_support.warnings import configure_warnings, warn, deprecated, deprecationWarningsEmitted
 from .util_support.auspice_config import read_auspice_configs, remove_unused_metadata_columns, update_deprecated_names
 from .validate import export_v2 as validate_v2, ValidateError, validation_failure
 from .version import __version__
-
-MINIFY_THRESHOLD_MB = 5
 
 # Invalid metadata columns because they are used internally by Auspice
 INVALID_METADATA_COLUMNS = ("none")
@@ -1244,24 +1242,14 @@ def run(args):
         data_json["meta"]["extensions"] = config["extensions"]
 
     # Should output be minified?
-    # Order of precedence:
-    # 1. Command-line arguments
-    # 2. Environment variable
-    # 3. Automatically determine based on the size of the tree
     if args.minify_json:
         minify = True
     elif args.no_minify_json:
         minify = False
-    elif os.environ.get("AUGUR_MINIFY_JSON"):
-        minify = True
     else:
-        if json_size(data_json) > MINIFY_THRESHOLD_MB * 10**6:
-            minify = True
-        else:
-            minify = False
+        minify = None
 
     # Write outputs - the (unified) dataset JSON intended for auspice & perhaps the ref root-sequence JSON
-    indent = {"indent": None} if minify else {}
     if args.include_root_sequence or args.include_root_sequence_inline:
         # Note - argparse enforces that only one of these args will be true
         if 'reference' in node_data:
@@ -1274,10 +1262,10 @@ def run(args):
                 # "auspice/zika_root-sequence.json".
                 output_path = Path(args.output)
                 root_sequence_path = output_path.parent / Path(output_path.stem + "_root-sequence" + output_path.suffix)
-                write_json(data=node_data['reference'], file=root_sequence_path, **indent)
+                write_json(data=node_data['reference'], file=root_sequence_path, minify=minify)
         else:
             raise AugurError("Root sequence output was requested, but the node data provided is missing a 'reference' key.")
-    write_json(data=orderKeys(data_json), file=args.output, **indent)
+    write_json(data=orderKeys(data_json), file=args.output, minify=minify)
 
     # validate outputs
     validate_data_json(args.output, args.validation_mode)

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -13,7 +13,7 @@ from .frequency_estimators import AlignmentKdeFrequencies, TreeKdeFrequencies, T
 from .dates import numeric_date_type, SUPPORTED_DATE_HELP_TEXT, get_numerical_dates
 from .io.file import open_file
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, METADATA_DATE_COLUMN, InvalidDelimiter, Metadata, read_metadata
-from .utils import write_json
+from .utils import write_augur_json
 
 REGION_COLUMN = 'region'
 DEFAULT_REGION = 'global'
@@ -218,7 +218,7 @@ def run(args):
                     "frequencies": format_frequencies(frequencies[node_name])
                 }
 
-        write_json(frequency_dict, args.output)
+        write_augur_json(frequency_dict, args.output)
         print("tree frequencies written to", args.output, file=sys.stdout)
     elif args.alignments:
         frequencies = None
@@ -265,5 +265,5 @@ def run(args):
                 frequencies["%s:counts" % gene] = [int(observations_per_pivot)
                                                    for observations_per_pivot in freqs.counts]
 
-        write_json(frequencies, args.output)
+        write_augur_json(frequencies, args.output)
         print("mutation frequencies written to", args.output, file=sys.stdout)

--- a/augur/import_/beast.py
+++ b/augur/import_/beast.py
@@ -12,7 +12,7 @@ import numpy as np
 from Bio import Phylo
 from treetime import TreeAnc
 from augur.io.file import open_file
-from augur.utils import write_json
+from augur.utils import write_augur_json
 
 def register_parser(parent_subparsers):
     """
@@ -588,6 +588,6 @@ def run(args):
     node_data['nodes'] = collect_node_data(tree, root_date_offset, most_recent_tip)
 
     tree_success = Phylo.write(tree, args.output_tree, 'newick', format_branch_length='%1.8f')
-    json_success = write_json(node_data, args.output_node_data)
+    json_success = write_augur_json(node_data, args.output_node_data)
 
     print_what_to_do_next(nodes=node_data['nodes'], mcc_path=args.mcc, tree_path=args.output_tree, node_data_path=args.output_node_data)

--- a/augur/io/__init__.py
+++ b/augur/io/__init__.py
@@ -3,6 +3,7 @@
 # Functions and variables exposed here are part of Augur's public Python API.
 # To use functions internally, import directly from the submodule.
 from .file import open_file  # noqa: F401
+from .json import write_json  # noqa: F401
 from .metadata import read_metadata  # noqa: F401
 from .sequences import read_sequences, write_sequences, load_features  # noqa: F401
 from .strains import read_strains  # noqa: F401

--- a/augur/lbi.py
+++ b/augur/lbi.py
@@ -7,7 +7,7 @@ import json
 import numpy as np
 from .argparse_ import ExtendOverwriteDefault
 from .io.file import open_file
-from .utils import write_json
+from .utils import write_augur_json
 
 
 def select_nodes_in_season(tree, timepoint, time_window=0.6):
@@ -128,4 +128,4 @@ def run(args):
             lbi_by_node[node.name][attribute_name] = node.attr[attribute_name]
 
     # Export LBI to JSON.
-    write_json({"nodes": lbi_by_node}, args.output)
+    write_augur_json({"nodes": lbi_by_node}, args.output)

--- a/augur/measurements/concat.py
+++ b/augur/measurements/concat.py
@@ -5,7 +5,8 @@ import os
 import sys
 
 from augur.argparse_ import ExtendOverwriteDefault
-from augur.utils import first_line, write_json
+from augur.io.json import write_json
+from augur.utils import first_line
 from augur.validate import (
     measurements as read_measurements_json,
     ValidateError

--- a/augur/measurements/concat.py
+++ b/augur/measurements/concat.py
@@ -46,7 +46,7 @@ def run(args):
         output['collections'].extend(measurements['collections'])
 
     indent = {"indent": None} if args.minify_json else {}
-    write_json(output, args.output_json, include_version=False, **indent)
+    write_json(output, args.output_json, **indent)
     try:
         read_measurements_json(measurements_json=args.output_json)
     except ValidateError:

--- a/augur/measurements/concat.py
+++ b/augur/measurements/concat.py
@@ -1,6 +1,7 @@
 """
 Concatenate multiple measurements JSONs into a single JSON file
 """
+import os
 import sys
 
 from augur.argparse_ import ExtendOverwriteDefault
@@ -45,8 +46,8 @@ def run(args):
         measurements = read_measurements_json(json)
         output['collections'].extend(measurements['collections'])
 
-    indent = {"indent": None} if args.minify_json else {}
-    write_json(output, args.output_json, **indent)
+    minify = True if args.minify_json or os.environ.get("AUGUR_MINIFY_JSON") else False
+    write_json(output, args.output_json, minify=minify)
     try:
         read_measurements_json(measurements_json=args.output_json)
     except ValidateError:

--- a/augur/measurements/export.py
+++ b/augur/measurements/export.py
@@ -7,7 +7,8 @@ import sys
 
 from augur.argparse_ import ExtendOverwriteDefault, HideAsFalseAction
 from augur.io.file import PANDAS_READ_CSV_OPTIONS
-from augur.utils import first_line, write_json
+from augur.io.json import write_json
+from augur.utils import first_line
 from augur.validate import (
     measurements as read_measurements_json,
     measurements_collection_config as read_collection_config_json,

--- a/augur/measurements/export.py
+++ b/augur/measurements/export.py
@@ -243,10 +243,10 @@ def run(args):
         'collections': [collection_output]
     }
 
-    # Set indentation to None to create compact JSON if specified
-    indent = {"indent": None} if args.minify_json else {}
+    # Compact JSON if specified
+    minify = True if args.minify_json or os.environ.get("AUGUR_MINIFY_JSON") else False
     # Create output JSON
-    write_json(output, args.output_json, **indent)
+    write_json(output, args.output_json, minify=minify)
     # Verify the produced output is a valid measurements JSON
     try:
         read_measurements_json(measurements_json=args.output_json)

--- a/augur/measurements/export.py
+++ b/augur/measurements/export.py
@@ -246,7 +246,7 @@ def run(args):
     # Set indentation to None to create compact JSON if specified
     indent = {"indent": None} if args.minify_json else {}
     # Create output JSON
-    write_json(output, args.output_json, include_version=False, **indent)
+    write_json(output, args.output_json, **indent)
     # Verify the produced output is a valid measurements JSON
     try:
         read_measurements_json(measurements_json=args.output_json)

--- a/augur/refine.py
+++ b/augur/refine.py
@@ -10,7 +10,7 @@ from .dates import get_numerical_dates
 from .dates.errors import InvalidYearBounds
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, METADATA_DATE_COLUMN, InvalidDelimiter, Metadata, read_metadata
 from .io.strains import read_strains
-from .utils import read_tree, write_json, InvalidTreeError
+from .utils import read_tree, write_augur_json, InvalidTreeError
 from .errors import AugurError
 from treetime.vcf_utils import read_vcf
 from treetime.seq_utils import profile_maps
@@ -437,7 +437,7 @@ def run(args):
     else:
         node_data_fname = '.'.join(args.tree.split('.')[:-1]) + '.node_data.json'
 
-    write_json(node_data, node_data_fname)
+    write_augur_json(node_data, node_data_fname)
     print("node attributes written to",node_data_fname, file=sys.stdout)
 
     return 0 if tree_success else 1

--- a/augur/sequence_traits.py
+++ b/augur/sequence_traits.py
@@ -8,7 +8,7 @@ from treetime.vcf_utils import read_vcf
 from collections import defaultdict
 from .io.file import PANDAS_READ_CSV_OPTIONS, open_file
 from .io.sequences import read_sequences
-from .utils import write_json, get_json_name
+from .utils import write_augur_json, get_json_name
 
 def read_in_translate_vcf(vcf_file, ref_file):
     """
@@ -340,5 +340,5 @@ def run(args):
 
     #write out json
     out_name = get_json_name(args)
-    write_json({"nodes":seq_features},out_name)
+    write_augur_json({"nodes":seq_features},out_name)
     print("sequence traits written to", out_name, file=sys.stdout)

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -7,7 +7,7 @@ from Bio import Phylo
 
 from .reconstruct_sequences import load_alignments
 from .titer_model import InsufficientDataException
-from .utils import write_json
+from .utils import write_augur_json
 from .argparse_ import add_default_command, ExtendOverwriteDefault
 
 
@@ -83,7 +83,7 @@ class infer_substitution_model():
             subs_model["nodes"] = nodes
 
         # export the substitution model
-        write_json(subs_model, args.output)
+        write_augur_json(subs_model, args.output)
 
         print("\nInferred titer model of type 'SubstitutionModel' using augur:"
               "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic phenotypes of seasonal influenza viruses."
@@ -125,7 +125,7 @@ class infer_tree_model():
                 sys.exit(1)
 
         # export the tree model
-        write_json(tree_model, args.output)
+        write_augur_json(tree_model, args.output)
         print("\nInferred titer model of type 'TreeModel' using augur:"
               "\n\tNeher et al. Prediction, dynamics, and visualization of antigenic phenotypes of seasonal influenza viruses."
               "\n\tPNAS, vol 113, 10.1073/pnas.1525578113\n")

--- a/augur/traits.py
+++ b/augur/traits.py
@@ -9,7 +9,7 @@ from .argparse_ import ExtendOverwriteDefault
 from .errors import AugurError
 from .io.file import open_file
 from .io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS, InvalidDelimiter, read_metadata
-from .utils import write_json, get_json_name
+from .utils import write_augur_json, get_json_name
 TINY = 1e-12
 
 def mugration_inference(tree=None, seq_meta=None, field='country', confidence=True,
@@ -308,7 +308,7 @@ def run(args):
     json_data = OrderedDict([["models", models], ["nodes", mugration_states]])
     if branch_states:
         json_data['branches'] = branch_states
-    write_json(json_data, out_name)
+    write_augur_json(json_data, out_name)
 
     print("\nInferred ancestral states of discrete character using TreeTime:"
           "\n\tSagulenko et al. TreeTime: Maximum-likelihood phylodynamic analysis"

--- a/augur/translate.py
+++ b/augur/translate.py
@@ -18,7 +18,7 @@ from Bio import SeqIO, Seq, SeqRecord, Phylo
 from .io.sequences import load_features, write_VCF_translation, is_vcf as is_filename_vcf
 from .io.print import print_err
 from .utils import parse_genes_argument, read_node_data, \
-    write_json, get_json_name, genome_features_to_auspice_annotation
+    write_augur_json, get_json_name, genome_features_to_auspice_annotation
 from treetime.vcf_utils import read_vcf
 from augur.errors import AugurError
 from textwrap import dedent
@@ -460,7 +460,7 @@ def run(args):
     # use NodeDataObject to perform validation on the file before it's written
     NodeDataObject(output_data, out_name, args.validation_mode)
 
-    write_json(output_data, out_name)
+    write_augur_json(output_data, out_name)
     print_err("amino acid mutations written to", out_name)
 
     ## write alignments to file if requested

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -125,7 +125,7 @@ def read_node_data(fnames, tree=None, validation_mode=ValidationMode.ERROR):
 def write_json(data, file, indent=(None if os.environ.get("AUGUR_MINIFY_JSON") else 2), include_version=True):
     """
     Write ``data`` as JSON to the given ``file``, creating parent directories
-    if necessary. The augur version is included as a top-level key "augur_version".
+    if necessary. The augur version is included as a top-level key "generated_by".
 
     Parameters
     ----------
@@ -135,7 +135,7 @@ def write_json(data, file, indent=(None if os.environ.get("AUGUR_MINIFY_JSON") e
         file path or handle to write to
     indent : int or None, optional
         JSON indentation level. Default is `None` if the environment variable :envvar:`AUGUR_MINIFY_JSON`
-        is truthy, else 1
+        is truthy, else 2
     include_version : bool, optional
         Include the augur version. Default: `True`.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,7 +133,7 @@ class TestUtils:
             'series': pd.Series([6,7,8])
         }
         file = Path(tmpdir) / Path("data.json")
-        utils.write_json(data, file, include_version=False)
+        utils.write_json(data, file)
         with open(file) as f:
             assert json.load(f) == {
                 'int': 1,


### PR DESCRIPTION
## Description of proposed changes

This PR contains 3 prep commits + 1 main commit + 1 follow-up commit. Message from main commit:

The auto-minification added in "export v2: Automatically minify output" (3f2e9ca1) was previously limited to export v2. Since this behavior is generally useful when writing JSON files, it has been moved into the underlying write_json() function.

Additional changes outside the function limit this commit to a refactor only, with no functional differences – auto-minification still only applies to the output of augur export v2.

## Related issue(s)

Prep for https://github.com/nextstrain/ncov/issues/1098

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests - export v2's [minify-output.t](https://github.com/nextstrain/augur/blob/dd806378b9b422470ddf2434c3c0b8247c6c0dc2/tests/functional/export_v2/cram/minify-output.t#L1) should be sufficient
- [x] [Check][3] if you need to update docs
- [x] Post-merge: release as 33.0.0 in January 2026

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
