### PR TITLE
docs: Turn off Sphinx Smart Quote dash transformations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,10 @@ html_css_files = [
     'css/custom.css',
 ]
 
+# Default action is "qDe", we are customizing to turn off the dash transformations.
+# See <https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-smart-quotes>
+smartquotes_action = "qe"
+
 # -- Resolve build warnings --------------------------------------------------
 
 nitpick_ignore = [


### PR DESCRIPTION
## Description of proposed changes

To minimize the changes, I'm only removing the Smart Quote transformation for dashes. If we determine that we don't want any Smart Quote transformations, we can turn it all off with `smartquotes = False`.

<img width="1866" height="231" alt="Screenshot 2026-05-11 at 10 52 01 AM" src="https://github.com/user-attachments/assets/5b0ba33d-8a6f-4910-8458-1e5a075e239b" />


## Related issue(s)

Prompted by discussion of docs on [Slack](https://bedfordlab.slack.com/archives/C7SDVPBLZ/p1778429376730979)

## Checklist

- [x] Automated checks pass (failed pathogen test unrelated)
- [x] ~[Check][1] if you need to add a changelog message~ doc style changes only
- [x] ~[Check][2] if you need to add tests~
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
