### PR TITLE
export v2: skip unhashable attrs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,11 +16,13 @@
 
 * export v2: Improved the error message that is displayed when a deprecated coloring key is used. [#1882][] (@corneliusroemer)
 * export v2: `--no-minify-json` now properly overrides any truthy value in `AUGUR_MINIFY_JSON`. [#1943][] (@victorlin)
+* export v2: Skip unhashable node attr values with warning message to avoid previously unhandled `TypeError`. [#1948][] (@joverlee521) 
 
 [#1304]: https://github.com/nextstrain/augur/issues/1304
 [#1768]: https://github.com/nextstrain/augur/issues/1768
 [#1882]: https://github.com/nextstrain/augur/issues/1882
 [#1943]: https://github.com/nextstrain/augur/pull/1943
+[#1948]: https://github.com/nextstrain/augur/pull/1948
 
 ## 32.1.0 (18 November 2025)
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import sys
 import time
 from collections import defaultdict, deque, OrderedDict
+from collections.abc import Hashable
 import numbers
 import math
 import re
@@ -168,8 +169,14 @@ def is_node_attr_defined(node_attrs, attr_name):
 def get_values_across_nodes(node_attrs, key):
     vals = set()
     for data in node_attrs.values():
-        if is_valid(data.get(key)):
-            vals.add(data.get(key))
+        value = data.get(key)
+        # Skip unhashable values, e.g. dict or lists,
+        # since they are not supported as node_attr values
+        if not isinstance(value, Hashable):
+            warn(f"Skipping key {key!r} with unexpected value type {type(value)!r}")
+            continue
+        if is_valid(value):
+            vals.add(value)
     return vals
 
 def is_valid(value):

--- a/tests/functional/export_v2/cram/node-data-types.t
+++ b/tests/functional/export_v2/cram/node-data-types.t
@@ -1,0 +1,23 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Test that node data attributes of different types are handled appropriately.
+
+  $ ${AUGUR} export v2 \
+  >   --tree "$TESTDIR/../data/tree.nwk" \
+  >   --node-data "$TESTDIR/../data/node-data-types.json" \
+  >   --output dataset.json &> /dev/null
+
+Verify the expected node attrs from the node-data JSON are exported as filters
+and colorings. Not diffing the dataset.json because order of node_attrs is not
+guaranteed without an auspice_config.json
+
+TODO: Switch to use jq once it's available in a well-defined test environment.
+<https://github.com/nextstrain/augur/issues/1557>
+
+  $ python3 -c 'import json, sys; print(sorted(json.load(sys.stdin)["meta"]["filters"]))' < dataset.json
+  ['test_bool', 'test_float', 'test_int', 'test_str']
+
+  $ python3 -c 'import json, sys; print(sorted(c["key"] for c in json.load(sys.stdin)["meta"]["colorings"]))' < dataset.json
+  ['test_bool', 'test_float', 'test_int', 'test_str']

--- a/tests/functional/export_v2/data/node-data-types.json
+++ b/tests/functional/export_v2/data/node-data-types.json
@@ -1,0 +1,37 @@
+{
+  "nodes": {
+    "tipA": {
+      "test_str": "abc",
+      "test_bool": "False",
+      "test_int": 1,
+      "test_float": 1.0,
+      "test_null": null,
+      "test_array": [0,1,2],
+      "test_obj": {
+        "obj": "abc"
+      }
+    },
+    "tipB": {
+      "test_str": "abc",
+      "test_bool": "False",
+      "test_int": 1,
+      "test_float": 1.0,
+      "test_null": null,
+      "test_array": [0,1,2],
+      "test_obj": {
+        "obj": "abc"
+      }
+    },
+    "tipC": {
+      "test_str": "abc",
+      "test_bool": "False",
+      "test_int": 1,
+      "test_float": 1.0,
+      "test_null": null,
+      "test_array": [0,1,2],
+      "test_obj": {
+        "obj": "abc"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description of proposed changes

Skip unhashable node attr values with a warning so that we don't run into unhandled errors with node data JSONs produced by `augur distance --compare-to pairwise`.

Note this does _not_ incorporate the `augur distance` output into the exported JSON for visualizations! That can be tackled as a separate feature if there are compelling use cases.

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/1842

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
