### PR TITLE
Update broken pandas links

### DIFF
--- a/augur/data/schema-subsample-config.json
+++ b/augur/data/schema-subsample-config.json
@@ -115,7 +115,7 @@
                 },
                 "query": {
                     "type": "string",
-                    "description": "Filter sequences by attribute. Uses `Pandas DataFrame query syntax`__.\n(e.g., \"country == 'Colombia'\" or \"(country == 'USA' & (division ==\n'Washington'))\")\n\n__ https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query"
+                    "description": "Filter sequences by attribute. Uses `Pandas DataFrame query syntax`__.\n(e.g., \"country == 'Colombia'\" or \"(country == 'USA' & (division ==\n'Washington'))\")\n\n__ https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query"
                 },
                 "query_columns": {
                     "oneOf": [
@@ -239,7 +239,7 @@
                 },
                 "query": {
                     "type": "string",
-                    "description": "Filter sequences by attribute. Uses `Pandas DataFrame query syntax`__.\n(e.g., \"country == 'Colombia'\" or \"(country == 'USA' & (division ==\n'Washington'))\")\n\n__ https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query"
+                    "description": "Filter sequences by attribute. Uses `Pandas DataFrame query syntax`__.\n(e.g., \"country == 'Colombia'\" or \"(country == 'USA' & (division ==\n'Washington'))\")\n\n__ https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query"
                 },
                 "query_columns": {
                     "oneOf": [

--- a/augur/filter/arguments.py
+++ b/augur/filter/arguments.py
@@ -15,7 +15,7 @@ descriptions = {
         (e.g., "country == 'Colombia'" or "(country == 'USA' & (division ==
         'Washington'))")
 
-        __ https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query"""),
+        __ https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query"""),
 
     "query_columns": dedent(f"""\
         Use alongside query to specify columns and data types in the format

--- a/augur/filter/include_exclude_rules.py
+++ b/augur/filter/include_exclude_rules.py
@@ -245,7 +245,7 @@ def filter_by_query(metadata: pd.DataFrame, query: str, column_types: Optional[D
     except Exception as e:
         if isinstance(e, PandasUndefinedVariableError):
             raise AugurError(f"Query contains a column that does not exist in metadata: {e}") from e
-        raise AugurError(f"Internal Pandas error when applying query:\n\t{e}\nEnsure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.") from e
+        raise AugurError(f"Internal Pandas error when applying query:\n\t{e}\nEnsure the syntax is valid per <https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query>.") from e
 
 
 def _string_to_boolean(s: str):

--- a/tests/functional/filter/cram/filter-query-errors.t
+++ b/tests/functional/filter/cram/filter-query-errors.t
@@ -23,7 +23,7 @@ Some error messages from Pandas may be useful, so they are exposed:
   >  --output-strains filtered_strains.txt > /dev/null
   ERROR: Internal Pandas error when applying query:
   	'>=' not supported between instances of 'str' and 'float'
-  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query>.
   [2]
 
 However, other Pandas errors are not so helpful, so a link is provided for users to learn more about query syntax.
@@ -34,7 +34,7 @@ However, other Pandas errors are not so helpful, so a link is provided for users
   >  --output-strains filtered_strains.txt > /dev/null
   ERROR: Internal Pandas error when applying query:
   	cannot assign without a target object
-  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query>.
   [2]
 
   $ ${AUGUR} filter \
@@ -51,5 +51,5 @@ However, other Pandas errors are not so helpful, so a link is provided for users
       some bad syntax
   ERROR: Internal Pandas error when applying query:
   	invalid syntax (<unknown>, line 1)
-  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query>.
   [2]

--- a/tests/functional/filter/cram/filter-query-numerical.t
+++ b/tests/functional/filter/cram/filter-query-numerical.t
@@ -31,7 +31,7 @@ The 'category' column will fail when used with a numerical comparison.
   >  --output-strains filtered_strains.txt
   ERROR: Internal Pandas error when applying query:
   	'>=' not supported between instances of 'str' and 'float'
-  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query>.
   [2]
 
 With automatic type inference, the 'coverage' column isn't query-able with
@@ -43,7 +43,7 @@ string comparisons:
   >  --output-strains filtered_strains.txt > /dev/null
   ERROR: Internal Pandas error when applying query:
   	Can only use .str accessor with string values!
-  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query>.
+  Ensure the syntax is valid per <https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query>.
   [2]
 
 However, that is still possible by explicitly specifying that it is a string column.


### PR DESCRIPTION
The previous URL is archived at
<https://web.archive.org/web/20260306082838/https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query> but Panda's URL scheme seems to have changed with the release of v3.0. The "latest" version of the page is
<https://pandas.pydata.org/docs/user_guide/indexing.html#indexing-query>. Since we explicitly don't install pandas 3.0 the most recent v2 URL is preferable
<https://pandas.pydata.org/pandas-docs/version/2.3/user_guide/indexing.html#indexing-query>.

The broken link was identified in CI
<https://github.com/nextstrain/augur/actions/runs/23122121288/job/67157947796> and this commit replaces all occurrences of it in this repo.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update
