### PR TITLE
merge: Always check for duplicates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* merge: Added a workaround for a bug in SQLite version 3.53.0. [#1984][] @victorlin
+
+[#1984]: https://github.com/nextstrain/augur/pull/1984
 
 ## 33.0.1 (11 March 2026)
 

--- a/augur/merge.py
+++ b/augur/merge.py
@@ -304,8 +304,25 @@ def merge_metadata(args):
             sqlite3(db_path,
                 f'.mode csv',
                 f'.separator {sqlite_quote_dot(m.delimiter)} {sqlite_quote_dot(newline)}',
-                f'.import {sqlite_quote_dot(f"|{augur()} read-file {shquote(m.path)}")} {sqlite_quote_dot(m.table_name)}',
+                f'.import {sqlite_quote_dot(f"|{augur()} read-file {shquote(m.path)}")} {sqlite_quote_dot(m.table_name)}')
 
+            proc = sqlite3(db_path, f"""
+                select {sqlite_quote_id(m.id_column)}
+                from {sqlite_quote_id(m.table_name)}
+                group by {sqlite_quote_id(m.id_column)}
+                having count(*) > 1;
+            """, stdout=subprocess.PIPE)
+
+            if duplicates := proc.stdout.splitlines():
+                raise AugurError(dedent(f"""\
+                    Sequence ids must be unique.
+
+                    The following {_n("id was", "ids were", len(duplicates))} duplicated in metadata table {m.name!r}:
+
+                      {indented_list(map(repr, sorted(duplicates)), '                    ' + '  ')}
+                    """)) from None
+
+            sqlite3(db_path,
                 f'create unique index {sqlite_quote_id(f"{m.table_name}_id")} on {sqlite_quote_id(m.table_name)}({sqlite_quote_id(m.id_column)});',
 
                 # <https://sqlite.org/pragma.html#pragma_optimize>
@@ -375,26 +392,6 @@ def merge_metadata(args):
             f'.output')
 
     except SQLiteError as err:
-        # Check for duplicates
-        try:
-            proc = sqlite3(db_path, f"""
-                select {sqlite_quote_id(m.id_column)}
-                from {sqlite_quote_id(m.table_name)}
-                group by {sqlite_quote_id(m.id_column)}
-                having count(*) > 1;
-            """, stdout=subprocess.PIPE)
-
-            if duplicates := proc.stdout.splitlines():
-                raise AugurError(dedent(f"""\
-                    Sequence ids must be unique.
-
-                    The following {_n("id was", "ids were", len(duplicates))} duplicated in metadata table {m.name!r}:
-
-                      {indented_list(map(repr, sorted(duplicates)), '                    ' + '  ')}
-                    """)) from None
-        except SQLiteError:
-            pass
-
         # Unknown SQLite error
         delete_db = False
         if err.proc.stderr:


### PR DESCRIPTION
## Description of proposed changes

Instead of checking only upon SQLite errors.

SQLite 3.53.0 changed behavior such that the process return code now only reflects the result of the last command string.¹ With the last command always being a successful `pragma optimize`, the earlier unique index creation no longer raises SQLiteError.

¹ https://sqlite.org/forum/forumpost/6fa3247e97

## Related issue(s)

Fixes test errors in CI.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
