### PR TITLE
filter: Add remediation option for missing weights error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,10 @@
 ### Bug fixes
 
 * filter, merge: Fixed formatting of the error message shown when there are duplicate sequence ids. [#1954][] @victorlin
+* filter: Adjusted the error message shown when there are missing weights to mention the option of updating values in metadata. [#1956][] @victorlin
 
 [#1954]: https://github.com/nextstrain/augur/pull/1954
+[#1956]: https://github.com/nextstrain/augur/pull/1956
 
 ## 33.0.0 (26 January 2026)
 

--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -486,9 +486,10 @@ def _handle_incomplete_weights(
         raise AugurError(dedent(f"""\
             The input metadata contains these values under the following columns that are not covered by {weights_file!r}:
             - {columns_with_values}
-            To fix this, either:
-            (1) specify weights explicitly - add entries to {weights_file!r} for the values above, or
-            (2) specify a default weight - add an entry to {weights_file!r} with the value {COLUMN_VALUE_FOR_DEFAULT_WEIGHT!r} for all columns"""))
+            Some ways to fix this:
+            (1) use existing weights - update the metadata file to use values in {weights_file!r}, or
+            (2) specify new weights - add entries to {weights_file!r} for the values above, or
+            (3) specify a default weight - add an entry to {weights_file!r} with the value {COLUMN_VALUE_FOR_DEFAULT_WEIGHT!r} for all columns"""))
     else:
         print_err(dedent(f"""\
             WARNING: The input metadata contains these values under the following columns that are not directly covered by {weights_file!r}:

--- a/tests/functional/filter/cram/subsample-weighted.t
+++ b/tests/functional/filter/cram/subsample-weighted.t
@@ -89,9 +89,10 @@ Sampling with incomplete weights should show an error.
   Sampling with weights defined by weights.tsv.
   ERROR: The input metadata contains these values under the following columns that are not covered by 'weights.tsv':
   - 'location': ['B']
-  To fix this, either:
-  (1) specify weights explicitly - add entries to 'weights.tsv' for the values above, or
-  (2) specify a default weight - add an entry to 'weights.tsv' with the value 'default' for all columns
+  Some ways to fix this:
+  (1) use existing weights - update the metadata file to use values in 'weights.tsv', or
+  (2) specify new weights - add entries to 'weights.tsv' for the values above, or
+  (3) specify a default weight - add an entry to 'weights.tsv' with the value 'default' for all columns
   [2]
 
 Re-running with a default weight shows a warning and continues.
@@ -139,9 +140,10 @@ To specify a default weight, the value 'default' must be set for all weighted co
   ERROR: The input metadata contains these values under the following columns that are not covered by 'weights.tsv':
   - 'location': ['B']
   - 'month': ['2000-01', '2000-03']
-  To fix this, either:
-  (1) specify weights explicitly - add entries to 'weights.tsv' for the values above, or
-  (2) specify a default weight - add an entry to 'weights.tsv' with the value 'default' for all columns
+  Some ways to fix this:
+  (1) use existing weights - update the metadata file to use values in 'weights.tsv', or
+  (2) specify new weights - add entries to 'weights.tsv' for the values above, or
+  (3) specify a default weight - add an entry to 'weights.tsv' with the value 'default' for all columns
   [2]
 
   $ cat >weights.tsv <<~~


### PR DESCRIPTION
Updating values in metadata is the most practical option we've seen in active usage.

## Related issue(s)

Follow-up to https://github.com/nextstrain/ncov-ingest/issues/514 and https://github.com/nextstrain/ncov-ingest/issues/516

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
