### PR TITLE
docs: Use custom formatter class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,13 @@
 ### Features
 
 * Support treetime 0.12.* [#1986][]
-    
+
+### Bug fixes
+
+* Improved formatting of command line help text. [#313][], [#1630][] @victorlin
+
+[#313]: https://github.com/nextstrain/augur/issues/313
+[#1630]: https://github.com/nextstrain/augur/issues/1630
 [#1986]: https://github.com/nextstrain/augur/pull/1986
 
 ## 33.1.0 (22 April 2026)

--- a/LICENSE.nextstrain-cli
+++ b/LICENSE.nextstrain-cli
@@ -1,8 +1,10 @@
 This license applies to the original copy of functions from the Nextstrain CLI
 project into this project, namely
 
+- everything in "augur/rst/__init__.py"
+- everything in "augur/rst/sphinx.py" (see also LICENSE.sphinx)
 - resource functions incorporated as "augur/data/__init__.py"
-- walk_commands() function incorporated into "augur/argparse_.py"
+- walk_commands() function and HelpFormatter class incorporated into "augur/argparse_.py"
 
 Any subsequent modifications to this project's copy of these functions are
 licensed under the license of this project, not of Nextstrain CLI.

--- a/LICENSE.sphinx
+++ b/LICENSE.sphinx
@@ -1,0 +1,30 @@
+This license applies to the original copy of code from the Sphinx project
+(version 4.3.2) into this project as "augur/rst/sphinx.py" with modifications
+from Nextstrain CLI. Subsequent modifications to this project's copy are
+licensed under the GNU AGPL 3.0 license of this project.
+
+Copyright (c) 2007-2022 by the Sphinx team (see AUTHORS file).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/augur/__init__.py
+++ b/augur/__init__.py
@@ -14,7 +14,7 @@ from treetime import TreeTimeError, TreeTimeUnknownError
 from .debug import DEBUGGING
 from .errors import AugurError
 from .io.print import print_err
-from .argparse_ import add_command_subparsers, add_default_command
+from .argparse_ import HelpFormatter, add_command_subparsers, add_default_command
 
 DEFAULT_AUGUR_RECURSION_LIMIT = 10000
 sys.setrecursionlimit(int(os.environ.get("AUGUR_RECURSION_LIMIT") or DEFAULT_AUGUR_RECURSION_LIMIT))
@@ -54,7 +54,8 @@ command_strings = [
 def make_parser():
     parser = argparse.ArgumentParser(
         prog        = "augur",
-        description = "Augur: A bioinformatics toolkit for phylogenetic analysis.")
+        description = "Augur: A bioinformatics toolkit for phylogenetic analysis.",
+        formatter_class = HelpFormatter)
 
     add_default_command(parser)
     add_version_alias(parser)

--- a/augur/argparse_.py
+++ b/augur/argparse_.py
@@ -33,6 +33,16 @@ def add_default_command(parser):
     parser.set_defaults(__command__ = default_command)
 
 
+def add_subparser(parent_subparsers: _SubParsersAction, *args, **kwargs) -> ArgumentParser:
+    """
+    Add a subparser to a parent subparser.
+    """
+    # Use the same formatting class for every command for consistency.
+    kwargs.setdefault("formatter_class", ArgumentDefaultsHelpFormatter)
+
+    return parent_subparsers.add_parser(*args, **kwargs)
+
+
 def add_command_subparsers(subparsers, commands, command_attribute='__command__'):
     """
     Add subparsers for each command module.

--- a/augur/argparse_.py
+++ b/augur/argparse_.py
@@ -4,7 +4,7 @@ Custom helpers for the argparse standard library.
 import os
 from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentParser, _ArgumentGroup, _SubParsersAction
 from itertools import chain
-from textwrap import indent as indent_text
+from textwrap import dedent, indent as indent_text
 from typing import Iterable, Optional, Tuple, Union
 from .rst import rst_to_text
 from .types import ValidationMode
@@ -160,7 +160,7 @@ def add_validation_arguments(parser: Union[ArgumentParser, _ArgumentGroup]):
         type=ValidationMode,
         choices=[mode for mode in ValidationMode],
         default=ValidationMode.ERROR,
-        help="""
+        help=dedent("""\
             Control if optional validation checks are performed and what
             happens if they fail.
 
@@ -172,7 +172,7 @@ def add_validation_arguments(parser: Union[ArgumentParser, _ArgumentGroup]):
 
             Note that some validation checks are non-optional and as such are
             not affected by this setting.
-        """)
+        """))
     parser.add_argument(
         '--skip-validation',
         dest="validation_mode",

--- a/augur/argparse_.py
+++ b/augur/argparse_.py
@@ -1,9 +1,12 @@
 """
 Custom helpers for the argparse standard library.
 """
+import os
 from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentParser, _ArgumentGroup, _SubParsersAction
 from itertools import chain
+from textwrap import indent as indent_text
 from typing import Iterable, Optional, Tuple, Union
+from .rst import rst_to_text
 from .types import ValidationMode
 
 
@@ -19,6 +22,45 @@ from .types import ValidationMode
 # Copied from the Nextstrain CLI repo
 # https://github.com/nextstrain/cli/blob/017c53805e8317951327d24c04184615cc400b09/nextstrain/cli/argparse.py#L13-L21
 SKIP_AUTO_DEFAULT_IN_HELP = "%(default).0s"
+
+
+class HelpFormatter(ArgumentDefaultsHelpFormatter):
+    def __init__(self, prog, indent_increment = 2, max_help_position = 24, width = None):
+        # Ignore terminal size, unlike standard argparse, as the readability of
+        # paragraphs of text suffers at wide widths.  Instead, default to 78
+        # columns (80 wide - 2 column gutter), but let that be overridden by an
+        # explicit COLUMNS variable or reduced by a smaller actual terminal.
+        if width is None:
+            try:
+                width = int(os.environ["COLUMNS"])
+            except (KeyError, ValueError):
+                try:
+                    width = min(os.get_terminal_size().columns, 80) - 2
+                except (AttributeError, OSError):
+                    width = 80 - 2
+
+        super().__init__(prog, indent_increment, max_help_position, width)
+
+    # Based on argparse.RawDescriptionHelpFormatter's implementation
+    def _fill_text(self, text, width, indent):
+        return indent_text(rst_to_text(text, width), prefix=indent)
+
+    # Based on argparse.RawTextHelpFormatter's implementation
+    def _split_lines(self, text, width):
+        # Render to rST here so rST gets control over wrapping/line breaks.
+        return rst_to_text(text, width).splitlines()
+
+    # Emit blank lines between arguments for better readability.  It might seem
+    # simpler to override _join_parts() instead, but that's called from two
+    # places and we only want to join on newlines for one of those places.
+    def add_arguments(self, actions):
+        for i, action in enumerate(actions):
+            if i != 0:
+                # Use " \n" to avoid a completely empty line (e.g. "\n") for
+                # the sake ShowBriefHelp.truncate_help()'s heuristic.
+                self._add_item(str, [" \n"])
+
+            self.add_argument(action)
 
 
 def add_default_command(parser):
@@ -38,7 +80,7 @@ def add_subparser(parent_subparsers: _SubParsersAction, *args, **kwargs) -> Argu
     Add a subparser to a parent subparser.
     """
     # Use the same formatting class for every command for consistency.
-    kwargs.setdefault("formatter_class", ArgumentDefaultsHelpFormatter)
+    kwargs.setdefault("formatter_class", HelpFormatter)
 
     return parent_subparsers.add_parser(*args, **kwargs)
 
@@ -72,7 +114,7 @@ def add_command_subparsers(subparsers, commands, command_attribute='__command__'
 
         # Use the same formatting class for every command for consistency.
         # Set here to avoid repeating it in every command's register_parser().
-        subparser.formatter_class = ArgumentDefaultsHelpFormatter
+        subparser.formatter_class = HelpFormatter
 
         if not subparser.description and command.__doc__:
             subparser.description = command.__doc__

--- a/augur/filter/__init__.py
+++ b/augur/filter/__init__.py
@@ -11,6 +11,7 @@ VCFtools is used behind the scenes to handle VCF files, but this should be
 considered an implementation detail that may change in the future.  The CLI
 program vcftools must be available on PATH.
 """
+from textwrap import dedent
 from augur.argparse_ import ExtendOverwriteDefault, SKIP_AUTO_DEFAULT_IN_HELP
 from augur.dates import numeric_date_type
 from augur.filter.arguments import descriptions
@@ -63,10 +64,11 @@ def register_arguments(parser):
     probabilistic_sampling_group.add_argument('--probabilistic-sampling', action='store_true', help=descriptions['probabilistic_sampling'])
     probabilistic_sampling_group.add_argument('--no-probabilistic-sampling', action='store_false', dest='probabilistic_sampling')
     subsample_group.add_argument('--group-by-weights', type=str, metavar="FILE", help=descriptions['group_by_weights'])
-    subsample_group.add_argument('--priority', type=str, help="""tab-delimited file with list of priority scores for strains (e.g., "<strain>\\t<priority>") and no header.
-    When scores are provided, Augur converts scores to floating point values, sorts strains within each subsampling group from highest to lowest priority, and selects the top N strains per group where N is the calculated or requested number of strains per group.
-    Higher numbers indicate higher priority.
-    Since priorities represent relative values between strains, these values can be arbitrary.""")
+    subsample_group.add_argument('--priority', type=str, help=dedent("""\
+        tab-delimited file with list of priority scores for strains (e.g., "<strain>\\t<priority>") and no header.
+        When scores are provided, Augur converts scores to floating point values, sorts strains within each subsampling group from highest to lowest priority, and selects the top N strains per group where N is the calculated or requested number of strains per group.
+        Higher numbers indicate higher priority.
+        Since priorities represent relative values between strains, these values can be arbitrary."""))
     subsample_group.add_argument('--subsample-seed', type=int, help="random number generator seed to allow reproducible subsampling (with same input data).")
 
     output_group = parser.add_argument_group("outputs", "options related to outputs, at least one of the possible representations of filtered data (--output-sequences, --output-metadata, --output-strains) is required")

--- a/augur/frequencies.py
+++ b/augur/frequencies.py
@@ -2,6 +2,7 @@
 infer frequencies of mutations or clades
 """
 import json, os, sys
+from textwrap import dedent
 import numpy as np
 from Bio import Phylo, AlignIO
 from Bio.Align import MultipleSeqAlignment
@@ -39,9 +40,9 @@ def register_parser(parent_subparsers):
     parser.add_argument("--pivot-interval-units", type=str, default="months", choices=['months', 'weeks'],
                         help="space pivots by months (default) or by weeks")
     parser.add_argument('--min-date', type=numeric_date_type,
-                        help=f"date to begin frequencies calculations; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
+                        help=f"date to begin frequencies calculations; may be specified as:\n\n{SUPPORTED_DATE_HELP_TEXT}")
     parser.add_argument('--max-date', type=numeric_date_type,
-                        help=f"date to end frequencies calculations; may be specified as: {SUPPORTED_DATE_HELP_TEXT}")
+                        help=f"date to end frequencies calculations; may be specified as:\n\n{SUPPORTED_DATE_HELP_TEXT}")
 
     # Tree-specific arguments
     parser.add_argument('--tree', '-t', type=str,
@@ -71,9 +72,10 @@ def register_parser(parent_subparsers):
     parser.add_argument('--minimal-clade-size', type=int, default=0,
                         help="minimal number of tips a clade must have for its diffusion frequencies to be reported")
     parser.add_argument('--minimal-clade-size-to-estimate', type=int, default=10,
-                        help="""minimal number of tips a clade must have for its diffusion frequencies to be estimated
-                                by the diffusion likelihood; all smaller clades will inherit frequencies from their
-                                parents""")
+                        help=dedent("""\
+                            minimal number of tips a clade must have for its diffusion frequencies to be estimated
+                            by the diffusion likelihood; all smaller clades will inherit frequencies from their
+                            parents"""))
     parser.add_argument("--stiffness", type=float, default=10.0, help="parameter penalizing curvature of the frequency trajectory")
     parser.add_argument("--inertia", type=float, default=0.0, help="determines how frequencies continue "
                         "in absense of data (inertia=0 -> go flat, inertia=1.0 -> continue current trend)")

--- a/augur/rst/__init__.py
+++ b/augur/rst/__init__.py
@@ -1,0 +1,312 @@
+"""
+reStructuredText conversion.
+
+.. envvar:: NEXTSTRAIN_RST_STRICT
+
+    If set to any value, then rST parsing is put into strict mode and any
+    warnings and errors are raised as exceptions.
+
+.. envvar:: NEXTSTRAIN_RST_DEBUG
+
+    If set to any value, then rST parsing produces the stringified doctree
+    instead of formatted plain text.  Being able to see the doctree is useful
+    for debugging and making changes to
+    :cls:`~nextstrain.cli.rst.sphinx.TextWriter`.
+
+Originally copied from the Nextstrain CLI project, which is licensed under an
+MIT license. See the LICENSE.nextstrain-cli file distributed alongside this
+project's own LICENSE file.
+
+Any future modifications are licensed under the GNU AGPL 3.0 license of this
+project.
+"""
+import docutils.nodes
+import docutils.readers.standalone
+import docutils.transforms
+import os
+import re
+from docutils.core import publish_string as convert_rst_to_string, publish_doctree as convert_rst_to_doctree
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives import register_directive
+from docutils.parsers.rst.roles import register_local_role
+from docutils.utils import unescape
+from ..__version__ import __version__ as cli_version
+from .sphinx import TextWriter
+
+
+# For dev
+DEBUG = os.environ.get("NEXTSTRAIN_RST_DEBUG", "") != ""
+
+# For CI testing
+STRICT = os.environ.get("NEXTSTRAIN_RST_STRICT", "") != ""
+
+# Ignore rST issues by default as we don't want messages included in output or
+# errors thrown at runtime.  Just do our best to convert.
+REPORT_LEVEL_WARNINGS = 2
+REPORT_LEVEL_NONE = 5
+REPORT_LEVEL = REPORT_LEVEL_WARNINGS if STRICT else REPORT_LEVEL_NONE
+
+REGISTERED = False
+
+# Some of these custom roles are identified by name and specially-processed in
+# our sphinx.TextWriter, e.g. see visit_literal() and visit_Text().
+PREAMBLE = """
+.. role:: command-invocation(literal)
+.. role:: command-reference(literal)
+.. role:: option(literal)
+.. role:: envvar(literal)
+.. role:: kbd(literal)
+.. role:: file(literal)
+.. default-role:: command-invocation
+"""
+
+POSTAMBLE = """
+.. target-notes::
+"""
+
+
+def rst_to_text(source: str, width: int = None) -> str:
+    """
+    Converts rST *source* to plain text.
+
+    Standard Docutils directives, roles, etc. are all supported, along with the
+    following additions:
+
+        * ``:doc:`` reference roles, which resolve to absolute URL references.
+        Automatic title expansion (e.g. like Sphinx's ``:doc:`` role) is not
+        supported.  Intersphinx-like project identifiers may be used as
+        prefixes, if configured in :func:`doc_url`.
+
+    Sphinx directives, roles, etc. are not supported.
+
+    The default role is ``command-invocation`` (a ``literal`` subrole which
+    emits the text surrounded by backticks) instead of ``title-reference``.
+
+    If conversion fails, *source* is returned.  Set
+    :envvar:`NEXTSTRAIN_RST_STRICT` to enable strict conversion and raise
+    exceptions for failures.
+    """
+    global REGISTERED
+    if not REGISTERED:
+        register_directive("envvar", EnvVar)
+        register_local_role("doc", doc_reference_role)
+        REGISTERED = True
+
+    settings = {
+        # Use Unicode strings for I/O, not encoded bytes.
+        "input_encoding": "unicode",
+        "output_encoding": "unicode",
+
+        # Never halt midway, just keep going.
+        "halt_level": REPORT_LEVEL_NONE,
+        "report_level": REPORT_LEVEL,
+        "exit_status_level": REPORT_LEVEL,
+    }
+
+    try:
+        return convert_rst(
+            "\n".join([PREAMBLE, source, POSTAMBLE]),
+            reader = Reader(),
+            writer = TextWriter(width = width),
+            settings_overrides = settings,
+            enable_exit_status = STRICT)
+    except:
+        if STRICT:
+            raise
+        else:
+            # Welp, we tried.  Return the rST input as a last resort.
+            return source
+
+
+def convert_rst(source: str, *, reader, writer, settings_overrides: dict, enable_exit_status: bool) -> str:
+    if DEBUG:
+        return str(
+            convert_rst_to_doctree(
+                source,
+                reader = reader,
+                settings_overrides = settings_overrides,
+                enable_exit_status = enable_exit_status))
+
+    return convert_rst_to_string(
+        source,
+        reader = reader,
+        writer = writer,
+        settings_overrides = settings_overrides,
+        enable_exit_status = enable_exit_status)
+
+
+# See docutils.parsers.rst.Directive and docutils.parsers.rst.directives and
+# submodules for this API and examples.
+class EnvVar(Directive):
+    required_arguments = 1
+    has_content = True
+
+    def run(self):
+        # XXX TODO: Inspect self.state.parent (or similar) and add more items
+        # to that if we're adjacent to a previous envvar directive's list?  Or
+        # maybe it's better to use a docutils Transform to combine them
+        # afterwards?  But either way, it doesn't really matter for our
+        # sphinx.TextWriter, so punting on that.
+        #   -trs, 20 July 2023
+        dl = docutils.nodes.definition_list(rawtext = self.block_text)
+        li = docutils.nodes.definition_list_item()
+        dt = docutils.nodes.term(text = self.arguments[0])
+        dd = docutils.nodes.definition(rawtext = "\n".join(self.content))
+
+        dl += li
+        li += [dt, dd]
+
+        self.state.nested_parse(self.content, self.content_offset, dd)
+
+        return [dl]
+
+
+# See docutils.parsers.rst.roles for this API and examples.
+def doc_reference_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
+    """
+    Docutils role handler for ``:doc:`` references.
+
+    Handles the forms::
+
+        :doc:`foo/bar`
+        :doc:`other-project:foo/bar`
+        :doc:`title <foo/bar>`
+        :doc:`title <other-project:foo/bar>`
+    """
+    # Regexp based on one from sphinx.util.docutils.ReferenceRole.
+    #
+    # \x00 is a docutils escaping that means the "<" was backslash-escaped in rawtext.
+    explicit_title = re.compile(r'^(?P<title>.+?)\s*(?<!\x00)<(?P<target>.*?)>$', re.DOTALL)
+
+    matched = explicit_title.match(text)
+    if matched:
+        title  = unescape(matched["title"])
+        target = unescape(matched["target"])
+    else:
+        title = None
+        target = unescape(text)
+
+    url = doc_url(target)
+
+    return [docutils.nodes.reference(rawtext, title or url, refuri = url, **options)], []
+
+
+def doc_url(target: str) -> str:
+    """
+    Construct the absolute URL for a ``:doc:`` *target*.
+
+    The default project is the Nextstrain CLI, and the URLs produced will be
+    version-specific so they stay relevant and accurate to what someone is
+    running locally.
+
+    *target* may be prefixed with a known project identifier (à la
+    Intersphinx).
+
+    If :envvar:`NEXTSTRAIN_RST_STRICT` is set, then an exception will be raised
+    for an unknown project identifier in *target*.  Otherwise, *target* is
+    returned as-is if unrecognized.
+    """
+    # Remove any +local part from the version (e.g. +git development versions)
+    # since those never exist on RTD.
+    cli_doc_version = cli_version.split("+", 1)[0]
+
+    if ":" in target:
+        project, path = target.split(":", 1)
+    else:
+        project, path = None, target
+
+    project_urls = {
+        None: (f"https://docs.nextstrain.org/projects/cli/en/{cli_doc_version}/", ""),
+        "docs": ("https://docs.nextstrain.org/page/", ".html"),
+    }
+
+    project_url, suffix = project_urls.get(project, (None, None))
+
+    if STRICT:
+        assert project_url is not None, f"unknown intersphinx id in :doc: target {target!r}"
+
+    if not project_url:
+        # Oh well.
+        return target
+
+    if path.endswith("/index"):
+        # a/b/index → a/b/ (e.g. implicitly a/b/index.html)
+        path_url = path.removesuffix("index")
+    else:
+        path_url = path + (suffix or "")
+
+    return project_url.rstrip("/") + "/" + path_url.lstrip("/")
+
+
+class Reader(docutils.readers.standalone.Reader):
+    def get_transforms(self):
+        return [*super().get_transforms(), MarkEmbeddedHyperlinkReferencesAnonymous]
+
+
+class MarkEmbeddedHyperlinkReferencesAnonymous(docutils.transforms.Transform):
+    """
+    Mark all hyperlink references with embedded targets as ``anonymous``.
+
+    Hyperlink references with embedded targets [1]_ are syntactically always
+    anonymous references [2]_, but the standard parser only marks them as
+    anonymous if they refer to a separate anonymous target (i.e. don't embed
+    the target using angle brackets) [3]_.  Presumably this is because such
+    anonymous reference and anonymous target pairs need special processing that
+    anonymous references with embedded targets don't [4]_.
+
+    For our use, we want these embedded-target references to be picked up by
+    the :cls:`docutils.transforms.references.TargetNotes` transform, which
+    requires them to be marked anonymous.
+
+    .. [1] https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#embedded-uris-and-aliases
+    .. [2] https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#anonymous-hyperlinks
+    .. [3] https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/parsers/rst/states.py#l859 (see phrase_ref() method)
+    .. [4] See :cls:`docutils.transforms.references.AnonymousHyperlinks`.
+
+    >>> rst_to_text('`foo <https://example.com/foo>`__')
+    'foo [1]\\n\\n[1] https://example.com/foo\\n'
+
+    >>> rst_to_text('''
+    ... `bar <https://example.com/bar>`_
+    ... `baz <bar_>`_
+    ... ''')
+    'bar [1] baz [1]\\n\\n[1] https://example.com/bar\\n'
+
+    >>> rst_to_text('just a link, https://example.com/standalone, sitting right there')
+    'just a link, https://example.com/standalone, sitting right there\\n'
+    """
+
+    # After other hyperlink reference processing, but before TargetNotes runs
+    # and before other target processing removes "refname" attributes.  See:
+    # https://docutils.sourceforge.io/docs/ref/transforms.html#transforms-listed-in-priority-order
+    default_priority = 480
+
+    def apply(self):
+        for ref in self.findall(docutils.nodes.reference):
+            # Not embedded if it's got a refname, which refers to a target
+            # name.
+            if ref.get("refname"):
+                continue
+
+            # We only care about external (refuri) not internal (refid) links.
+            if not ref.get("refuri"):
+                continue
+
+            # Skip standalone hyperlinks where the link text is the URL itself
+            # since duplicating them in a footnote doesn't make much sense.
+            if ref.get("refuri") == ref.astext().strip():
+                continue
+
+            # Some refs by this point will already be marked anonymous, but
+            # there's no harm in marking "again".
+            ref["anonymous"] = 1
+
+    @property
+    def findall(self):
+        try:
+            # docutils 0.18.1 started issuing a PendingDeprecationWarning for
+            # calls to traverse(), so use the findall() method introduced in
+            # that same version when we can.
+            return self.document.findall
+        except AttributeError:
+            return self.document.traverse

--- a/augur/rst/__init__.py
+++ b/augur/rst/__init__.py
@@ -1,7 +1,7 @@
 """
 reStructuredText conversion.
 
-.. envvar:: NEXTSTRAIN_RST_STRICT
+.. envvar:: AUGUR_RST_STRICT
 
     If set to any value, then rST parsing is put into strict mode and any
     warnings and errors are raised as exceptions.
@@ -11,7 +11,7 @@ reStructuredText conversion.
     If set to any value, then rST parsing produces the stringified doctree
     instead of formatted plain text.  Being able to see the doctree is useful
     for debugging and making changes to
-    :cls:`~nextstrain.cli.rst.sphinx.TextWriter`.
+    :cls:`~augur.rst.sphinx.TextWriter`.
 
 Originally copied from the Nextstrain CLI project, which is licensed under an
 MIT license. See the LICENSE.nextstrain-cli file distributed alongside this
@@ -30,7 +30,7 @@ from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import register_directive
 from docutils.parsers.rst.roles import register_local_role
 from docutils.utils import unescape
-from ..__version__ import __version__ as cli_version
+from ..__version__ import __version__ as augur_version
 from .sphinx import TextWriter
 
 
@@ -38,7 +38,7 @@ from .sphinx import TextWriter
 DEBUG = os.environ.get("NEXTSTRAIN_RST_DEBUG", "") != ""
 
 # For CI testing
-STRICT = os.environ.get("NEXTSTRAIN_RST_STRICT", "") != ""
+STRICT = os.environ.get("AUGUR_RST_STRICT", "") != ""
 
 # Ignore rST issues by default as we don't want messages included in output or
 # errors thrown at runtime.  Just do our best to convert.
@@ -83,7 +83,7 @@ def rst_to_text(source: str, width: int = None) -> str:
     emits the text surrounded by backticks) instead of ``title-reference``.
 
     If conversion fails, *source* is returned.  Set
-    :envvar:`NEXTSTRAIN_RST_STRICT` to enable strict conversion and raise
+    :envvar:`AUGUR_RST_STRICT` to enable strict conversion and raise
     exceptions for failures.
     """
     global REGISTERED
@@ -195,20 +195,20 @@ def doc_url(target: str) -> str:
     """
     Construct the absolute URL for a ``:doc:`` *target*.
 
-    The default project is the Nextstrain CLI, and the URLs produced will be
+    The default project is Augur, and the URLs produced will be
     version-specific so they stay relevant and accurate to what someone is
     running locally.
 
     *target* may be prefixed with a known project identifier (à la
     Intersphinx).
 
-    If :envvar:`NEXTSTRAIN_RST_STRICT` is set, then an exception will be raised
+    If :envvar:`AUGUR_RST_STRICT` is set, then an exception will be raised
     for an unknown project identifier in *target*.  Otherwise, *target* is
     returned as-is if unrecognized.
     """
     # Remove any +local part from the version (e.g. +git development versions)
     # since those never exist on RTD.
-    cli_doc_version = cli_version.split("+", 1)[0]
+    augur_doc_version = augur_version.split("+", 1)[0]
 
     if ":" in target:
         project, path = target.split(":", 1)
@@ -216,7 +216,7 @@ def doc_url(target: str) -> str:
         project, path = None, target
 
     project_urls = {
-        None: (f"https://docs.nextstrain.org/projects/cli/en/{cli_doc_version}/", ""),
+        None: (f"https://docs.nextstrain.org/projects/augur/en/{augur_doc_version}/", ""),
         "docs": ("https://docs.nextstrain.org/page/", ".html"),
     }
 

--- a/augur/rst/sphinx.py
+++ b/augur/rst/sphinx.py
@@ -1,0 +1,1262 @@
+# mypy: ignore-errors
+"""
+rST to plain text implementation.
+
+Originally copied from the Nextstrain CLI project, which is licensed under an
+MIT license. See the LICENSE.nextstrain-cli file distributed alongside this
+project's own LICENSE file.
+
+Nextstrain CLI had originally copied from the Sphinx project (version 4.3.2),
+which is licensed under a BSD 2-clause license. See the LICENSE.sphinx file
+distributed alongside this project's own LICENSE file.
+
+Any future modifications are licensed under the GNU AGPL 3.0 license of this
+project.
+"""
+import math
+import re
+import textwrap
+from itertools import chain, groupby
+from typing import (Any, Dict, Generator, Iterable, List, Optional, Set, Tuple, Union, cast)
+
+from docutils import nodes, writers
+from docutils.nodes import Element, Node, Text
+from docutils.utils import column_width
+
+
+MAXWIDTH = 80
+STDINDENT = 4
+
+
+# Stubs taking the place of a full Sphinx builder with config and what not.
+# The builder in Sphinx is a global context object ("god object") which isn't
+# very amenable to extraction.
+class TextConfig:
+    text_sectionchars = '*=-~"+`'
+    text_add_secnumbers = False   # Sphinx default is True, but we don't want 'em.
+    text_secnumber_suffix = ". "  # referenced but not used because above is False.
+    text_max_width = MAXWIDTH
+
+class TextBuilder:
+    config = TextConfig()
+    secnumbers: Dict = {}
+
+
+# Originally from sphinx/util/docutils.py (version 4.3.2)
+class SphinxTranslator(nodes.NodeVisitor):
+    """A base class for Sphinx translators.
+
+    This class adds a support for visitor/departure method for super node class
+    if visitor/departure method for node class is not found.
+
+    It also provides helper methods for Sphinx translators.
+
+    .. note:: The subclasses of this class might not work with docutils.
+              This class is strongly coupled with Sphinx.
+    """
+
+    def __init__(self, document: nodes.document, builder) -> None:
+        super().__init__(document)
+        self.builder = builder
+        self.config = builder.config
+        self.settings = document.settings
+
+    def dispatch_visit(self, node: Node) -> None:
+        """
+        Dispatch node to appropriate visitor method.
+        The priority of visitor method is:
+
+        1. ``self.visit_{node_class}()``
+        2. ``self.visit_{super_node_class}()``
+        3. ``self.unknown_visit()``
+        """
+        for node_class in node.__class__.__mro__:
+            method = getattr(self, 'visit_%s' % (node_class.__name__), None)
+            if method:
+                method(node)
+                break
+        else:
+            super().dispatch_visit(node)
+
+    def dispatch_departure(self, node: Node) -> None:
+        """
+        Dispatch node to appropriate departure method.
+        The priority of departure method is:
+
+        1. ``self.depart_{node_class}()``
+        2. ``self.depart_{super_node_class}()``
+        3. ``self.unknown_departure()``
+        """
+        for node_class in node.__class__.__mro__:
+            method = getattr(self, 'depart_%s' % (node_class.__name__), None)
+            if method:
+                method(node)
+                break
+        else:
+            super().dispatch_departure(node)
+
+
+# Originally from sphinx/writers/text.py (version 4.3.2)
+class Cell:
+    """Represents a cell in a table.
+    It can span multiple columns or multiple lines.
+    """
+    def __init__(self, text: str = "", rowspan: int = 1, colspan: int = 1) -> None:
+        self.text = text
+        self.wrapped: List[str] = []
+        self.rowspan = rowspan
+        self.colspan = colspan
+        self.col: Optional[int] = None
+        self.row: Optional[int] = None
+
+    def __repr__(self) -> str:
+        return "<Cell {!r} {}v{}/{}>{}>".format(
+            self.text, self.row, self.rowspan, self.col, self.colspan
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.col, self.row))
+
+    def wrap(self, width: int) -> None:
+        self.wrapped = my_wrap(self.text, width)
+
+
+class Table:
+    """Represents a table, handling cells that can span multiple lines
+    or rows, like::
+
+       +-----------+-----+
+       | AAA       | BBB |
+       +-----+-----+     |
+       |     | XXX |     |
+       |     +-----+-----+
+       | DDD | CCC       |
+       +-----+-----------+
+
+    This class can be used in two ways, either:
+
+    - With absolute positions: call ``table[line, col] = Cell(...)``,
+      this overwrites any existing cell(s) at these positions.
+
+    - With relative positions: call the ``add_row()`` and
+      ``add_cell(Cell(...))`` as needed.
+
+    Cells spanning multiple rows or multiple columns (having a
+    colspan or rowspan greater than one) are automatically referenced
+    by all the table cells they cover. This is a useful
+    representation as we can simply check
+    ``if self[x, y] is self[x, y+1]`` to recognize a rowspan.
+
+    Colwidth is not automatically computed, it has to be given, either
+    at construction time, or during the table construction.
+
+    Example usage::
+
+       table = Table([6, 6])
+       table.add_cell(Cell("foo"))
+       table.add_cell(Cell("bar"))
+       table.set_separator()
+       table.add_row()
+       table.add_cell(Cell("FOO"))
+       table.add_cell(Cell("BAR"))
+       print(table)
+       +--------+--------+
+       | foo    | bar    |
+       |========|========|
+       | FOO    | BAR    |
+       +--------+--------+
+
+    """
+    def __init__(self, colwidth: List[int] = None) -> None:
+        self.lines: List[List[Cell]] = []
+        self.separator = 0
+        self.colwidth: List[int] = (colwidth if colwidth is not None else [])
+        self.current_line = 0
+        self.current_col = 0
+
+    def add_row(self) -> None:
+        """Add a row to the table, to use with ``add_cell()``.  It is not needed
+        to call ``add_row()`` before the first ``add_cell()``.
+        """
+        self.current_line += 1
+        self.current_col = 0
+
+    def set_separator(self) -> None:
+        """Sets the separator below the current line."""
+        self.separator = len(self.lines)
+
+    def add_cell(self, cell: Cell) -> None:
+        """Add a cell to the current line, to use with ``add_row()``.  To add
+        a cell spanning multiple lines or rows, simply set the
+        ``cell.colspan`` or ``cell.rowspan`` BEFORE inserting it into
+        the table.
+        """
+        while self[self.current_line, self.current_col]:
+            self.current_col += 1
+        self[self.current_line, self.current_col] = cell
+        self.current_col += cell.colspan
+
+    def __getitem__(self, pos: Tuple[int, int]) -> Cell:
+        line, col = pos
+        self._ensure_has_line(line + 1)
+        self._ensure_has_column(col + 1)
+        return self.lines[line][col]
+
+    def __setitem__(self, pos: Tuple[int, int], cell: Cell) -> None:
+        line, col = pos
+        self._ensure_has_line(line + cell.rowspan)
+        self._ensure_has_column(col + cell.colspan)
+        for dline in range(cell.rowspan):
+            for dcol in range(cell.colspan):
+                self.lines[line + dline][col + dcol] = cell
+                cell.row = line
+                cell.col = col
+
+    def _ensure_has_line(self, line: int) -> None:
+        while len(self.lines) < line:
+            self.lines.append([])
+
+    def _ensure_has_column(self, col: int) -> None:
+        for line in self.lines:
+            while len(line) < col:
+                line.append(None)
+
+    def __repr__(self) -> str:
+        return "\n".join(repr(line) for line in self.lines)
+
+    def cell_width(self, cell: Cell, source: List[int]) -> int:
+        """Give the cell width, according to the given source (either
+        ``self.colwidth`` or ``self.measured_widths``).
+        This takes into account cells spanning multiple columns.
+        """
+        width = 0
+        for i in range(self[cell.row, cell.col].colspan):
+            width += source[cell.col + i]
+        return width + (cell.colspan - 1) * 3
+
+    @property
+    def cells(self) -> Generator[Cell, None, None]:
+        seen: Set[Cell] = set()
+        for lineno, line in enumerate(self.lines):
+            for colno, cell in enumerate(line):
+                if cell and cell not in seen:
+                    yield cell
+                    seen.add(cell)
+
+    def rewrap(self) -> None:
+        """Call ``cell.wrap()`` on all cells, and measure each column width
+        after wrapping (result written in ``self.measured_widths``).
+        """
+        self.measured_widths = self.colwidth[:]
+        for cell in self.cells:
+            cell.wrap(width=self.cell_width(cell, self.colwidth))
+            if not cell.wrapped:
+                continue
+            width = math.ceil(max(column_width(x) for x in cell.wrapped) / cell.colspan)
+            for col in range(cell.col, cell.col + cell.colspan):
+                self.measured_widths[col] = max(self.measured_widths[col], width)
+
+    def physical_lines_for_line(self, line: List[Cell]) -> int:
+        """For a given line, compute the number of physical lines it spans
+        due to text wrapping.
+        """
+        physical_lines = 1
+        for cell in line:
+            physical_lines = max(physical_lines, len(cell.wrapped))
+        return physical_lines
+
+    def __str__(self) -> str:
+        out = []
+        self.rewrap()
+
+        def writesep(char: str = "-", lineno: Optional[int] = None) -> str:
+            """Called on the line *before* lineno.
+            Called with no *lineno* for the last sep.
+            """
+            out: List[str] = []
+            for colno, width in enumerate(self.measured_widths):
+                if (
+                    lineno is not None and
+                    lineno > 0 and
+                    self[lineno, colno] is self[lineno - 1, colno]
+                ):
+                    out.append(" " * (width + 2))
+                else:
+                    out.append(char * (width + 2))
+            head = "+" if out[0][0] == "-" else "|"
+            tail = "+" if out[-1][0] == "-" else "|"
+            glue = [
+                "+" if left[0] == "-" or right[0] == "-" else "|"
+                for left, right in zip(out, out[1:])
+            ]
+            glue.append(tail)
+            return head + "".join(chain.from_iterable(zip(out, glue)))
+
+        for lineno, line in enumerate(self.lines):
+            if self.separator and lineno == self.separator:
+                out.append(writesep("=", lineno))
+            else:
+                out.append(writesep("-", lineno))
+            for physical_line in range(self.physical_lines_for_line(line)):
+                linestr = ["|"]
+                for colno, cell in enumerate(line):
+                    if cell.col != colno:
+                        continue
+                    if lineno != cell.row:
+                        physical_text = ""
+                    elif physical_line >= len(cell.wrapped):
+                        physical_text = ""
+                    else:
+                        physical_text = cell.wrapped[physical_line]
+                    adjust_len = len(physical_text) - column_width(physical_text)
+                    linestr.append(
+                        " " +
+                        physical_text.ljust(
+                            self.cell_width(cell, self.measured_widths) + 1 + adjust_len
+                        ) + "|"
+                    )
+                out.append("".join(linestr))
+        out.append(writesep("-"))
+        return "\n".join(out)
+
+
+class TextWrapper(textwrap.TextWrapper):
+    """Custom subclass that uses a different word separator regex."""
+
+    wordsep_re = re.compile(
+        r'(\s+|'                                  # any whitespace
+        r'(?<=\s)(?::[a-z-]+:)?`\S+|'             # interpreted text start
+        r'[^\s\w]*\w+[a-zA-Z]-(?=\w+[a-zA-Z])|'   # hyphenated words
+        r'(?<=[\w\!\"\'\&\.\,\?])-{2,}(?=\w))')   # em-dash
+
+    def _wrap_chunks(self, chunks: List[str]) -> List[str]:
+        """_wrap_chunks(chunks : [string]) -> [string]
+
+        The original _wrap_chunks uses len() to calculate width.
+        This method respects wide/fullwidth characters for width adjustment.
+        """
+        lines: List[str] = []
+        if self.width <= 0:
+            raise ValueError("invalid width %r (must be > 0)" % self.width)
+
+        chunks.reverse()
+
+        while chunks:
+            cur_line = []
+            cur_len = 0
+
+            if lines:
+                indent = self.subsequent_indent
+            else:
+                indent = self.initial_indent
+
+            width = self.width - column_width(indent)
+
+            if self.drop_whitespace and chunks[-1].strip() == '' and lines:
+                del chunks[-1]
+
+            while chunks:
+                l = column_width(chunks[-1])
+
+                if cur_len + l <= width:
+                    cur_line.append(chunks.pop())
+                    cur_len += l
+
+                else:
+                    break
+
+            if chunks and column_width(chunks[-1]) > width:
+                self._handle_long_word(chunks, cur_line, cur_len, width)
+
+            if self.drop_whitespace and cur_line and cur_line[-1].strip() == '':
+                del cur_line[-1]
+
+            if cur_line:
+                lines.append(indent + ''.join(cur_line))
+
+        return lines
+
+    def _break_word(self, word: str, space_left: int) -> Tuple[str, str]:
+        """_break_word(word : string, space_left : int) -> (string, string)
+
+        Break line by unicode width instead of len(word).
+        """
+        total = 0
+        for i, c in enumerate(word):
+            total += column_width(c)
+            if total > space_left:
+                return word[:i - 1], word[i - 1:]
+        return word, ''
+
+    def _split(self, text: str) -> List[str]:
+        """_split(text : string) -> [string]
+
+        Override original method that only split by 'wordsep_re'.
+        This '_split' splits wide-characters into chunks by one character.
+        """
+        def split(t: str) -> List[str]:
+            return super(TextWrapper, self)._split(t)
+        chunks: List[str] = []
+        for chunk in split(text):
+            for w, g in groupby(chunk, column_width):
+                if w == 1:
+                    chunks.extend(split(''.join(g)))
+                else:
+                    chunks.extend(list(g))
+        return chunks
+
+    def _handle_long_word(self, reversed_chunks: List[str], cur_line: List[str],
+                          cur_len: int, width: int) -> None:
+        """_handle_long_word(chunks : [string],
+                             cur_line : [string],
+                             cur_len : int, width : int)
+
+        Override original method for using self._break_word() instead of slice.
+        """
+        space_left = max(width - cur_len, 1)
+        if self.break_long_words:
+            l, r = self._break_word(reversed_chunks[-1], space_left)
+            cur_line.append(l)
+            reversed_chunks[-1] = r
+
+        elif not cur_line:
+            cur_line.append(reversed_chunks.pop())
+
+
+def my_wrap(text: str, width: int = MAXWIDTH, **kwargs: Any) -> List[str]:
+    w = TextWrapper(width=width, **kwargs)
+    return w.wrap(text)
+
+
+class TextWriter(writers.Writer):
+    supported = ('text',)
+    settings_spec = ('No options here.', '', ())
+    settings_defaults = {}
+
+    output: str = None
+
+    def __init__(self, builder: "TextBuilder" = None, width: int = None) -> None:
+        super().__init__()
+        self.builder = builder or TextBuilder()
+        if width:
+            self.builder.config.text_max_width = width
+
+    def translate(self) -> None:
+        visitor = TextTranslator(self.document, self.builder)
+        self.document.walkabout(visitor)
+        self.output = visitor.body
+
+
+class TextTranslator(SphinxTranslator):
+    builder: "TextBuilder" = None
+
+    def __init__(self, document: nodes.document, builder: "TextBuilder") -> None:
+        super().__init__(document, builder)
+
+        self.nl = '\n'
+        self.sectionchars = self.config.text_sectionchars
+        self.add_secnumbers = self.config.text_add_secnumbers
+        self.secnumber_suffix = self.config.text_secnumber_suffix
+        self.max_width = self.config.text_max_width
+        self.states: List[List[Tuple[int, Union[str, List[str]]]]] = [[]]
+        self.stateindent = [0]
+        self.list_counter: List[int] = []
+        self.sectionlevel = 0
+        self.lineblocklevel = 0
+        self.table: Table = None
+
+    def add_text(self, text: str) -> None:
+        self.states[-1].append((-1, text))
+
+    def new_state(self, indent: int = STDINDENT) -> None:
+        self.states.append([])
+        self.stateindent.append(indent)
+
+    def end_state(self, wrap: bool = True, end: List[str] = [''], first: str = None) -> None:
+        content = self.states.pop()
+        maxindent = sum(self.stateindent)
+        indent = self.stateindent.pop()
+        result: List[Tuple[int, List[str]]] = []
+        toformat: List[str] = []
+
+        def do_format() -> None:
+            if not toformat:
+                return
+            if wrap:
+                res = my_wrap(''.join(toformat), width=self.max_width - maxindent)
+            else:
+                res = ''.join(toformat).splitlines()
+            if end:
+                res += end
+            result.append((indent, res))
+        for itemindent, item in content:
+            if itemindent == -1:
+                toformat.append(item)  # type: ignore
+            else:
+                do_format()
+                result.append((indent + itemindent, item))  # type: ignore
+                toformat = []
+        do_format()
+        if first is not None and result:
+            # insert prefix into first line (ex. *, [1], See also, etc.)
+            newindent = result[0][0] - indent
+            if result[0][1] == ['']:
+                result.insert(0, (newindent, [first]))
+            else:
+                text = first + result[0][1].pop(0)
+                result.insert(0, (newindent, [text]))
+
+        self.states[-1].extend(result)
+
+    def visit_document(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_document(self, node: Element) -> None:
+        self.end_state()
+        self.body = self.nl.join(line and (' ' * indent + line)
+                                 for indent, lines in self.states[0]
+                                 for line in lines)
+        # XXX header/footer?
+
+    def visit_section(self, node: Element) -> None:
+        self._title_char = self.sectionchars[self.sectionlevel]
+        self.sectionlevel += 1
+
+    def depart_section(self, node: Element) -> None:
+        self.sectionlevel -= 1
+
+    def visit_topic(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_topic(self, node: Element) -> None:
+        self.end_state()
+
+    visit_sidebar = visit_topic
+    depart_sidebar = depart_topic
+
+    def visit_rubric(self, node: Element) -> None:
+        self.new_state(0)
+        self.add_text('-[ ')
+
+    def depart_rubric(self, node: Element) -> None:
+        self.add_text(' ]-')
+        self.end_state()
+
+    def visit_compound(self, node: Element) -> None:
+        pass
+
+    def depart_compound(self, node: Element) -> None:
+        pass
+
+    def visit_glossary(self, node: Element) -> None:
+        pass
+
+    def depart_glossary(self, node: Element) -> None:
+        pass
+
+    def visit_title(self, node: Element) -> None:
+        if isinstance(node.parent, nodes.Admonition):
+            self.add_text(node.astext() + ': ')
+            raise nodes.SkipNode
+        self.new_state(0)
+
+    def get_section_number_string(self, node: Element) -> str:
+        if isinstance(node.parent, nodes.section):
+            anchorname = '#' + node.parent['ids'][0]
+            numbers = self.builder.secnumbers.get(anchorname)
+            if numbers is None:
+                numbers = self.builder.secnumbers.get('')
+            if numbers is not None:
+                return '.'.join(map(str, numbers)) + self.secnumber_suffix
+        return ''
+
+    def depart_title(self, node: Element) -> None:
+        if isinstance(node.parent, nodes.section):
+            char = self._title_char
+        else:
+            char = '^'
+        text = ''
+        text = ''.join(x[1] for x in self.states.pop() if x[0] == -1)  # type: ignore
+        if self.add_secnumbers:
+            text = self.get_section_number_string(node) + text
+        self.stateindent.pop()
+        title = ['', text, '%s' % (char * column_width(text)), '']
+        if len(self.states) == 2 and len(self.states[-1]) == 0:
+            # remove an empty line before title if it is first section title in the document
+            title.pop(0)
+        self.states[-1].append((0, title))
+
+    def visit_subtitle(self, node: Element) -> None:
+        pass
+
+    def depart_subtitle(self, node: Element) -> None:
+        pass
+
+    def visit_attribution(self, node: Element) -> None:
+        self.add_text('-- ')
+
+    def depart_attribution(self, node: Element) -> None:
+        pass
+
+    #############################################################
+    # Domain-specific object descriptions
+    #############################################################
+
+    # Top-level nodes
+    #################
+
+    def visit_desc(self, node: Element) -> None:
+        pass
+
+    def depart_desc(self, node: Element) -> None:
+        pass
+
+    def visit_desc_signature(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_desc_signature(self, node: Element) -> None:
+        # XXX: wrap signatures in a way that makes sense
+        self.end_state(wrap=False, end=None)
+
+    def visit_desc_signature_line(self, node: Element) -> None:
+        pass
+
+    def depart_desc_signature_line(self, node: Element) -> None:
+        self.add_text('\n')
+
+    def visit_desc_content(self, node: Element) -> None:
+        self.new_state()
+        self.add_text(self.nl)
+
+    def depart_desc_content(self, node: Element) -> None:
+        self.end_state()
+
+    def visit_desc_inline(self, node: Element) -> None:
+        pass
+
+    def depart_desc_inline(self, node: Element) -> None:
+        pass
+
+    # Nodes for high-level structure in signatures
+    ##############################################
+
+    def visit_desc_name(self, node: Element) -> None:
+        pass
+
+    def depart_desc_name(self, node: Element) -> None:
+        pass
+
+    def visit_desc_addname(self, node: Element) -> None:
+        pass
+
+    def depart_desc_addname(self, node: Element) -> None:
+        pass
+
+    def visit_desc_type(self, node: Element) -> None:
+        pass
+
+    def depart_desc_type(self, node: Element) -> None:
+        pass
+
+    def visit_desc_returns(self, node: Element) -> None:
+        self.add_text(' -> ')
+
+    def depart_desc_returns(self, node: Element) -> None:
+        pass
+
+    def visit_desc_parameterlist(self, node: Element) -> None:
+        self.add_text('(')
+        self.first_param = 1
+
+    def depart_desc_parameterlist(self, node: Element) -> None:
+        self.add_text(')')
+
+    def visit_desc_parameter(self, node: Element) -> None:
+        if not self.first_param:
+            self.add_text(', ')
+        else:
+            self.first_param = 0
+        self.add_text(node.astext())
+        raise nodes.SkipNode
+
+    def visit_desc_optional(self, node: Element) -> None:
+        self.add_text('[')
+
+    def depart_desc_optional(self, node: Element) -> None:
+        self.add_text(']')
+
+    def visit_desc_annotation(self, node: Element) -> None:
+        pass
+
+    def depart_desc_annotation(self, node: Element) -> None:
+        pass
+
+    ##############################################
+
+    def visit_figure(self, node: Element) -> None:
+        self.new_state()
+
+    def depart_figure(self, node: Element) -> None:
+        self.end_state()
+
+    def visit_caption(self, node: Element) -> None:
+        pass
+
+    def depart_caption(self, node: Element) -> None:
+        pass
+
+    def visit_footnote(self, node: Element) -> None:
+        label = cast(nodes.label, node[0])
+        self._footnote = label.astext().strip()
+        self.new_state(len(self._footnote) + 3)
+
+    def depart_footnote(self, node: Element) -> None:
+        self.end_state(first='[%s] ' % self._footnote)
+
+    def visit_citation(self, node: Element) -> None:
+        if len(node) and isinstance(node[0], nodes.label):
+            self._citlabel = node[0].astext()
+        else:
+            self._citlabel = ''
+        self.new_state(len(self._citlabel) + 3)
+
+    def depart_citation(self, node: Element) -> None:
+        self.end_state(first='[%s] ' % self._citlabel)
+
+    def visit_label(self, node: Element) -> None:
+        raise nodes.SkipNode
+
+    def visit_legend(self, node: Element) -> None:
+        pass
+
+    def depart_legend(self, node: Element) -> None:
+        pass
+
+    # XXX: option list could use some better styling
+
+    def visit_option_list(self, node: Element) -> None:
+        pass
+
+    def depart_option_list(self, node: Element) -> None:
+        pass
+
+    def visit_option_list_item(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_option_list_item(self, node: Element) -> None:
+        self.end_state()
+
+    def visit_option_group(self, node: Element) -> None:
+        self._firstoption = True
+
+    def depart_option_group(self, node: Element) -> None:
+        self.add_text('     ')
+
+    def visit_option(self, node: Element) -> None:
+        if self._firstoption:
+            self._firstoption = False
+        else:
+            self.add_text(', ')
+
+    def depart_option(self, node: Element) -> None:
+        pass
+
+    def visit_option_string(self, node: Element) -> None:
+        pass
+
+    def depart_option_string(self, node: Element) -> None:
+        pass
+
+    def visit_option_argument(self, node: Element) -> None:
+        self.add_text(node['delimiter'])
+
+    def depart_option_argument(self, node: Element) -> None:
+        pass
+
+    def visit_description(self, node: Element) -> None:
+        pass
+
+    def depart_description(self, node: Element) -> None:
+        pass
+
+    def visit_tabular_col_spec(self, node: Element) -> None:
+        raise nodes.SkipNode
+
+    def visit_colspec(self, node: Element) -> None:
+        self.table.colwidth.append(node["colwidth"])
+        raise nodes.SkipNode
+
+    def visit_tgroup(self, node: Element) -> None:
+        pass
+
+    def depart_tgroup(self, node: Element) -> None:
+        pass
+
+    def visit_thead(self, node: Element) -> None:
+        pass
+
+    def depart_thead(self, node: Element) -> None:
+        pass
+
+    def visit_tbody(self, node: Element) -> None:
+        self.table.set_separator()
+
+    def depart_tbody(self, node: Element) -> None:
+        pass
+
+    def visit_row(self, node: Element) -> None:
+        if self.table.lines:
+            self.table.add_row()
+
+    def depart_row(self, node: Element) -> None:
+        pass
+
+    def visit_entry(self, node: Element) -> None:
+        self.entry = Cell(
+            rowspan=node.get("morerows", 0) + 1, colspan=node.get("morecols", 0) + 1
+        )
+        self.new_state(0)
+
+    def depart_entry(self, node: Element) -> None:
+        text = self.nl.join(self.nl.join(x[1]) for x in self.states.pop())
+        self.stateindent.pop()
+        self.entry.text = text
+        self.table.add_cell(self.entry)
+        self.entry = None
+
+    def visit_table(self, node: Element) -> None:
+        if self.table:
+            raise NotImplementedError('Nested tables are not supported.')
+        self.new_state(0)
+        self.table = Table()
+
+    def depart_table(self, node: Element) -> None:
+        self.add_text(str(self.table))
+        self.table = None
+        self.end_state(wrap=False)
+
+    def visit_acks(self, node: Element) -> None:
+        bullet_list = cast(nodes.bullet_list, node[0])
+        list_items = cast(Iterable[nodes.list_item], bullet_list)
+        self.new_state(0)
+        self.add_text(', '.join(n.astext() for n in list_items) + '.')
+        self.end_state()
+        raise nodes.SkipNode
+
+    def visit_image(self, node: Element) -> None:
+        if 'alt' in node.attributes:
+            self.add_text('[image: %s]' % node['alt'])
+        self.add_text('[image]')
+        raise nodes.SkipNode
+
+    def visit_transition(self, node: Element) -> None:
+        indent = sum(self.stateindent)
+        self.new_state(0)
+        self.add_text('=' * (self.max_width - indent))
+        self.end_state()
+        raise nodes.SkipNode
+
+    def visit_bullet_list(self, node: Element) -> None:
+        self.list_counter.append(-1)
+
+    def depart_bullet_list(self, node: Element) -> None:
+        self.list_counter.pop()
+
+    def visit_enumerated_list(self, node: Element) -> None:
+        self.list_counter.append(node.get('start', 1) - 1)
+
+    def depart_enumerated_list(self, node: Element) -> None:
+        self.list_counter.pop()
+
+    def visit_definition_list(self, node: Element) -> None:
+        self.list_counter.append(-2)
+
+    def depart_definition_list(self, node: Element) -> None:
+        self.list_counter.pop()
+
+    def visit_list_item(self, node: Element) -> None:
+        if self.list_counter[-1] == -1:
+            # bullet list
+            self.new_state(2)
+        elif self.list_counter[-1] == -2:
+            # definition list
+            pass
+        else:
+            # enumerated list
+            self.list_counter[-1] += 1
+            self.new_state(len(str(self.list_counter[-1])) + 2)
+
+    def depart_list_item(self, node: Element) -> None:
+        if self.list_counter[-1] == -1:
+            self.end_state(first='• ')
+        elif self.list_counter[-1] == -2:
+            pass
+        else:
+            self.end_state(first='%s. ' % self.list_counter[-1])
+
+    def visit_definition_list_item(self, node: Element) -> None:
+        self._classifier_count_in_li = len(list(node.traverse(nodes.classifier)))
+        self.new_state(2)
+
+    def depart_definition_list_item(self, node: Element) -> None:
+        self.end_state()
+
+    def visit_term(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_term(self, node: Element) -> None:
+        if not self._classifier_count_in_li:
+            self.end_state(end=None)
+
+    def visit_classifier(self, node: Element) -> None:
+        self.add_text(' : ')
+
+    def depart_classifier(self, node: Element) -> None:
+        self._classifier_count_in_li -= 1
+        if not self._classifier_count_in_li:
+            self.end_state(end=None)
+
+    def visit_definition(self, node: Element) -> None:
+        self.new_state()
+
+    def depart_definition(self, node: Element) -> None:
+        self.end_state()
+
+    def visit_field_list(self, node: Element) -> None:
+        pass
+
+    def depart_field_list(self, node: Element) -> None:
+        pass
+
+    def visit_field(self, node: Element) -> None:
+        pass
+
+    def depart_field(self, node: Element) -> None:
+        pass
+
+    def visit_field_name(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_field_name(self, node: Element) -> None:
+        self.add_text(':')
+        self.end_state(end=None)
+
+    def visit_field_body(self, node: Element) -> None:
+        self.new_state()
+
+    def depart_field_body(self, node: Element) -> None:
+        self.end_state()
+
+    def visit_centered(self, node: Element) -> None:
+        pass
+
+    def depart_centered(self, node: Element) -> None:
+        pass
+
+    def visit_hlist(self, node: Element) -> None:
+        pass
+
+    def depart_hlist(self, node: Element) -> None:
+        pass
+
+    def visit_hlistcol(self, node: Element) -> None:
+        pass
+
+    def depart_hlistcol(self, node: Element) -> None:
+        pass
+
+    def visit_admonition(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_admonition(self, node: Element) -> None:
+        self.end_state()
+
+    def _visit_admonition(self, node: Element) -> None:
+        self.new_state(2)
+
+    def _depart_admonition(self, node: Element) -> None:
+        admonitionlabels = {
+            'attention': 'Attention',
+            'caution':   'Caution',
+            'danger':    'Danger',
+            'error':     'Error',
+            'hint':      'Hint',
+            'important': 'Important',
+            'note':      'Note',
+            'seealso':   'See also',
+            'tip':       'Tip',
+            'warning':   'Warning',
+        }
+        label = admonitionlabels[node.tagname]
+        indent = sum(self.stateindent) + len(label)
+        if (len(self.states[-1]) == 1 and
+                self.states[-1][0][0] == 0 and
+                self.max_width - indent >= sum(len(s) for s in self.states[-1][0][1])):
+            # short text: append text after admonition label
+            self.stateindent[-1] += len(label)
+            self.end_state(first=label + ': ')
+        else:
+            # long text: append label before the block
+            self.states[-1].insert(0, (0, [self.nl]))
+            self.end_state(first=label + ':')
+
+    visit_attention = _visit_admonition
+    depart_attention = _depart_admonition
+    visit_caution = _visit_admonition
+    depart_caution = _depart_admonition
+    visit_danger = _visit_admonition
+    depart_danger = _depart_admonition
+    visit_error = _visit_admonition
+    depart_error = _depart_admonition
+    visit_hint = _visit_admonition
+    depart_hint = _depart_admonition
+    visit_important = _visit_admonition
+    depart_important = _depart_admonition
+    visit_note = _visit_admonition
+    depart_note = _depart_admonition
+    visit_tip = _visit_admonition
+    depart_tip = _depart_admonition
+    visit_warning = _visit_admonition
+    depart_warning = _depart_admonition
+    visit_seealso = _visit_admonition
+    depart_seealso = _depart_admonition
+
+    def visit_versionmodified(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_versionmodified(self, node: Element) -> None:
+        self.end_state()
+
+    def visit_literal_block(self, node: Element) -> None:
+        self.new_state()
+
+    def depart_literal_block(self, node: Element) -> None:
+        self.end_state(wrap=False)
+
+    def visit_doctest_block(self, node: Element) -> None:
+        self.new_state(0)
+
+    def depart_doctest_block(self, node: Element) -> None:
+        self.end_state(wrap=False)
+
+    def visit_line_block(self, node: Element) -> None:
+        self.new_state()
+        self.lineblocklevel += 1
+
+    def depart_line_block(self, node: Element) -> None:
+        self.lineblocklevel -= 1
+        self.end_state(wrap=False, end=None)
+        if not self.lineblocklevel:
+            self.add_text('\n')
+
+    def visit_line(self, node: Element) -> None:
+        pass
+
+    def depart_line(self, node: Element) -> None:
+        self.add_text('\n')
+
+    def visit_block_quote(self, node: Element) -> None:
+        self.new_state()
+
+    def depart_block_quote(self, node: Element) -> None:
+        self.end_state()
+
+    def visit_compact_paragraph(self, node: Element) -> None:
+        pass
+
+    def depart_compact_paragraph(self, node: Element) -> None:
+        pass
+
+    def visit_paragraph(self, node: Element) -> None:
+        if not isinstance(node.parent, nodes.Admonition):
+            self.new_state(0)
+
+    def depart_paragraph(self, node: Element) -> None:
+        within_admonition = isinstance(node.parent, nodes.Admonition)
+
+        # Avoid wrapping paragraphs which are just URLs, such as those within
+        # footnotes.
+        looks_like_url = bool(re.match(r'(?i)^https?://[^ ]+?$', node.astext().strip()))
+
+        if not within_admonition:
+            self.end_state(wrap = not looks_like_url)
+
+    def visit_target(self, node: Element) -> None:
+        raise nodes.SkipNode
+
+    def visit_index(self, node: Element) -> None:
+        raise nodes.SkipNode
+
+    def visit_toctree(self, node: Element) -> None:
+        raise nodes.SkipNode
+
+    def visit_substitution_definition(self, node: Element) -> None:
+        raise nodes.SkipNode
+
+    def visit_pending_xref(self, node: Element) -> None:
+        pass
+
+    def depart_pending_xref(self, node: Element) -> None:
+        pass
+
+    def visit_reference(self, node: Element) -> None:
+        if self.add_secnumbers:
+            numbers = node.get("secnumber")
+            if numbers is not None:
+                self.add_text('.'.join(map(str, numbers)) + self.secnumber_suffix)
+
+    def depart_reference(self, node: Element) -> None:
+        pass
+
+    def visit_number_reference(self, node: Element) -> None:
+        text = nodes.Text(node.get('title', '#'))
+        self.visit_Text(text)
+        raise nodes.SkipNode
+
+    def visit_download_reference(self, node: Element) -> None:
+        pass
+
+    def depart_download_reference(self, node: Element) -> None:
+        pass
+
+    def visit_emphasis(self, node: Element) -> None:
+        self.add_text('*')
+
+    def depart_emphasis(self, node: Element) -> None:
+        self.add_text('*')
+
+    def visit_literal_emphasis(self, node: Element) -> None:
+        self.add_text('*')
+
+    def depart_literal_emphasis(self, node: Element) -> None:
+        self.add_text('*')
+
+    def visit_strong(self, node: Element) -> None:
+        self.add_text('**')
+
+    def depart_strong(self, node: Element) -> None:
+        self.add_text('**')
+
+    def visit_literal_strong(self, node: Element) -> None:
+        self.add_text('**')
+
+    def depart_literal_strong(self, node: Element) -> None:
+        self.add_text('**')
+
+    def visit_abbreviation(self, node: Element) -> None:
+        self.add_text('')
+
+    def depart_abbreviation(self, node: Element) -> None:
+        if node.hasattr('explanation'):
+            self.add_text(' (%s)' % node['explanation'])
+
+    def visit_manpage(self, node: Element) -> None:
+        return self.visit_literal_emphasis(node)
+
+    def depart_manpage(self, node: Element) -> None:
+        return self.depart_literal_emphasis(node)
+
+    def visit_title_reference(self, node: Element) -> None:
+        self.add_text('*')
+
+    def depart_title_reference(self, node: Element) -> None:
+        self.add_text('*')
+
+    def visit_literal(self, node: Element) -> None:
+        if 'command-invocation' in node['classes']:
+            self.add_text('`')
+        elif 'command-reference' in node['classes']:
+            self.add_text('`')
+
+    def depart_literal(self, node: Element) -> None:
+        if 'command-invocation' in node['classes']:
+            self.add_text('`')
+        elif 'command-reference' in node['classes']:
+            self.add_text(' --help`')
+
+    def visit_subscript(self, node: Element) -> None:
+        self.add_text('_')
+
+    def depart_subscript(self, node: Element) -> None:
+        pass
+
+    def visit_superscript(self, node: Element) -> None:
+        self.add_text('^')
+
+    def depart_superscript(self, node: Element) -> None:
+        pass
+
+    def visit_footnote_reference(self, node: Element) -> None:
+        self.add_text('[%s]' % node.astext())
+        raise nodes.SkipNode
+
+    def visit_citation_reference(self, node: Element) -> None:
+        self.add_text('[%s]' % node.astext())
+        raise nodes.SkipNode
+
+    def visit_Text(self, node: Text) -> None:
+        self.add_text(node.astext())
+
+    def depart_Text(self, node: Text) -> None:
+        pass
+
+    def visit_generated(self, node: Element) -> None:
+        pass
+
+    def depart_generated(self, node: Element) -> None:
+        pass
+
+    def visit_inline(self, node: Element) -> None:
+        if 'xref' in node['classes'] or 'term' in node['classes']:
+            self.add_text('*')
+
+    def depart_inline(self, node: Element) -> None:
+        if 'xref' in node['classes'] or 'term' in node['classes']:
+            self.add_text('*')
+
+    def visit_container(self, node: Element) -> None:
+        pass
+
+    def depart_container(self, node: Element) -> None:
+        pass
+
+    def visit_problematic(self, node: Element) -> None:
+        self.add_text('>>')
+
+    def depart_problematic(self, node: Element) -> None:
+        self.add_text('<<')
+
+    def visit_system_message(self, node: Element) -> None:
+        self.new_state(0)
+        self.add_text('<SYSTEM MESSAGE: %s>' % node.astext())
+        self.end_state()
+        raise nodes.SkipNode
+
+    def visit_comment(self, node: Element) -> None:
+        raise nodes.SkipNode
+
+    def visit_meta(self, node: Element) -> None:
+        # only valid for HTML
+        raise nodes.SkipNode
+
+    def visit_raw(self, node: Element) -> None:
+        if 'text' in node.get('format', '').split():
+            self.new_state(0)
+            self.add_text(node.astext())
+            self.end_state(wrap = False)
+        raise nodes.SkipNode
+
+    def visit_math(self, node: Element) -> None:
+        pass
+
+    def depart_math(self, node: Element) -> None:
+        pass
+
+    def visit_math_block(self, node: Element) -> None:
+        self.new_state()
+
+    def depart_math_block(self, node: Element) -> None:
+        self.end_state()
+
+    def unknown_visit(self, node: Node) -> None:
+        raise NotImplementedError('Unknown node: ' + node.__class__.__name__)

--- a/augur/titers.py
+++ b/augur/titers.py
@@ -8,7 +8,7 @@ from Bio import Phylo
 from .reconstruct_sequences import load_alignments
 from .titer_model import InsufficientDataException
 from .utils import write_augur_json
-from .argparse_ import add_default_command, ExtendOverwriteDefault
+from .argparse_ import add_default_command, add_subparser, ExtendOverwriteDefault
 
 
 def register_parser(parent_subparsers):
@@ -16,7 +16,7 @@ def register_parser(parent_subparsers):
     subparsers = parser.add_subparsers()
     add_default_command(parser)
 
-    tree_model = subparsers.add_parser('tree', help='tree model')
+    tree_model = add_subparser(subparsers, 'tree', help='tree model')
     tree_model.add_argument('--titers', nargs='+', action=ExtendOverwriteDefault, type=str, required=True, help="file with titer measurements")
     tree_model.add_argument('--tree', '-t', type=str, required=True, help="tree to perform fit titer model to")
     tree_model.add_argument('--allow-empty-model', action="store_true", help="allow model to be empty")
@@ -26,7 +26,7 @@ def register_parser(parent_subparsers):
         __command__ = infer_tree_model
     )
 
-    sub_model = subparsers.add_parser('sub', help='substitution model')
+    sub_model = add_subparser(subparsers, 'sub', help='substitution model')
     sub_model.add_argument('--titers', nargs='+', action=ExtendOverwriteDefault, type=str, required=True, help="file with titer measurements")
     sub_model.add_argument('--alignment', nargs='+', action=ExtendOverwriteDefault, type=str, required=True, help="sequence to be used in the substitution model, supplied as fasta files")
     sub_model.add_argument('--gene-names', nargs='+', action=ExtendOverwriteDefault, type=str, required=True, help="names of the sequences in the alignment, same order assumed")

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -12,6 +12,7 @@ from itertools import groupby
 from referencing import Registry
 from textwrap import indent
 from typing import Iterable, Union
+from augur.argparse_ import add_subparser
 from augur.data import as_file
 from augur.io.file import open_file
 from augur.io.print import print_err
@@ -462,20 +463,20 @@ def register_parser(parent_subparsers):
     parser = parent_subparsers.add_parser("validate", help=__doc__)
     subparsers = parser.add_subparsers(dest="subcommand", help="Which file(s) do you want to validate?")
 
-    subparsers.add_parser("export-v2", help="validate JSON intended for auspice v2") \
+    add_subparser(subparsers, "export-v2", help="validate JSON intended for auspice v2") \
         .add_argument('main_json', metavar='JSON', help="exported (main) v2 auspice JSON")
 
-    export_v1 = subparsers.add_parser("export-v1", help="validate tree+meta JSONs intended for auspice v1")
+    export_v1 = add_subparser(subparsers, "export-v1", help="validate tree+meta JSONs intended for auspice v1")
     export_v1.add_argument('meta_json', metavar='META-JSON', help="exported (v1) meta JSON")
     export_v1.add_argument('tree_json', metavar='TREE-JSON', help="exported (v1) tree JSON")
 
-    subparsers.add_parser("auspice-config-v2", help="validate auspice config intended for `augur export v2`") \
+    add_subparser(subparsers, "auspice-config-v2", help="validate auspice config intended for `augur export v2`") \
         .add_argument('config_json', metavar='JSON', help="auspice config JSON")
 
-    subparsers.add_parser("measurements", help="validate measurements JSON intended for auspice measurements panel") \
+    add_subparser(subparsers, "measurements", help="validate measurements JSON intended for auspice measurements panel") \
         .add_argument("measurements_json", metavar="JSON", help="exported measurements JSON")
 
-    subparsers.add_parser("measurements-collection-config", help="validate measurement collection config intended for `augur measurements export`") \
+    add_subparser(subparsers, "measurements-collection-config", help="validate measurement collection config intended for `augur measurements export`") \
         .add_argument("collection_config_json", metavar="JSON", help="collection config JSON")
     return parser
 

--- a/devel/regenerate-developer-api-docs
+++ b/devel/regenerate-developer-api-docs
@@ -8,4 +8,5 @@ sphinx-apidoc \
   --separate \
   --no-toc \
   --output-dir docs/api/developer \
-  augur
+  augur \
+  augur/rst

--- a/mypy.ini
+++ b/mypy.ini
@@ -50,3 +50,6 @@ ignore_missing_imports = True
 
 [mypy-scipy.*]
 ignore_missing_imports = True
+
+[mypy-docutils.*]
+ignore_missing_imports = True

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -4,6 +4,9 @@
 
   "include": ["augur/"],
 
+  "ignore": [
+    "augur/rst/sphinx.py",
+  ],
 
   "typeCheckingMode": "basic",
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setuptools.setup(
         # TODO: Remove biopython >= 1.80 pin if it is added to bcbio-gff: https://github.com/chapmanb/bcbb/issues/142
         "biopython >=1.80, ==1.*",
         "cvxopt >=1.1.9, ==1.*",
+        "docutils",
         "importlib_resources >=5.3.0; python_version < '3.11'",
         "isodate >=0.6,<0.8",
         # Sync this with 'types-jsonschema' dev dependency

--- a/tests/test_argparse_linting.py
+++ b/tests/test_argparse_linting.py
@@ -2,13 +2,15 @@
 #
 # ¹ <https://github.com/nextstrain/cli/blob/4a00d7100eff811eab6df34db73c7f6d4196e22b/tests/help.py>
 import pytest
+import sys
 
 from augur import make_parser
 from augur.argparse_ import walk_commands, ExtendOverwriteDefault
+from subprocess import run
 
 
 # Walking commands is slow, so do it only once and use it for all tests in this
-# file (though currently n=1).
+# file.
 commands = list(walk_commands(make_parser()))
 
 
@@ -22,3 +24,14 @@ commands = list(walk_commands(make_parser()))
 ])
 def test_ExtendOverwriteDefault(action):
     assert isinstance(action, ExtendOverwriteDefault)
+
+
+@pytest.mark.parametrize("command", [command for command, parser in commands], ids = lambda command: " ".join(command))
+def test_help(command):
+    args = [sys.executable, "-m", "augur", *command[1:], "--help"]
+
+    # Check the exit status ourselves for nicer test output on failure
+    result = run(args)
+    assert result.returncode == 0, f"{args} exited with error"
+
+    # TODO: Test with NEXTSTRAIN_RST_STRICT once all Augur help strings are valid strict rST.

--- a/tests/test_argparse_linting.py
+++ b/tests/test_argparse_linting.py
@@ -34,4 +34,4 @@ def test_help(command):
     result = run(args)
     assert result.returncode == 0, f"{args} exited with error"
 
-    # TODO: Test with NEXTSTRAIN_RST_STRICT once all Augur help strings are valid strict rST.
+    # TODO: Test with AUGUR_RST_STRICT once all Augur help strings are valid strict rST.


### PR DESCRIPTION
## Description of proposed changes

This PR contains 1 prep commit, 1 main commit, and 4 follow-up commits. Message from main commit:

This improves the rendering of --help output, mainly by preserving paragraph breaks and converting rST syntax to plain text.

Largely inspired by Nextstrain CLI.

## Related issue(s)

- Closes #313
- Closes #1630

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update
