### PR TITLE
Only run docs CI on schedule or code change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -361,12 +361,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  build-docs:
-    uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master
-    with:
-      docs-directory: docs/
-      pip-install-target: .[dev]
-
   check-docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,27 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths: &paths
+      - docs/**
+      - setup.py
+      - .github/workflows/docs.yaml
+
+  pull_request:
+    paths: *paths
+
+  workflow_dispatch:
+
+  # Routinely check that we continue to work in the face of external changes.
+  schedule:
+    # Every Monday at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
+    - cron: "42 17 * * 1"
+
+jobs:
+  ci:
+    uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master
+    with:
+      docs-directory: docs/
+      pip-install-target: .[dev]


### PR DESCRIPTION
## Description of proposed changes

Previously, docs CI was run on every code change, even when docs were untouched. This tended to generate noise with many false positives.

Scheduled runs still catch when any existing links break, but at a weekly frequency so that any false positives are less noisy.

## Related issue(s)

- https://github.com/nextstrain/.github/issues/116

## Checklist

- [x] This PR has a "Docs / ci / build" check
- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update