### PR TITLE
filter, merge: Fix formatting in error message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* filter, merge: Fixed formatting of the error message shown when there are duplicate sequence ids. [#1954][] @victorlin
+
+[#1954]: https://github.com/nextstrain/augur/pull/1954
 
 ## 33.0.0 (26 January 2026)
 

--- a/augur/io/sequences.py
+++ b/augur/io/sequences.py
@@ -537,9 +537,9 @@ def read_sequence_ids(file: str, nthreads: int):
         raise AugurError(dedent(f"""\
             Sequence ids must be unique.
 
-            The following {_n("id was", "ids were", len(duplicates))} were duplicated in {file!r}:
+            The following {_n("id was", "ids were", len(duplicates))} duplicated in {file!r}:
 
-              {indented_list(sorted(duplicates), '            ' + '  ')}
+              {indented_list(map(repr, sorted(duplicates)), '            ' + '  ')}
         """))
     
     return unique

--- a/tests/functional/filter/cram/filter-duplicates-error.t
+++ b/tests/functional/filter/cram/filter-duplicates-error.t
@@ -69,10 +69,10 @@ Error on duplicates in sequences.
   >   --output-sequences sequences-filtered.fasta
   ERROR: Sequence ids must be unique.
   
-  The following ids were were duplicated in 'sequences.fasta':
+  The following ids were duplicated in 'sequences.fasta':
   
-    a
-    c
+    'a'
+    'c'
   
   [2]
 
@@ -84,10 +84,10 @@ Error even if the corresponding output is not used.
   >   --output-strains filtered.txt
   ERROR: Sequence ids must be unique.
   
-  The following ids were were duplicated in 'sequences.fasta':
+  The following ids were duplicated in 'sequences.fasta':
   
-    a
-    c
+    'a'
+    'c'
   
   [2]
 

--- a/tests/functional/merge/cram/merge-sequences-duplicates.t
+++ b/tests/functional/merge/cram/merge-sequences-duplicates.t
@@ -33,10 +33,10 @@ Duplicates within the same file are not allowed.
   WARNING: Metadata merge was successful but sequence merge has failed, so --output-metadata has no corresponding sequence output.
   ERROR: Sequence ids must be unique.
   
-  The following ids were were duplicated in 'x.fasta':
+  The following ids were duplicated in 'x.fasta':
   
-    seq2
-    seq3
+    'seq2'
+    'seq3'
   
   [2]
 


### PR DESCRIPTION
## Description of proposed changes

Removed an extra word and added quotes, which helps reveal any whitespace in ids.

## Related issue(s)

I noticed this small bug when testing something with an badly constructed FASTA header `> {id}` instead of `>{id}` and saw this weird output:

```
The following id was were duplicated in 'sequences.fasta':


```

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
