### PR TITLE
subsample: Print errors from get_referenced_files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,10 @@
 
 * filter, merge: Fixed formatting of the error message shown when there are duplicate sequence ids. [#1954][] @victorlin
 * filter: Adjusted the error message shown when there are missing weights to mention the option of updating values in metadata. [#1956][] @victorlin
+* The helper function `augur.subsample.get_referenced_files` now shows errors when used in a lambda expression for a Snakemake input. [#1955][] (@victorlin)
 
 [#1954]: https://github.com/nextstrain/augur/pull/1954
+[#1955]: https://github.com/nextstrain/augur/pull/1955
 [#1956]: https://github.com/nextstrain/augur/pull/1956
 
 ## 33.0.0 (26 January 2026)

--- a/augur/subsample.py
+++ b/augur/subsample.py
@@ -265,15 +265,21 @@ def get_referenced_files(
     set
         Resolved filepaths
     """
-    # Load schema, parse and validate config.
-    schema_validator = load_json_schema("schema-subsample-config.json")
-    config = _parse_config(config_file, config_section, schema_validator)
+    # TODO: Remove try/except once Snakemake bug is fixed.
+    # <https://github.com/snakemake/snakemake/issues/3953>
+    try:
+        # Load schema, parse and validate config.
+        schema_validator = load_json_schema("schema-subsample-config.json")
+        config = _parse_config(config_file, config_section, schema_validator)
 
-    # Resolve filepaths.
-    search_path_objs = _get_search_paths(config_file, search_paths)
-    config, filepaths = _resolve_filepaths(config, search_path_objs, schema_validator.schema)
+        # Resolve filepaths.
+        search_path_objs = _get_search_paths(config_file, search_paths)
+        config, filepaths = _resolve_filepaths(config, search_path_objs, schema_validator.schema)
 
-    return set(filepaths)
+        return set(filepaths)
+    except Exception as e:
+        print_err(f"ERROR: {e}")
+        raise e
 
 
 def _parse_config(filename: str, config_section: Optional[List[str]], schema) -> Dict[str, Any]:


### PR DESCRIPTION
This is a workaround for a Snakemake bug that suppresses the errors.

Upstream issue: https://github.com/snakemake/snakemake/issues/3953

## Checklist

- [x] ~Automated checks pass~ N/A
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs
- [ ] Post-merge: create issue to track TODO

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
