### PR TITLE
merge: Fixes for SQLite version 3.52.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,13 @@
 * filter, merge: Fixed formatting of the error message shown when there are duplicate sequence ids. [#1954][] @victorlin
 * filter: Adjusted the error message shown when there are missing weights to mention the option of updating values in metadata. [#1956][] @victorlin
 * frequencies: Added a proper error message for missing or invalid dates. [#1960][] @victorlin
+* merge: Added a workaround for a bug in SQLite version 3.52.0. [#1969][] @victorlin
+* merge: Improved error messages from SQLite. [#1969][] @victorlin
 
 [#1954]: https://github.com/nextstrain/augur/pull/1954
 [#1956]: https://github.com/nextstrain/augur/pull/1956
 [#1960]: https://github.com/nextstrain/augur/issues/1960
+[#1969]: https://github.com/nextstrain/augur/pull/1969
 
 ## 33.0.0 (26 January 2026)
 

--- a/augur/io/print.py
+++ b/augur/io/print.py
@@ -4,16 +4,16 @@ import sys
 from augur.debug import DEBUGGING
 
 
-def print_err(*args):
+def print_err(*args, **kwargs):
     """Print to stderr. When data goes to stdout (most cases), this should be
     used for any informational messages, not just errors/warnings."""
-    print(*args, file=sys.stderr)
+    print(*args, file=sys.stderr, **kwargs)
 
 
-def print_debug(*args):
+def print_debug(*args, **kwargs):
     """Print to stderr if in debugging mode."""
     if DEBUGGING:
-        print_err(*args)
+        print_err(*args, **kwargs)
 
 
 def indented_list(xs, prefix):

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -375,6 +375,27 @@ def merge_metadata(args):
             f'.output')
 
     except SQLiteError as err:
+        # Check for duplicates
+        try:
+            proc = sqlite3(db_path, f"""
+                select {sqlite_quote_id(m.id_column)}
+                from {sqlite_quote_id(m.table_name)}
+                group by {sqlite_quote_id(m.id_column)}
+                having count(*) > 1;
+            """, stdout=subprocess.PIPE)
+
+            if duplicates := proc.stdout.splitlines():
+                raise AugurError(dedent(f"""\
+                    Sequence ids must be unique.
+
+                    The following {_n("id was", "ids were", len(duplicates))} duplicated in metadata table {m.name!r}:
+
+                      {indented_list(map(repr, sorted(duplicates)), '                    ' + '  ')}
+                    """)) from None
+        except SQLiteError:
+            pass
+
+        # Unknown SQLite error
         delete_db = False
         if err.proc.stderr:
             print_err(f"[SQLite] {err.proc.stderr}", end="")

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -365,12 +365,14 @@ def merge_metadata(args):
         # Assume TSV like nearly all other extant --output-metadata options.
         print_info(f"Merging metadata and writing to {args.output_metadata!r}…")
         print_debug(query)
+        # TODO: Use .once after SQLite bug is fixed: <https://sqlite.org/forum/forumpost/ea9c546fdf>
         sqlite3(db_path,
             f'.mode csv',
             f'.separator "\\t" "\\n"',
             f'.headers on',
-            f'.once {sqlite_quote_dot(f"|{augur()} write-file {shquote(args.output_metadata)}")}',
-            query)
+            f'.output {sqlite_quote_dot(f"|{augur()} write-file {shquote(args.output_metadata)}")}',
+            query,
+            f'.output')
 
     except SQLiteError as err:
         delete_db = False

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -376,6 +376,8 @@ def merge_metadata(args):
 
     except SQLiteError as err:
         delete_db = False
+        if err.proc.stderr:
+            print_err(f"[SQLite] {err.proc.stderr}", end="")
         raise AugurError(str(err)) from err
 
     finally:
@@ -435,22 +437,28 @@ def sqlite3(*args, **kwargs):
     argv = [sqlite3, "-init", os.devnull, "-batch", *args]
 
     print_debug(f"running {argv!r}")
-    proc = subprocess.run(argv, encoding="utf-8", text=True, **kwargs)
+    proc = subprocess.run(argv, encoding="utf-8", text=True, stderr=subprocess.PIPE, **kwargs)
 
     try:
         proc.check_returncode()
     except subprocess.CalledProcessError as err:
-        raise SQLiteError(f"sqlite3 invocation failed") from err
+        raise SQLiteError(proc, f"sqlite3 invocation failed") from err
 
     return proc
 
 
 class SQLiteError(Exception):
-    pass
+    """
+    Exception raised when `sqlite3` invocation fails.
+    `proc` stores the failed process. Useful for retrieving info such as output.
+    """
+    def __init__(self, proc: subprocess.CompletedProcess, *args):
+        super().__init__(*args)
+        self.proc = proc
 
 
 def sqlite3_table_columns(db_path, table: str) -> Iterable[str]:
-    return sqlite3(db_path, f"select name from pragma_table_info({sqlite_quote_string(table)})", capture_output=True).stdout.splitlines();
+    return sqlite3(db_path, f"select name from pragma_table_info({sqlite_quote_string(table)})", stdout=subprocess.PIPE).stdout.splitlines();
 
 
 def sqlite_quote_id(*xs):

--- a/tests/functional/merge/cram/merge-metadata.t
+++ b/tests/functional/merge/cram/merge-metadata.t
@@ -275,7 +275,7 @@ Duplicates.
   >   --metadata dups=dups.tsv Y=y.tsv \
   >   --output-metadata /dev/null
   Reading 'dups' metadata from 'dups.tsv'…
-  Error: stepping, UNIQUE constraint failed: metadata_dups.strain (19)
+  [SQLite] Error: stepping, UNIQUE constraint failed: metadata_dups.strain (19)
   WARNING: Skipped deletion of */augur-merge-*.sqlite due to error, but you may want to clean it up yourself (e.g. if it's large). (glob)
   ERROR: sqlite3 invocation failed
   [2]
@@ -426,7 +426,7 @@ handled).
   > ${AUGUR} merge \
   >   --metadata X=x.tsv Y=y.tsv \
   >   --output-metadata /dev/null --quiet
-  This isn't the program you're looking for.
+  [SQLite] This isn't the program you're looking for.
   ERROR: sqlite3 invocation failed
   [2]
 

--- a/tests/functional/merge/cram/merge-metadata.t
+++ b/tests/functional/merge/cram/merge-metadata.t
@@ -275,9 +275,12 @@ Duplicates.
   >   --metadata dups=dups.tsv Y=y.tsv \
   >   --output-metadata /dev/null
   Reading 'dups' metadata from 'dups.tsv'…
-  [SQLite] Error: stepping, UNIQUE constraint failed: metadata_dups.strain (19)
-  WARNING: Skipped deletion of */augur-merge-*.sqlite due to error, but you may want to clean it up yourself (e.g. if it's large). (glob)
-  ERROR: sqlite3 invocation failed
+  ERROR: Sequence ids must be unique.
+  
+  The following id was duplicated in metadata table 'dups':
+  
+    'one'
+  
   [2]
 
 Unknown metadata names in --metadata-delimiters.


### PR DESCRIPTION
## Description of proposed changes

A couple small improvements in error handling.

## Related issue(s)

Addresses CI failures due to changes from [new SQLite version](https://www.sqlite.org/releaselog/3_52_0.html), first noticed in [scheduled run](https://github.com/nextstrain/augur/actions/runs/22804022514)

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update
