### PR TITLE
Use fixed seed in test

### DIFF
--- a/tests/test_ancestral.py
+++ b/tests/test_ancestral.py
@@ -37,6 +37,7 @@ class TestRootNodeMutationAssignment:
             'fill_overhangs': True, # augur default
             'marginal': 'joint', # augur default
             'alphabet': 'nuc', # augur default
+            'rng_seed': 0,
         }
 
 


### PR DESCRIPTION
This prevents test failures due to sampling differences.

[Example](https://github.com/nextstrain/augur/actions/runs/21641756172/job/62383078148#step:10:1177) of such a failure:

```
tests/test_ancestral.py:93: in test_vcf_with_ambiguity_inferred
    assert(gather_mutations_at_pos(3, nuc_result)==[])
E   AssertionError: assert ['C3A', 'C3A'] == []
E     
E     Left contains 2 more items, first extra item: 'C3A'
E     
E     Full diff:
E     - []
E     + [
E     +     'C3A',
E     +     'C3A',
E     + ]
```

## Checklist

- [x] Automated checks pass
- [x] ~[Check][1] if you need to add a changelog message~
- [x] ~[Check][2] if you need to add tests~
- [x] ~[Check][3] if you need to update docs~

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
