### PR TITLE
Ancestral reconstruction bug fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,16 @@
 
 ## __NEXT__
 
+### Features
+
+* ancestral: Add `--report-inconsistent-translation` argument to report where amino acid reconstruction differed from the translation of the reconstructed nuc sequence. [#1975][] @jameshadfield
+
 ### Bug fixes
 
+* ancestral: Fix potential bugs where 'N' could be used as the ambiguous character for AA sequences (this bug wasn't exposed if the provided translations came from Nextclade which was the usual path). Also includes fixes for nucleotide reconstructions involving the ambiguous 'X' character. [#1975][] @jameshadfield
 * merge: Added a workaround for a bug in SQLite version 3.53.0. [#1984][] @victorlin
 
+[#1975]: https://github.com/nextstrain/augur/pull/1975
 [#1984]: https://github.com/nextstrain/augur/pull/1984
 
 ## 33.0.1 (11 March 2026)

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -23,10 +23,12 @@ nucleotide sequences, please use `augur translate`.
     The mutation positions in the node-data JSON are one-based.
 """
 from augur.argparse_ import ExtendOverwriteDefault
+import argparse
 from augur.errors import AugurError
 import sys
 import numpy as np
 from Bio import SeqIO
+from Bio.Phylo.BaseTree import Tree  # type: ignore[import-untyped]
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from .utils import parse_genes_argument, read_tree, InvalidTreeError, write_augur_json, get_json_name, \
@@ -37,60 +39,37 @@ from treetime.vcf_utils import read_vcf, write_vcf
 from collections import defaultdict
 from .argparse_ import add_validation_arguments
 from .util_support.node_data_file import NodeDataObject
+from typing import cast, Any, TypedDict
+from typing_extensions import NotRequired
 
-def ancestral_sequence_inference(tree=None, aln=None, ref=None, infer_gtr=True,
-                                 marginal=False, fill_overhangs=True, infer_tips=False,
-                                 alphabet='nuc', rng_seed=None):
-    """infer ancestral sequences using TreeTime
+VCF_Alignment = dict[str, dict[int, str]]
 
-    Parameters
-    ----------
-    tree : Bio.Phylo.BaseTree.Tree or str
-        tree or filename of tree
-    aln : Bio.Align.MultipleSeqAlignment or str
-        alignment or filename of alignment
-    ref : str, optional
-        reference sequence to pass to TreeTime's TreeAnc class
-    infer_gtr : bool, optional
-        Description
-    marginal : bool, optional
-        Description
-    fill_overhangs : bool
-       In some cases, the missing data on both ends of the alignment is
-       filled with the gap character ('-'). If set to True, these end-gaps are
-       converted to "ambiguous" characters ('N' for nucleotides, 'X' for
-       aminoacids). Otherwise, the alignment is treated as-is
-    infer_tips : bool
-        Since v0.7, TreeTime does not reconstruct tip states by default.
-        This is only relevant when tip-state are not exactly specified, e.g. via
-        characters that signify ambiguous states. To replace those with the
-        most-likely state, set infer_tips=True
-    alphabet : str
-        alphabet to use for ancestral sequence inference. Default is the nucleotide
-        alphabet that included a gap character 'nuc'. Alternative is `aa` for amino
-        acids.
-    rng_seed : int, optional
-        random seed value to use for inference
+VCF_Metadata = dict[str, Any]
 
-    Returns
-    -------
-    treetime.TreeAnc
-        treetime.TreeAnc instance
-    """
+class Mutations(TypedDict):
+    nodes: Any
+    mask: Any # numpy.ndarray(bool)
+    
+class Ancestral_Reconstruction(TypedDict):
+    tt: Any
+    root_seq: str
+    mutations: Mutations
 
-    from treetime import TreeAnc
+class Nuc_Annotation(TypedDict):
+    start: int
+    end: int
+    strand: str
+    type: str
 
-    tt = TreeAnc(tree=tree, aln=aln, ref=ref, gtr='JC69', alphabet=alphabet,
-                 fill_overhangs=fill_overhangs, verbose=1, rng_seed=rng_seed)
+class Annotations_JSON(TypedDict):
+    nuc: Nuc_Annotation
 
-    # convert marginal (from args.inference) from 'joint' or 'marginal' to True or False
-    bool_marginal = (marginal == "marginal")
+class Ancestral_JSON(TypedDict):
+    reference: dict[str, str]
+    mask: NotRequired[str]
+    annotations: Annotations_JSON
+    nodes: Any
 
-    # only infer ancestral sequences, leave branch length untouched
-    tt.infer_ancestral_sequences(infer_gtr=infer_gtr, marginal=bool_marginal,
-                                 reconstruct_tip_states=infer_tips, sample_from_profile='root')
-
-    return tt
 
 def create_mask(is_vcf, tt, reference_sequence, aln):
     """
@@ -229,15 +208,31 @@ def collect_sequences(tt, mask, reference_sequence=None, infer_ambiguous=False):
             print("No sequence available for node ",n.name)
     return sequences
 
-def run_ancestral(T, aln, reference_sequence=None, is_vcf=False, full_sequences=False, fill_overhangs=False,
-                  infer_ambiguous=False, marginal=False, alphabet='nuc', rng_seed=None):
+
+def run_ancestral(
+        T:Tree,
+        aln: str|VCF_Alignment,
+        reference_sequence:str|None=None,
+        is_vcf=False,
+        full_sequences=False,
+        fill_overhangs=False,
+        infer_ambiguous=False,
+        marginal=False,
+        alphabet='nuc',
+        rng_seed:int|None=None
+        ) -> Ancestral_Reconstruction:
     """
     ancestral nucleotide reconstruction using TreeTime
     """
+    from treetime import TreeAnc
+    
+    tt = TreeAnc(tree=T, aln=aln, ref=reference_sequence if is_vcf else None, gtr='JC69', alphabet=alphabet,
+                 fill_overhangs=fill_overhangs, verbose=1, rng_seed=rng_seed)
 
-    tt = ancestral_sequence_inference(tree=T, aln=aln, ref=reference_sequence if is_vcf else None, marginal=marginal,
-                                      fill_overhangs = fill_overhangs, alphabet=alphabet,
-                                      infer_tips = infer_ambiguous, rng_seed=rng_seed)
+    # only infer ancestral sequences, leave branch length untouched
+    tt.infer_ancestral_sequences(infer_gtr=True, marginal=marginal,
+                                 reconstruct_tip_states=infer_ambiguous, sample_from_profile='root')
+
 
     character_map = {}
     for x in tt.gtr.profile_map:
@@ -252,7 +247,7 @@ def run_ancestral(T, aln, reference_sequence=None, is_vcf=False, full_sequences=
     if reference_sequence:
         root_seq = reference_sequence
     else:
-        root_seq = tt.sequence(T.root, as_string=True)
+        root_seq = str(tt.sequence(T.root, as_string=True))
 
     mask = create_mask(is_vcf, tt, reference_sequence, aln)
     mutations = collect_mutations(tt, mask, character_map, reference_sequence, infer_ambiguous)
@@ -262,7 +257,7 @@ def run_ancestral(T, aln, reference_sequence=None, is_vcf=False, full_sequences=
 
     # Combine the mutations & sequences into a single dict which downstream code
     # expects
-    nodes = defaultdict(dict)
+    nodes: defaultdict[str, dict[str, Any]] = defaultdict(dict)
     for n in tt.tree.find_clades():
         name = n.name
         if name in mutations:
@@ -363,40 +358,40 @@ def validate_arguments(args, is_vcf):
         raise AugurError("VCF output has been requested but the input alignment is not VCF.")
 
 
-def run(args):
-    # check alignment type, set flags, read in if VCF
-    is_vcf = is_filename_vcf(args.alignment)
-    ref = None
-    validate_arguments(args, is_vcf)
-
+def _read_tree(fname: str) -> Tree:
     try:
-        T = read_tree(args.tree)
+        T = read_tree(fname)
     except FileNotFoundError:
-        raise AugurError(f"The provided tree file {args.tree!r} doesn't exist")
+        raise AugurError(f"The provided tree file {fname!r} doesn't exist")
     except InvalidTreeError as error:
         raise AugurError(error)
     # Note that a number of other errors may be thrown by `read_tree` such as Bio.Phylo.NewickIO.NewickError
 
-    import numpy as np
     missing_internal_node_names = [n.name is None for n in T.get_nonterminals()]
     if np.all(missing_internal_node_names):
         print("\n*** WARNING: Tree has no internal node names!", file=sys.stderr)
         print("*** Without internal node names, ancestral sequences can't be linked up to the correct node later.", file=sys.stderr)
         print("*** If you want to use 'augur export' or `augur translate` later, re-run this command with the output of 'augur refine'.", file=sys.stderr)
         print("*** If you haven't run 'augur refine', you can add node names to your tree by running:", file=sys.stderr)
-        print("*** augur refine --tree %s --output-tree <filename>.nwk"%(args.tree) , file=sys.stderr)
+        print("*** augur refine --tree %s --output-tree <filename>.nwk"%(fname) , file=sys.stderr)
         print("*** And use <filename>.nwk as the tree when running 'ancestral', 'translate', and 'traits'", file=sys.stderr)
+    
+    return T
 
+def _read_sequence_data(args: argparse.Namespace, is_vcf: bool) \
+        -> tuple[str|None, VCF_Alignment|str, VCF_Metadata|None]:
+    aln: VCF_Alignment | str
     if is_vcf:
         if not args.vcf_reference:
             raise AugurError("a reference Fasta is required with VCF-format alignments")
         compress_seq = read_vcf(args.alignment, args.vcf_reference)
-        aln = compress_seq['sequences']
-        ref = compress_seq['reference']
-        vcf_metadata = compress_seq['metadata']
+        aln = cast(VCF_Alignment, compress_seq['sequences'])
+        ref = cast(str, compress_seq['reference'])
+        vcf_metadata = cast(VCF_Metadata, compress_seq['metadata'])
     else:
-        aln = args.alignment
+        aln = cast(str, args.alignment)
         ref = None
+        vcf_metadata = None
         if args.root_sequence:
             for fmt in ['fasta', 'genbank']:
                 try:
@@ -407,76 +402,124 @@ def run(args):
             if ref is None:
                 raise AugurError(f"could not read root sequence from {args.root_sequence}")
 
+    return (ref, aln, vcf_metadata)
+
+def _to_ancestral_json(anc: Ancestral_Reconstruction) -> Ancestral_JSON:
+    """Convert the results of a nucleotide ancestral reconstruction into the JSON
+    format used by other augur tools"""
+    root_seq = anc['root_seq']
+    j: Ancestral_JSON = {
+        'annotations': {
+            'nuc': {'start': 1, 'end': len(root_seq), 'strand': '+', 'type': 'source'},
+        },
+        'reference': {'nuc': root_seq,},
+        'nodes': anc['mutations']['nodes'],
+    }
+    if anc['mutations']['mask'] is not None:
+        j['mask'] = "".join(['1' if x else '0' for x in anc["mutations"]["mask"]])
+    return j
+
+def reconstruct_translations(
+    anc_seqs: Ancestral_JSON,
+    ref: str|None,
+    T: Tree,
+    genes_arg: list[str], # filename or list of genes
+    annotation_fname: str,
+    translations_fname_pattern: str,
+    infer_ambiguous: bool,
+    fill_overhangs: bool,
+    marginal: bool,
+    rng_seed: int,
+    output_fname_pattern: str|None,
+):
+    genes = parse_genes_argument(genes_arg)
+    if genes is None or not len(genes):
+        raise AugurError("Empty list of genes provided")
+
+    ## load features; only requested features if genes given
+    from .io.sequences import load_features
+    features = load_features(annotation_fname, genes)
+    
+    # Ensure the already-created nuc annotation coordinates match those parsed from the reference file
+    if (features['nuc'].location.start+1 != anc_seqs['annotations']['nuc']['start'] or
+        features['nuc'].location.end != anc_seqs['annotations']['nuc']['end']):
+        raise AugurError(f"The 'nuc' annotation coordinates parsed from {annotation_fname!r} ({features['nuc'].location.start+1}..{features['nuc'].location.end})"
+            f" don't match the provided sequence data coordinates ({anc_seqs['annotations']['nuc']['start']}..{anc_seqs['annotations']['nuc']['end']}).")
+
+    print("Read in {} features from reference sequence file".format(len(features)))
+    for gene in genes:
+        print(f"Processing gene: {gene}")
+        fname = translations_fname_pattern.replace("%GENE", gene)
+        feat = features[gene]
+        reference_sequence = str(feat.extract(Seq(ref)).translate()) if ref else None
+
+        aa_result = run_ancestral(T, fname, reference_sequence=reference_sequence, is_vcf=False, fill_overhangs=fill_overhangs,
+                                    marginal=marginal, infer_ambiguous=infer_ambiguous, alphabet='aa', rng_seed=rng_seed)
+        len_translated_alignment = aa_result['tt'].data.full_length*3
+        if len_translated_alignment != len(feat):
+            raise AugurError(f"length of translated alignment for {gene} ({len_translated_alignment})"
+                    f" does not match length of reference feature ({len(feat)})."
+                    " Please make sure that the annotation matches the translations.")
+
+        for key, node in anc_seqs['nodes'].items():
+            if 'aa_muts' not in node:
+                node['aa_muts'] = {}
+            node['aa_muts'][gene] = aa_result['mutations']['nodes'][key]['muts']
+
+            # Add amino acid sequences to the root node of the tree.
+            if key == T.root.name:
+                if "aa_sequences" not in node:
+                    node["aa_sequences"] = {}
+
+                node["aa_sequences"][gene] = aa_result['tt'].sequence(T.root, as_string=True, reconstructed=True)
+
+        anc_seqs['reference'][gene] = aa_result['root_seq']
+        anc_seqs['annotations'].update(genome_features_to_auspice_annotation({gene: feat}, annotation_fname))
+
+        # For each translated gene, save ancestral amino acid sequences to FASTA
+        if output_fname_pattern:
+            with open_file(output_fname_pattern.replace("%GENE", gene), "w") as oh:
+                for node in aa_result["tt"].tree.find_clades():
+                    oh.write(f">{node.name}\n{aa_result['tt'].sequence(node, as_string=True, reconstructed=True)}\n")
+
+
+def run(args: argparse.Namespace):
+
+    # check alignment type, set flags, read in if VCF
+    is_vcf = is_filename_vcf(args.alignment)
+    validate_arguments(args, is_vcf)
+
+    T = _read_tree(args.tree)
+    ref, aln, vcf_metadata = _read_sequence_data(args, is_vcf)
+
+
     import treetime
     print("\nInferred ancestral sequence states using TreeTime:"
           "\n\tSagulenko et al. TreeTime: Maximum-likelihood phylodynamic analysis"
           "\n\tVirus Evolution, vol 4, https://academic.oup.com/ve/article/4/1/vex042/4794731\n")
-
     print(f"augur ancestral is using TreeTime version {treetime.version}")
 
     # Infer ambiguous bases if the user has requested that we infer them (either
     # explicitly or by default) and the user has not explicitly requested that
     # we keep them.
-    infer_ambiguous = args.infer_ambiguous and not args.keep_ambiguous
-    full_sequences = not is_vcf
-    nuc_result = run_ancestral(T, aln, reference_sequence=ref if ref else None, is_vcf=is_vcf, fill_overhangs=not args.keep_overhangs,
-                               full_sequences=full_sequences, marginal=args.inference, infer_ambiguous=infer_ambiguous, alphabet='nuc',
-                               rng_seed=args.seed)
-    anc_seqs = nuc_result['mutations']
-    anc_seqs['reference'] = {'nuc': nuc_result['root_seq']}
+    infer_ambiguous = bool(args.infer_ambiguous and not args.keep_ambiguous)
+    rng_seed: int = args.seed
+    fill_overhangs = not args.keep_overhangs
+    marginal_inference = bool(args.inference=='marginal')
+    
+    anc = run_ancestral(T, aln, reference_sequence=ref if ref else None, is_vcf=is_vcf, fill_overhangs=fill_overhangs,
+                        full_sequences=not is_vcf, marginal=marginal_inference, infer_ambiguous=infer_ambiguous, alphabet='nuc',
+                        rng_seed=rng_seed)
+    anc_seqs = _to_ancestral_json(anc)
 
-    if anc_seqs.get("mask") is not None:
-        anc_seqs["mask"] = "".join(['1' if x else '0' for x in anc_seqs["mask"]])
+    # If genes are provided then read the already-translated (AA) FASTAs and reconstruct across the tree
+    # Results are stored in the provided `anc_seqs` object and written to FASTA if requested
+    if args.genes:
+        assert not is_vcf # guaranteed by validate_arguments() but good to double check   
+        reconstruct_translations(anc_seqs, ref, T, args.genes, args.annotation, args.translations,
+            infer_ambiguous, fill_overhangs, marginal_inference, rng_seed,
+            args.output_translations)
 
-    anc_seqs['annotations'] = {'nuc': {'start': 1, 'end': len(anc_seqs['reference']['nuc']),
-                                       'strand': '+', 'type': 'source'}}
-
-    if not is_vcf and args.genes:
-        genes = parse_genes_argument(args.genes)
-
-        from .io.sequences import load_features
-        ## load features; only requested features if genes given
-        features = load_features(args.annotation, genes)
-        # Ensure the already-created nuc annotation coordinates match those parsed from the reference file
-        if (features['nuc'].location.start+1 != anc_seqs['annotations']['nuc']['start'] or
-            features['nuc'].location.end != anc_seqs['annotations']['nuc']['end']):
-            raise AugurError(f"The 'nuc' annotation coordinates parsed from {args.annotation!r} ({features['nuc'].location.start+1}..{features['nuc'].location.end})"
-                f" don't match the provided sequence data coordinates ({anc_seqs['annotations']['nuc']['start']}..{anc_seqs['annotations']['nuc']['end']}).")
-
-        print("Read in {} features from reference sequence file".format(len(features)))
-        for gene in genes:
-            print(f"Processing gene: {gene}")
-            fname = args.translations.replace("%GENE", gene)
-            feat = features[gene]
-            reference_sequence = str(feat.extract(Seq(ref)).translate()) if ref else None
-
-            aa_result = run_ancestral(T, fname, reference_sequence=reference_sequence, is_vcf=is_vcf, fill_overhangs=not args.keep_overhangs,
-                                        marginal=args.inference, infer_ambiguous=infer_ambiguous, alphabet='aa', rng_seed=args.seed)
-            len_translated_alignment = aa_result['tt'].data.full_length*3
-            if len_translated_alignment != len(feat):
-                raise AugurError(f"length of translated alignment for {gene} ({len_translated_alignment})"
-                       f" does not match length of reference feature ({len(feat)})."
-                       " Please make sure that the annotation matches the translations.")
-
-            for key, node in anc_seqs['nodes'].items():
-                if 'aa_muts' not in node: node['aa_muts'] = {}
-                node['aa_muts'][gene] = aa_result['mutations']['nodes'][key]['muts']
-
-                # Add amino acid sequences to the root node of the tree.
-                if key == T.root.name:
-                    if "aa_sequences" not in node:
-                        node["aa_sequences"] = {}
-
-                    node["aa_sequences"][gene] = aa_result['tt'].sequence(T.root, as_string=True, reconstructed=True)
-
-            anc_seqs['reference'][gene] = aa_result['root_seq']
-            anc_seqs['annotations'].update(genome_features_to_auspice_annotation({gene: feat}, args.annotation))
-
-            # Save ancestral amino acid sequences to FASTA.
-            if args.output_translations:
-                with open_file(args.output_translations.replace("%GENE", gene), "w") as oh:
-                    for node in aa_result["tt"].tree.find_clades():
-                        oh.write(f">{node.name}\n{aa_result['tt'].sequence(node, as_string=True, reconstructed=True)}\n")
 
     out_name = get_json_name(args, '.'.join(args.alignment.split('.')[:-1]) + '_mutations.json')
     # use NodeDataObject to perform validation on the file before it's written
@@ -497,9 +540,9 @@ def run(args):
     # output VCF including new ancestral seqs
     if args.output_vcf:
         assert is_vcf
-        tree_dict = nuc_result['tt'].get_tree_dict(keep_var_ambigs=not infer_ambiguous)
+        tree_dict = anc['tt'].get_tree_dict(keep_var_ambigs=not infer_ambiguous)
         tree_dict['metadata'] = vcf_metadata
-        write_vcf(tree_dict, args.output_vcf, anc_seqs['mask'])
+        write_vcf(tree_dict, args.output_vcf, anc_seqs.get('mask'))
         print("Mutations, including for ancestral nodes, exported as VCF to", args.output_vcf, file=sys.stdout)
 
     return 0

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -32,6 +32,7 @@ from Bio.Phylo.BaseTree import Tree  # type: ignore[import-untyped]
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from .translate import safe_translate
 from .utils import parse_genes_argument, read_tree, InvalidTreeError, write_augur_json, get_json_name, \
     genome_features_to_auspice_annotation
 from .io.file import open_file
@@ -42,6 +43,7 @@ from .argparse_ import add_validation_arguments
 from .util_support.node_data_file import NodeDataObject
 from typing import cast, Any, Callable, TypedDict
 from typing_extensions import NotRequired
+from math import floor
 
 VCF_Alignment = dict[str, dict[int, str]]
 
@@ -362,6 +364,9 @@ def register_parser(parent_subparsers):
                            "Currently only supported for FASTA-input. Specify the file name via a "
                            "template like 'aa_sequences_%%GENE.fasta' where %%GENE will be replaced "
                            "by the gene name.")
+    amino_acid_options_group.add_argument('--report-inconsistent-translation', action="store_true",
+                                help='Report where amino acid reconstruction differed from a translation of the reconstructed nuc sequence')
+
 
     # ----------------------------- OUTPUTS ----------------------------- 
     output_group = parser.add_argument_group(
@@ -465,6 +470,53 @@ def _to_ancestral_json(anc: Ancestral_Reconstruction) -> Ancestral_JSON:
         j['mask'] = "".join(['1' if x else '0' for x in anc["mutations"]["mask"]])
     return j
 
+def _validate_translated_consistency(anc_seqs, aa_result, feat, gene, T):
+    """Compare the independently reconstructed AA sequences with translations
+    of the reconstructed nucleotide sequences for a given gene. Reports any
+    inconsistencies as warnings.
+
+    Parameters
+    ----------
+    anc_seqs : Ancestral_JSON
+        Contains reconstructed nucleotide sequences for all nodes.
+    aa_result : Ancestral_Reconstruction
+        The independent AA reconstruction for this gene.
+    feat : Bio.SeqFeature.SeqFeature
+        The gene feature, used to extract the nucleotide region.
+    gene : str
+        Gene name, for reporting.
+    T : Bio.Phylo.BaseTree.Tree
+        The tree (used to iterate over all nodes).
+    """
+    nodes_with_differences = {'tips': 0, 'internal': 0}
+    difference_counts: list[int] = []
+
+    for node in T.find_clades():
+        nuc_seq = anc_seqs['nodes'].get(node.name, {}).get('sequence')
+        assert nuc_seq is not None
+        nuc_translated = safe_translate(str(feat.extract(Seq(nuc_seq))))
+        # re-reconstruct the inferred protein sequence since we don't store them on anc_seqs
+        aa_seq = aa_result['tt'].sequence(node, as_string=True, reconstructed=True)
+        assert len(aa_seq)==len(nuc_translated)
+    
+        if nuc_translated != aa_seq:
+            nodes_with_differences["tips" if node.is_terminal() else "internal"] += 1
+            difference_counts.append(sum(c1!=c2 for c1,c2 in zip(nuc_translated, aa_seq)))
+
+    if len(difference_counts) > 0:
+        difference_counts.sort()
+        median = difference_counts[floor(len(difference_counts)/2)]
+        print(
+            f"WARNING: gene {gene!r} has differences between the independently reconstructed"
+            f" amino acid sequence and a translation of the reconstructed nucleotide sequence."
+            f" {nodes_with_differences['tips']} terminal nodes and"
+            f" {nodes_with_differences['internal']} internal nodes were different."
+            f" Median residue mismatch count: {median:,}"
+            f" (range: {difference_counts[0]:,} - {difference_counts[-1]:,})",
+            file=sys.stderr,
+        )
+
+
 def reconstruct_translations(
     anc_seqs: Ancestral_JSON,
     ref: str|None,
@@ -477,6 +529,7 @@ def reconstruct_translations(
     marginal: bool,
     rng_seed: int,
     output_fname_pattern: str|None,
+    report_inconsistent_translation: bool,
 ):
     genes = parse_genes_argument(genes_arg)
     if genes is None or not len(genes):
@@ -523,6 +576,9 @@ def reconstruct_translations(
                     node["aa_sequences"] = {}
 
                 node["aa_sequences"][gene] = aa_result['tt'].sequence(T.root, as_string=True, reconstructed=True)
+        
+        if report_inconsistent_translation:
+            _validate_translated_consistency(anc_seqs, aa_result, feat, gene, T)
 
         anc_seqs['reference'][gene] = aa_result['root_seq']
         anc_seqs['annotations'].update(genome_features_to_auspice_annotation({gene: feat}, annotation_fname))
@@ -570,7 +626,7 @@ def run(args: argparse.Namespace):
         assert not is_vcf # guaranteed by validate_arguments() but good to double check   
         reconstruct_translations(anc_seqs, ref, T, args.genes, args.annotation, args.translations,
             infer_ambiguous, fill_overhangs, marginal_inference, rng_seed,
-            args.output_translations)
+            args.output_translations, args.report_inconsistent_translation)
 
 
     out_name = get_json_name(args, '.'.join(args.alignment.split('.')[:-1]) + '_mutations.json')

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -29,6 +29,7 @@ import sys
 import numpy as np
 from Bio import SeqIO
 from Bio.Phylo.BaseTree import Tree  # type: ignore[import-untyped]
+from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from .utils import parse_genes_argument, read_tree, InvalidTreeError, write_augur_json, get_json_name, \
@@ -39,7 +40,7 @@ from treetime.vcf_utils import read_vcf, write_vcf
 from collections import defaultdict
 from .argparse_ import add_validation_arguments
 from .util_support.node_data_file import NodeDataObject
-from typing import cast, Any, TypedDict
+from typing import cast, Any, Callable, TypedDict
 from typing_extensions import NotRequired
 
 VCF_Alignment = dict[str, dict[int, str]]
@@ -69,6 +70,65 @@ class Ancestral_JSON(TypedDict):
     mask: NotRequired[str]
     annotations: Annotations_JSON
     nodes: Any
+
+
+def _make_seq_corrector(alphabet: str) -> Callable[[str], str]:
+    """Build a function that replaces invalid or fully-ambiguous characters in a
+    sequence with the standard ambiguous character for the given alphabet
+    ('N' for nuc, 'X' for aa).
+
+    A character is replaced if it is either:
+    - not present in TreeTime's profile_map (i.e. completely unknown), or
+    - fully ambiguous (its profile has equal weight across all states)
+
+    The standard ambiguous character itself (N/X) is kept as-is since it is
+    valid and expected by downstream code such as create_mask.
+    
+    The corrected sequence string will be all uppercase.
+    """
+    from treetime.seq_utils import alphabets, profile_maps
+    profile_map = profile_maps[alphabet]
+    n_states = len(alphabets[alphabet])
+
+    if alphabet == 'nuc':
+        ambiguous_char = 'N'
+    elif alphabet == 'aa':
+        ambiguous_char = 'X'
+    else:
+        raise ValueError(f"Unknown alphabet: {alphabet!r}")
+
+    # Identify characters in the profile_map that are valid and not fully
+    # ambiguous (partially ambiguous IUPAC chars like R, Y are kept)
+    valid = set()
+    for char, profile in profile_map.items():
+        if char == ambiguous_char:
+            valid.add(char)
+        elif sum(profile) < n_states:
+            valid.add(char)
+        # else: fully ambiguous non-standard char → will be replaced
+
+    def correct(seq: str) -> str:
+        seq_upper = seq.upper()
+        if all(c in valid for c in seq_upper):
+            return seq_upper
+        return ''.join(c if c in valid else ambiguous_char for c in seq_upper)
+
+    return correct
+
+
+def correct_alignment(aln_fname: str, correct_seq: Callable[[str], str]) -> MultipleSeqAlignment:
+    """Read an alignment from a FASTA file and correct sequences using the
+    provided correction function (from _make_seq_corrector).
+
+    Returns a MultipleSeqAlignment suitable for passing directly to TreeAnc.
+    """
+    from Bio import AlignIO
+    alignment = AlignIO.read(aln_fname, 'fasta')
+    corrected_records = [
+        SeqRecord(Seq(correct_seq(str(record.seq))), id=record.id, description=record.description)
+        for record in alignment
+    ]
+    return MultipleSeqAlignment(corrected_records)
 
 
 def create_mask(is_vcf, tt, reference_sequence, aln):
@@ -117,7 +177,7 @@ def create_mask(is_vcf, tt, reference_sequence, aln):
         mask = ambiguous_count==num_tips
     return mask
 
-def collect_mutations(tt, mask, character_map=None, reference_sequence=None, infer_ambiguous=False):
+def collect_mutations(tt, mask, reference_sequence=None, infer_ambiguous=False):
     """iterates of the tree and produces dictionaries with
     mutations and sequences for each node.
 
@@ -132,8 +192,6 @@ def collect_mutations(tt, mask, character_map=None, reference_sequence=None, inf
     tt : treetime.TreeTime
         instance of treetime with valid ancestral reconstruction
     mask : numpy.ndarray(bool)
-    character_map : None, optional
-        optional dictionary to map characters to a custom set.
     reference_sequence : str, optional
 
     Returns
@@ -143,25 +201,22 @@ def collect_mutations(tt, mask, character_map=None, reference_sequence=None, inf
         <from><1-based-pos><to>
     """
 
-    if character_map is None:
-        cm = lambda x:x
-    else:
-        cm = lambda x: character_map.get(x, x)
-
     data = {}
     inc = 1 # convert python numbering to start-at-1
 
-    # Note that for mutations reported across the tree we don't have to consider
-    # the mask, because while sites which are all Ns may have an inferred base,
-    # there will be no variablity and thus no mutations.
+    # Masked positions are fully ambiguous columns where the inferred base is
+    # arbitrary; skip any mutations at those positions. This matters when
+    # infer_ambiguous=False because tips retain their ambiguous character while
+    # internal nodes carry an inferred base, producing spurious <inferred>→N
+    # transitions in n.mutations.
     for n in tt.tree.find_clades():
-        data[n.name] = [a+str(int(pos)+inc)+cm(d)
-                        for a,pos,d in n.mutations]
+        data[n.name] = [a+str(int(pos)+inc)+d
+                        for a,pos,d in n.mutations if not mask[int(pos)]]
 
     if reference_sequence:
         data[tt.tree.root.name] = []
         for pos, (root_state, tree_state) in enumerate(zip(reference_sequence, tt.sequence(tt.tree.root, reconstructed=infer_ambiguous, as_string=True))):
-            if mask[pos] and infer_ambiguous:
+            if mask[pos]:
                 continue
             if root_state != tree_state:
                 data[tt.tree.root.name].append(f"{root_state}{pos+1}{tree_state}")
@@ -211,7 +266,7 @@ def collect_sequences(tt, mask, reference_sequence=None, infer_ambiguous=False):
 
 def run_ancestral(
         T:Tree,
-        aln: str|VCF_Alignment,
+        aln: str|VCF_Alignment|MultipleSeqAlignment,
         reference_sequence:str|None=None,
         is_vcf=False,
         full_sequences=False,
@@ -233,15 +288,6 @@ def run_ancestral(
     tt.infer_ancestral_sequences(infer_gtr=True, marginal=marginal,
                                  reconstruct_tip_states=infer_ambiguous, sample_from_profile='root')
 
-
-    character_map = {}
-    for x in tt.gtr.profile_map:
-        if tt.gtr.profile_map[x].sum()==tt.gtr.n_states:
-            # TreeTime treats all characters that are not valid IUPAC nucleotide chars as fully ambiguous
-            # To clean up auspice output, we map all those to 'N'
-            character_map[x] = 'N'
-        else:
-            character_map[x] = x
     # add reference sequence to json structure. This is the sequence with
     # respect to which mutations on the tree are defined.
     if reference_sequence:
@@ -250,7 +296,7 @@ def run_ancestral(
         root_seq = str(tt.sequence(T.root, as_string=True))
 
     mask = create_mask(is_vcf, tt, reference_sequence, aln)
-    mutations = collect_mutations(tt, mask, character_map, reference_sequence, infer_ambiguous)
+    mutations = collect_mutations(tt, mask, reference_sequence, infer_ambiguous)
     sequences = {}
     if full_sequences:
         sequences = collect_sequences(tt, mask, reference_sequence, infer_ambiguous)
@@ -379,17 +425,17 @@ def _read_tree(fname: str) -> Tree:
     return T
 
 def _read_sequence_data(args: argparse.Namespace, is_vcf: bool) \
-        -> tuple[str|None, VCF_Alignment|str, VCF_Metadata|None]:
-    aln: VCF_Alignment | str
+        -> tuple[str|None, VCF_Alignment|MultipleSeqAlignment, VCF_Metadata|None]:
+    correct_nuc = _make_seq_corrector('nuc')
     if is_vcf:
         if not args.vcf_reference:
             raise AugurError("a reference Fasta is required with VCF-format alignments")
         compress_seq = read_vcf(args.alignment, args.vcf_reference)
-        aln = cast(VCF_Alignment, compress_seq['sequences'])
+        aln: VCF_Alignment | MultipleSeqAlignment = cast(VCF_Alignment, compress_seq['sequences'])
         ref = cast(str, compress_seq['reference'])
         vcf_metadata = cast(VCF_Metadata, compress_seq['metadata'])
     else:
-        aln = cast(str, args.alignment)
+        aln = correct_alignment(args.alignment, correct_nuc)
         ref = None
         vcf_metadata = None
         if args.root_sequence:
@@ -401,6 +447,8 @@ def _read_sequence_data(args: argparse.Namespace, is_vcf: bool) \
                     pass
             if ref is None:
                 raise AugurError(f"could not read root sequence from {args.root_sequence}")
+    if ref:
+        ref = correct_nuc(ref)
 
     return (ref, aln, vcf_metadata)
 
@@ -446,14 +494,19 @@ def reconstruct_translations(
         raise AugurError(f"The 'nuc' annotation coordinates parsed from {annotation_fname!r} ({features['nuc'].location.start+1}..{features['nuc'].location.end})"
             f" don't match the provided sequence data coordinates ({anc_seqs['annotations']['nuc']['start']}..{anc_seqs['annotations']['nuc']['end']}).")
 
+    correct_aa = _make_seq_corrector('aa')
+
     print("Read in {} features from reference sequence file".format(len(features)))
     for gene in genes:
         print(f"Processing gene: {gene}")
         fname = translations_fname_pattern.replace("%GENE", gene)
         feat = features[gene]
         reference_sequence = str(feat.extract(Seq(ref)).translate()) if ref else None
+        if reference_sequence:
+            reference_sequence = correct_aa(reference_sequence)
 
-        aa_result = run_ancestral(T, fname, reference_sequence=reference_sequence, is_vcf=False, fill_overhangs=fill_overhangs,
+        aa_aln = correct_alignment(fname, correct_aa)
+        aa_result = run_ancestral(T, aa_aln, reference_sequence=reference_sequence, is_vcf=False, fill_overhangs=fill_overhangs,
                                     marginal=marginal, infer_ambiguous=infer_ambiguous, alphabet='aa', rng_seed=rng_seed)
         len_translated_alignment = aa_result['tt'].data.full_length*3
         if len_translated_alignment != len(feat):
@@ -490,6 +543,7 @@ def run(args: argparse.Namespace):
     validate_arguments(args, is_vcf)
 
     T = _read_tree(args.tree)
+    # read sequence data, correcting any invalid nucleotide states
     ref, aln, vcf_metadata = _read_sequence_data(args, is_vcf)
 
 

--- a/augur/ancestral.py
+++ b/augur/ancestral.py
@@ -319,6 +319,7 @@ def run_ancestral(
 def register_parser(parent_subparsers):
     parser = parent_subparsers.add_parser("ancestral", help=__doc__)
 
+    # ----------------------------- INPUTS ----------------------------- 
     input_group = parser.add_argument_group(
         "inputs",
         "Tree and sequences to use for ancestral reconstruction"
@@ -333,6 +334,7 @@ def register_parser(parent_subparsers):
                                  help='[FASTA alignment only] file of the sequence that is used as root for mutation calling.'
                                       ' Differences between this sequence and the inferred root will be reported as mutations on the root branch.')
 
+    # ----------------------------- GLOBAL OPTIONS -----------------------------
     global_options_group = parser.add_argument_group(
         "global options",
         "Options to configure reconstruction of both nucleotide and amino acid sequences"
@@ -340,19 +342,15 @@ def register_parser(parent_subparsers):
     global_options_group.add_argument('--inference', default='joint', choices=["joint", "marginal"],
                                     help="calculate joint or marginal maximum likelihood ancestral sequence states")
     global_options_group.add_argument('--seed', type=int, help="seed for random number generation")
-
-    nucleotide_options_group = parser.add_argument_group(
-        "nucleotide options",
-        "Options to configure reconstruction of ancestral nucleotide sequences"
-    )
-    ambiguous = nucleotide_options_group.add_mutually_exclusive_group()
+    ambiguous = global_options_group.add_mutually_exclusive_group()
     ambiguous.add_argument('--keep-ambiguous', action="store_true",
-                                help='do not infer nucleotides at ambiguous (N) sites on tip sequences (leave as N).')
+                                help='do not infer ambiguous states on tip sequences')
     ambiguous.add_argument('--infer-ambiguous', action="store_true", default=True,
-                                help='infer nucleotides at ambiguous (N,W,R,..) sites on tip sequences and replace with most likely state.')
-    nucleotide_options_group.add_argument('--keep-overhangs', action="store_true", default=False,
-                                help='do not infer nucleotides for gaps (-) on either side of the alignment')
+                                help='infer ambiguous states on tip sequences and replace with most likely state')
+    global_options_group.add_argument('--keep-overhangs', action="store_true", default=False,
+                                help='do not infer states for gaps (-) on either side of the alignment')
 
+    # ------------------- AMINO-ACID (TRANSLATION) OPTIONS ONLY ------------------------ 
     amino_acid_options_group = parser.add_argument_group(
         "amino acid options",
         "Options to configure reconstruction of ancestral amino acid sequences. All arguments are required for ancestral amino acid sequence reconstruction."
@@ -365,6 +363,7 @@ def register_parser(parent_subparsers):
                            "template like 'aa_sequences_%%GENE.fasta' where %%GENE will be replaced "
                            "by the gene name.")
 
+    # ----------------------------- OUTPUTS ----------------------------- 
     output_group = parser.add_argument_group(
         "outputs",
         "Outputs supported for reconstructed ancestral sequences"
@@ -376,9 +375,8 @@ def register_parser(parent_subparsers):
                         "the gene name.")
     output_group.add_argument('--output-vcf', type=str, help='name of output VCF file which will include ancestral seqs')
 
-    general_group = parser.add_argument_group(
-        "general",
-    )
+    # ----------------------------- GENERAL / MISC ----------------------------- 
+    general_group = parser.add_argument_group("general",)
     add_validation_arguments(general_group)
 
     return parser

--- a/augur/utils.py
+++ b/augur/utils.py
@@ -551,7 +551,7 @@ def read_entries(*files, comment_char="#"):
     return entries
 
 
-def parse_genes_argument(input):
+def parse_genes_argument(input) -> None|list[str]:
     if input is None:
         return None
 
@@ -563,7 +563,7 @@ def parse_genes_argument(input):
     return input
 
 
-def _get_genes_from_file(fname):
+def _get_genes_from_file(fname) -> list[str]:
     if os.path.isfile(fname):
         genes = read_entries(fname)
     else:
@@ -575,7 +575,7 @@ def _get_genes_from_file(fname):
         print("You have duplicates in your genes file. They are being ignored.")
     print("Read in {} specified genes to translate.".format(len(unique_genes)))
 
-    return unique_genes
+    return list(unique_genes)
 
 
 

--- a/tests/functional/ancestral/cram/infer-ambiguous-nucleotides.t
+++ b/tests/functional/ancestral/cram/infer-ambiguous-nucleotides.t
@@ -15,3 +15,166 @@ There should not be N bases in the inferred output sequences.
 
   $ grep "^N" "$CRAMTMP/$TESTFILE/ancestral_sequences.fasta"
   [1]
+
+test ambiguous bases remain in seqs and muts if we use `--keep-ambiguous`
+The ambiguous nuc 'Y' (representing a 'T' or 'C') should be reported as a mutation on the sample_C branch
+and  also remain in the resulting sequence.
+
+  $ cat > aln_pos3Y.fasta <<EOF
+  > >sample_A
+  > AAGAA
+  > >sample_B
+  > AAGAA
+  > >sample_C
+  > AAYAA
+  > EOF
+
+  $ ${AUGUR} ancestral --seed 0 \
+  >  --keep-ambiguous \
+  >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3Y.fasta \
+  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" \
+  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_1.fasta" &> /dev/null
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" | jq -c '.nodes.sample_C.muts'
+  ["C3Y"]
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" | jq -c '.nodes.sample_C.sequence'
+  "AAYAA"
+
+  $ grep 'sample_C' -A 1 "$CRAMTMP/$TESTFILE/ancestral_sequences_1.fasta"
+  >sample_C
+  AAYAA
+
+
+Same test as above but using `--infer-ambiguous` (the default) infers Y as either T or C as appropriate
+
+  $ ${AUGUR} ancestral --seed 0 \
+  >  --infer-ambiguous \
+  >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3Y.fasta \
+  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_2.json" \
+  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_2.fasta" &> /dev/null
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_2.json" | jq -c '.nodes.sample_C.muts'
+  []
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_2.json" | jq -c '.nodes.sample_C.sequence'
+  "AACAA"
+
+  $ grep 'sample_C' -A 1 "$CRAMTMP/$TESTFILE/ancestral_sequences_2.fasta"
+  >sample_C
+  AACAA
+
+
+Test the ambiguous nucleotide "X" is turned into a "N" with --keep-ambiguous
+'X' has a flat profile map in treetime and thus is considered ambiguous.
+Ensure it's reported as "N" regardless of whether we infer ambiguous states or not
+and reported in both sequences and mutations. Note that the parent state
+(i.e. the "G" in "G3N" below) is not the focus of this test!
+
+  $ cat > aln_pos3X.fasta <<EOF
+  > >sample_A
+  > AAGAA
+  > >sample_B
+  > AAGAA
+  > >sample_C
+  > AAXAA
+  > EOF
+
+  $ ${AUGUR} ancestral --seed 0 \
+  >  --keep-ambiguous \
+  >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3X.fasta \
+  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_3.json" \
+  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_3.fasta" &> /dev/null
+
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_3.json" | jq -c '.nodes.sample_C.muts'
+  ["G3N"]
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_3.json" | jq -c '.nodes.sample_C.sequence'
+  "AANAA"
+
+  $ grep 'sample_C' -A 1 "$CRAMTMP/$TESTFILE/ancestral_sequences_3.fasta"
+  >sample_C
+  AANAA
+
+Test the ambiguous nucleotide "X" is turned into one of A/T/G/C with --infer-ambiguous
+Note the specific inferred state (TreeTime chooses 'G') is not the focus of the test here.
+Note 2: TreeTime chooses the root state as G as well, so there's no mutation on sample_C
+
+  $ ${AUGUR} ancestral --seed 0 \
+  >  --infer-ambiguous \
+  >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3X.fasta \
+  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json" \
+  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_4.fasta" &> /dev/null
+
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json" | jq -c '.nodes.sample_C.muts'
+  []
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json" | jq -c '.nodes.sample_C.sequence'
+  "AAGAA"
+
+  $ grep 'sample_C' -A 1 "$CRAMTMP/$TESTFILE/ancestral_sequences_4.fasta"
+  >sample_C
+  AAGAA
+
+
+Test the ambiguous nucleotide "X" on internal nodes is turned into an "N"  with --keep-ambiguous
+When all descendant tips of an internal node have 'X' at a position, the internal node's sequence
+should report 'N' (the standard ambiguous nucleotide) when we're not inferring ambiguous bases.
+
+  $ cat > aln_pos3X_internal.fasta <<EOF
+  > >sample_A
+  > AAXAA
+  > >sample_B
+  > AAXAA
+  > >sample_C
+  > AAXAA
+  > EOF
+
+  $ ${AUGUR} ancestral --seed 0 \
+  >  --keep-ambiguous \
+  >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3X_internal.fasta \
+  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_5.json" \
+  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_5.fasta" &> /dev/null
+
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_5.json" | jq -c '.nodes.node_AB.sequence'
+  "AANAA"
+
+
+For a fully ambiguous column (all Ns) and a reference with 'X' (also ambiguous)
+we shouldn't report a mutation at the root!
+(Internally, the position is masked in the reconstruction, but masked root mutations are still checked.
+The reference 'X' at pos 3 should be equivalent to 'N')
+
+  $ cat > aln_col3N.fasta <<EOF
+  > >sample_A
+  > AANAA
+  > >sample_B
+  > AANAA
+  > >sample_C
+  > AANAA
+  > EOF
+
+  $ cat > ref_pos3X.fasta <<EOF
+  > >ref
+  > AAXAA
+  > EOF
+
+  $ ${AUGUR} ancestral --seed 0 \
+  >  --keep-ambiguous \
+  >  --root-sequence ref_pos3X.fasta \
+  >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_col3N.fasta \
+  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_6.json" \
+  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_6.fasta" &> /dev/null
+
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_6.json" | jq -c '[.nodes[].sequence] | unique'
+  ["AANAA"]
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_6.json" | jq -c '[.nodes[].muts[]]'
+  []
+
+  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_6.json" | jq -c '.reference.nuc'
+  "AANAA"

--- a/tests/test_ancestral.py
+++ b/tests/test_ancestral.py
@@ -35,7 +35,7 @@ class TestRootNodeMutationAssignment:
     def default_augur_args(self):
         return {
             'fill_overhangs': True, # augur default
-            'marginal': 'joint', # augur default
+            'marginal': False, # augur default -- `bool(args.inference=='marginal')`
             'alphabet': 'nuc', # augur default
             'rng_seed': 0,
         }

--- a/tests/test_ancestral.py
+++ b/tests/test_ancestral.py
@@ -2,6 +2,9 @@ from augur.ancestral import run_ancestral
 from io import StringIO
 from Bio import Phylo
 import pytest
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+from Bio.Align import MultipleSeqAlignment
 
 def gather_mutations_at_pos(pos, nuc_result):
     """pos is 1-based"""
@@ -43,9 +46,6 @@ class TestRootNodeMutationAssignment:
 
     @pytest.fixture()
     def fasta_aln(self):
-        from Bio.Seq import Seq
-        from Bio.SeqRecord import SeqRecord
-        from Bio.Align import MultipleSeqAlignment
         aln = MultipleSeqAlignment(
             [
                 SeqRecord(Seq("AANATA"), id="sample_A"),
@@ -92,3 +92,127 @@ class TestRootNodeMutationAssignment:
         nuc_result = run_ancestral(T=tree, aln=vcf_aln, reference_sequence=ref, is_vcf=is_vcf, full_sequences=not is_vcf, infer_ambiguous=True, **default_augur_args)
         assert(nuc_result['root_seq'] == ref)
         assert(gather_mutations_at_pos(3, nuc_result)==[])
+
+
+class TestAmbiguousAAReconstruction:
+    # NOTE: these tests may be better expressed in `cram`, following `tests/functional/ancestral/cram/infer-ambiguous-nucleotides.t`,
+    # once `augur ancestral` can perform AA inference without needing nuc sequences.
+    # See <https://github.com/nextstrain/augur/pull/1975#discussion_r3002628926> for more discussion
+    
+    # See <https://www.bioinformatics.org/sms/iupac.html> for ambiguous bases.
+
+    @pytest.fixture
+    def tree(self):
+        t = "(sample_C:0.02,(sample_B:0.02,sample_A:0.02)node_AB:0.06)node_root:0.02;"
+        T = Phylo.read(StringIO(t), 'newick')
+        return T
+
+    @pytest.fixture
+    def generic_args(self):
+        """Generic args to run_ancestral"""
+        # Note: `augur ancestral` doesn't report full_sequences, but we want to test that here
+        args = {"reference_sequence": None, "is_vcf": False, "full_sequences": True,
+            "fill_overhangs": True, "marginal": False, "alphabet": 'aa', "rng_seed": 0}
+        return args
+
+    @pytest.mark.xfail  # TODO XXX - fix bug - we report I3N mutation, because N is hardcoded as ambiguous (nuc!) base, but N = Asn = Asparagine 
+    def test_unknown_aa_is_x(self, tree, generic_args):
+        """
+        Ensure we treat "X" as the ambiguous AA residue, not N (N = Asn = Asparagine)
+        """
+        aln = MultipleSeqAlignment([
+            SeqRecord(Seq("IIXII"), id="sample_A"),
+            SeqRecord(Seq("IIIII"), id="sample_B"),
+            SeqRecord(Seq("IIIII"), id="sample_C"),
+        ])
+        result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=False)
+        sample_a = result['mutations']['nodes']['sample_A']
+        assert sample_a['sequence'][2] == 'X'
+        pos3_muts = gather_mutations_at_pos(3, result)
+        assert len(pos3_muts)==1
+        assert pos3_muts[0] == "I3X"
+    
+    def test_unknown_aa_is_reconstructed(self, tree, generic_args):
+        """
+        Ensure "X" (the ambiguous AA residue) is reconstructed
+        """
+        aln = MultipleSeqAlignment([
+            SeqRecord(Seq("IIXII"), id="sample_A"),
+            SeqRecord(Seq("IIIII"), id="sample_B"),
+            SeqRecord(Seq("IIIII"), id="sample_C"),
+        ])
+        result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=True)
+        sample_a = result['mutations']['nodes']['sample_A']
+        assert sample_a['sequence'][2] == 'I'
+        pos3_muts = gather_mutations_at_pos(3, result)
+        assert len(pos3_muts)==0
+    
+    @pytest.mark.xfail
+    def test_invalid_residues_are_replaced_with_X(self, tree, generic_args):
+        """
+        Ensure "J" (invalid) is replaced with "X" (the ambiguous AA residue)
+        """
+        aln = MultipleSeqAlignment([
+            SeqRecord(Seq("IIJII"), id="sample_A"),
+            SeqRecord(Seq("IIIII"), id="sample_B"),
+            SeqRecord(Seq("IIIII"), id="sample_C"),
+        ])
+        result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=False)
+        sample_a = result['mutations']['nodes']['sample_A']
+        
+        # The invalid J in position 3 (idx 2) has been corrected to X
+        assert sample_a['sequence'][2] == 'X'
+        pos3_muts = gather_mutations_at_pos(3, result)
+        assert len(pos3_muts)==1
+        assert pos3_muts[0] == "I3X"
+
+    def test_ambiguous_residues_are_passed_through(self, tree, generic_args):
+        """
+        Ensure "Z" (Glx = Glutamic acid (E) or Glutamine (Q)) is passed though
+        """
+        aln = MultipleSeqAlignment([
+            SeqRecord(Seq("IIZII"), id="sample_A"),
+            SeqRecord(Seq("IIIII"), id="sample_B"),
+            SeqRecord(Seq("IIIII"), id="sample_C"),
+        ])
+        result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=False)
+        sample_a = result['mutations']['nodes']['sample_A']
+        
+        # The valid Z in position 3 (idx 2)
+        assert sample_a['sequence'][2] == 'Z'
+        pos3_muts = gather_mutations_at_pos(3, result)
+        assert len(pos3_muts)==1
+        assert pos3_muts[0].endswith("Z")
+
+    def test_invalid_residues_are_inferred(self, tree, generic_args):
+        """
+        Ensure "J" (invalid) is inferred (to I, as that's what every other residue is at this pos)
+        """
+        aln = MultipleSeqAlignment([
+            SeqRecord(Seq("IIJII"), id="sample_A"),
+            SeqRecord(Seq("IIIII"), id="sample_B"),
+            SeqRecord(Seq("IIIII"), id="sample_C"),
+        ])
+        result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=True)
+        sample_a = result['mutations']['nodes']['sample_A']
+        
+        assert sample_a['sequence'][2] == 'I'
+        pos3_muts = gather_mutations_at_pos(3, result)
+        assert len(pos3_muts)==0
+        
+    def test_ambiguous_residues_are_inferred(self, tree, generic_args):
+        """
+        Ensure "Z" (Glx = Glutamic acid (E) or Glutamine (Q)) is inferred as E or Q
+        """
+        aln = MultipleSeqAlignment([
+            SeqRecord(Seq("IIZII"), id="sample_A"),
+            SeqRecord(Seq("IIIII"), id="sample_B"),
+            SeqRecord(Seq("IIIII"), id="sample_C"),
+        ])
+        result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=True)
+        sample_a = result['mutations']['nodes']['sample_A']
+        
+        assert sample_a['sequence'][2] in ['E', 'Q']
+        pos3_muts = gather_mutations_at_pos(3, result)
+        assert len(pos3_muts)==1
+        assert pos3_muts[0] in ['I3E', 'I3Q']

--- a/tests/test_ancestral.py
+++ b/tests/test_ancestral.py
@@ -1,10 +1,27 @@
-from augur.ancestral import run_ancestral
+from augur.ancestral import run_ancestral, _make_seq_corrector
 from io import StringIO
 from Bio import Phylo
 import pytest
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Align import MultipleSeqAlignment
+
+
+correctors = {
+    'nuc': _make_seq_corrector("nuc"),
+    'aa':  _make_seq_corrector("aa"),
+}
+
+def corrected_alignment(alphabet:str, data: list[tuple[str,str]]):
+    """
+    Helper function to return a MultipleSeqAlignment of corrected sequence
+    strings, where invalid states are replaced by the appropriate ambiguous
+    character. This approach is used when reading data in `augur ancestral`
+    """
+    return MultipleSeqAlignment(
+        [SeqRecord(Seq(correctors[alphabet](d[1])), d[0]) for d in data]
+    )
+    
 
 def gather_mutations_at_pos(pos, nuc_result):
     """pos is 1-based"""
@@ -115,15 +132,14 @@ class TestAmbiguousAAReconstruction:
             "fill_overhangs": True, "marginal": False, "alphabet": 'aa', "rng_seed": 0}
         return args
 
-    @pytest.mark.xfail  # TODO XXX - fix bug - we report I3N mutation, because N is hardcoded as ambiguous (nuc!) base, but N = Asn = Asparagine 
     def test_unknown_aa_is_x(self, tree, generic_args):
         """
         Ensure we treat "X" as the ambiguous AA residue, not N (N = Asn = Asparagine)
         """
-        aln = MultipleSeqAlignment([
-            SeqRecord(Seq("IIXII"), id="sample_A"),
-            SeqRecord(Seq("IIIII"), id="sample_B"),
-            SeqRecord(Seq("IIIII"), id="sample_C"),
+        aln = corrected_alignment('aa', [
+            ("sample_A", "IIXII"),
+            ("sample_B", "IIIII"),
+            ("sample_C", "IIIII"),
         ])
         result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=False)
         sample_a = result['mutations']['nodes']['sample_A']
@@ -136,10 +152,10 @@ class TestAmbiguousAAReconstruction:
         """
         Ensure "X" (the ambiguous AA residue) is reconstructed
         """
-        aln = MultipleSeqAlignment([
-            SeqRecord(Seq("IIXII"), id="sample_A"),
-            SeqRecord(Seq("IIIII"), id="sample_B"),
-            SeqRecord(Seq("IIIII"), id="sample_C"),
+        aln = corrected_alignment('aa', [
+            ("sample_A", "IIXII"),
+            ("sample_B", "IIIII"),
+            ("sample_C", "IIIII"),
         ])
         result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=True)
         sample_a = result['mutations']['nodes']['sample_A']
@@ -147,15 +163,14 @@ class TestAmbiguousAAReconstruction:
         pos3_muts = gather_mutations_at_pos(3, result)
         assert len(pos3_muts)==0
     
-    @pytest.mark.xfail
     def test_invalid_residues_are_replaced_with_X(self, tree, generic_args):
         """
-        Ensure "J" (invalid) is replaced with "X" (the ambiguous AA residue)
+        Ensure "J" (invalid) is replaced with "X" (the ambiguous AA residue).
         """
-        aln = MultipleSeqAlignment([
-            SeqRecord(Seq("IIJII"), id="sample_A"),
-            SeqRecord(Seq("IIIII"), id="sample_B"),
-            SeqRecord(Seq("IIIII"), id="sample_C"),
+        aln = corrected_alignment('aa', [
+            ("sample_A", "IIJII"),
+            ("sample_B", "IIIII"),
+            ("sample_C", "IIIII"),
         ])
         result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=False)
         sample_a = result['mutations']['nodes']['sample_A']
@@ -170,10 +185,10 @@ class TestAmbiguousAAReconstruction:
         """
         Ensure "Z" (Glx = Glutamic acid (E) or Glutamine (Q)) is passed though
         """
-        aln = MultipleSeqAlignment([
-            SeqRecord(Seq("IIZII"), id="sample_A"),
-            SeqRecord(Seq("IIIII"), id="sample_B"),
-            SeqRecord(Seq("IIIII"), id="sample_C"),
+        aln = corrected_alignment('aa', [
+            ("sample_A", "IIZII"),
+            ("sample_B", "IIIII"),
+            ("sample_C", "IIIII"),
         ])
         result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=False)
         sample_a = result['mutations']['nodes']['sample_A']
@@ -188,10 +203,10 @@ class TestAmbiguousAAReconstruction:
         """
         Ensure "J" (invalid) is inferred (to I, as that's what every other residue is at this pos)
         """
-        aln = MultipleSeqAlignment([
-            SeqRecord(Seq("IIJII"), id="sample_A"),
-            SeqRecord(Seq("IIIII"), id="sample_B"),
-            SeqRecord(Seq("IIIII"), id="sample_C"),
+        aln = corrected_alignment('aa', [
+            ("sample_A", "IIJII"),
+            ("sample_B", "IIIII"),
+            ("sample_C", "IIIII"),
         ])
         result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=True)
         sample_a = result['mutations']['nodes']['sample_A']
@@ -204,10 +219,10 @@ class TestAmbiguousAAReconstruction:
         """
         Ensure "Z" (Glx = Glutamic acid (E) or Glutamine (Q)) is inferred as E or Q
         """
-        aln = MultipleSeqAlignment([
-            SeqRecord(Seq("IIZII"), id="sample_A"),
-            SeqRecord(Seq("IIIII"), id="sample_B"),
-            SeqRecord(Seq("IIIII"), id="sample_C"),
+        aln = corrected_alignment('aa', [
+            ("sample_A", "IIZII"),
+            ("sample_B", "IIIII"),
+            ("sample_C", "IIIII"),
         ])
         result = run_ancestral(T=tree, aln=aln, **generic_args, infer_ambiguous=True)
         sample_a = result['mutations']['nodes']['sample_A']


### PR DESCRIPTION
Fixes reconstruction bugs in `augur ancestral`, most notably when we would use the hardcoded 'N' character as the ambiguous state for AA sequences, and thus report erroneous mutations to N = Asn = Asparagine. See added tests for full details.

These bugs were noticed during refactoring as part of #1958, but they are not a result of the refactor. I've cherry-picked them into a new PR as they are unrelated to that work.

I tested on a 5.5k H3N2 HA dataset and there were no occurrences of these bugs implying that they may be rare. (The worst would need ambiguous ("X") states in the translated tip sequences, which nextclade may never produce??)

Relatedly, I've always wanted to check reconstructed translations against what the reconstructed nucleotide sequence would translate to. The final commit indicates mismatches here in an opt-in fashion.