### PR TITLE
Normalize help text indentation

### DIFF
--- a/augur/curate/__init__.py
+++ b/augur/curate/__init__.py
@@ -4,6 +4,7 @@ A suite of commands to help with data curation.
 import argparse
 import sys
 from collections import deque
+from inspect import cleandoc
 from textwrap import dedent
 from typing import Iterable, Set
 
@@ -50,10 +51,10 @@ def create_shared_parser():
 
     shared_inputs = shared_parser.add_argument_group(
         title="INPUTS",
-        description="""
+        description=cleandoc("""
             Input options shared by all `augur curate` commands.
             If no input options are provided, commands will try to read NDJSON records from stdin.
-        """)
+        """))
     shared_inputs.add_argument("--metadata",
         help="Input metadata file. May be plain text (TSV, CSV) or an Excel or OpenOffice spreadsheet workbook file. When an Excel or OpenOffice workbook, only the first visible worksheet will be read and initial empty rows/columns will be ignored. Accepts '-' to read plain text from stdin.")
     shared_inputs.add_argument("--id-column",
@@ -84,10 +85,10 @@ def create_shared_parser():
 
     shared_outputs = shared_parser.add_argument_group(
         title="OUTPUTS",
-        description="""
+        description=cleandoc("""
             Output options shared by all `augur curate` commands.
             If no output options are provided, commands will output NDJSON records to stdout.
-        """)
+        """))
     shared_outputs.add_argument("--output-metadata",
         help="Output metadata TSV file. Accepts '-' to output TSV to stdout.")
 

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -11,6 +11,7 @@ import numbers
 import math
 import re
 from Bio import Phylo
+from inspect import cleandoc
 from typing import Dict, Union, TypedDict, Any, Tuple
 from urllib.parse import urlparse
 
@@ -942,20 +943,21 @@ def register_parser(parent_subparsers):
                                  help="names of possible metadata columns containing identifier information, ordered by priority. Only one ID column will be inferred.")
     optional_inputs.add_argument('--colors', metavar="FILE", help="Custom color definitions, one per line in the format `TRAIT_TYPE\\tTRAIT_VALUE\\tHEX_CODE`")
     optional_inputs.add_argument('--lat-longs', metavar="TSV",
-        help=f"""Latitudes and longitudes for geography traits. See this file for the format:
-                 <https://github.com/nextstrain/augur/blob/{__version__}/augur/data/lat_longs.tsv>.
-                 This file provides the default set of latitudes and longitudes. An additional file
-                 specified by this option will extend the default set. Duplicates based on the first
-                 two columns will be resolved by taking the coordinates from the user-provided
-                 file.""")
+        help=cleandoc(f"""
+            Latitudes and longitudes for geography traits. See this file for the format:
+            <https://github.com/nextstrain/augur/blob/{__version__}/augur/data/lat_longs.tsv>.
+            This file provides the default set of latitudes and longitudes. An additional file
+            specified by this option will extend the default set. Duplicates based on the first
+            two columns will be resolved by taking the coordinates from the user-provided
+            file."""))
 
     minify_group = parser.add_argument_group(
             title="OPTIONAL MINIFY SETTINGS",
-            description=f"""
+            description=cleandoc(f"""
                 By default, output JSON files (both main and sidecar) are automatically minimized if
                 the size of the un-minified main JSON file exceeds {MINIFY_THRESHOLD_MB} MB. Use
                 these options to override that behavior.
-                """
+                """)
         ).add_mutually_exclusive_group()
     minify_group.add_argument(
         '--minify-json',
@@ -970,12 +972,12 @@ def register_parser(parent_subparsers):
 
     root_sequence = parser.add_argument_group(
             title="OPTIONAL ROOT-SEQUENCE SETTINGS",
-            description=f"""
+            description=cleandoc(f"""
                 The root-sequences describe the sequences (nuc + aa) for the parent of the tree's root-node. They may represent a
                 reference sequence or the inferred sequence at the root node, depending on how they were generated.
                 The data is taken directly from the `reference` key within the provided node-data JSONs.
                 These arguments are mutually exclusive.
-                """
+                """)
         ).add_mutually_exclusive_group()
     root_sequence.add_argument('--include-root-sequence', action="store_true", help="Export as an additional JSON. The filename will follow the pattern of <OUTPUT>_root-sequence.json for a main auspice JSON of <OUTPUT>.json")
     root_sequence.add_argument('--include-root-sequence-inline', action="store_true", help="Export the root sequence within the dataset JSON. This should only be used for small genomes for file size reasons.")

--- a/augur/tree.py
+++ b/augur/tree.py
@@ -14,6 +14,7 @@ import Bio
 from Bio.Seq import MutableSeq
 from Bio import Phylo
 import numpy as np
+from inspect import cleandoc
 from shlex import quote as shquote
 from treetime.vcf_utils import read_vcf
 from pathlib import Path
@@ -491,9 +492,10 @@ def register_parser(parent_subparsers):
             """))
     parser.add_argument('--override-default-args', action="store_true", help="override default tree builder arguments with the values provided by the user in ``--tree-builder-args`` instead of augmenting the existing defaults.")
 
-    parser.epilog = """For example, to build a tree with IQ-TREE, use the following format:
-    augur tree --method iqtree --alignment <alignment> --substitution-model <model> --output <tree> --tree-builder-args="<extra arguments>"
-    """
+    parser.epilog = cleandoc("""
+        For example, to build a tree with IQ-TREE, use the following format:
+        augur tree --method iqtree --alignment <alignment> --substitution-model <model> --output <tree> --tree-builder-args="<extra arguments>"
+        """)
     return parser
 
 def run(args):

--- a/tests/test_argparse_linting.py
+++ b/tests/test_argparse_linting.py
@@ -14,6 +14,18 @@ from subprocess import run
 commands = list(walk_commands(make_parser()))
 
 
+def help_texts():
+    for command, parser in commands:
+        for attribute in ("description", "epilog"):
+            yield command, attribute, getattr(parser, attribute)
+
+        for group in parser._action_groups:
+            yield command, f"{group.title} description", group.description
+
+        for action in parser._actions:
+            yield command, "/".join(action.option_strings) or action.dest, action.help
+
+
 # Ensure we always use ExtendOverwriteDefault for options that take a variable
 # number of arguments.  See <https://github.com/nextstrain/augur/pull/1709>.
 @pytest.mark.parametrize("action", [
@@ -35,3 +47,35 @@ def test_help(command):
     assert result.returncode == 0, f"{args} exited with error"
 
     # TODO: Test with AUGUR_RST_STRICT once all Augur help strings are valid strict rST.
+
+
+@pytest.mark.parametrize("command, location, text", [
+    pytest.param(command, location, text, id = " ".join(command) + " " + location)
+        for command, location, text in help_texts()
+])
+def test_multiline_help_dedented(command, location, text):
+    assert not _has_extra_indent(text), \
+        f"{' '.join(command)} {location} has extra indentation"
+
+
+def _has_extra_indent(text):
+    # Ignore non-strings.
+    if not isinstance(text, str):
+        return False
+
+    # Ignore blank lines, since leading/trailing blank lines are common in
+    # triple-quoted strings and do not affect indentation.
+    lines = [line for line in text.splitlines() if line.strip()]
+
+    if len(lines) < 2:
+        return False
+
+    indents = [
+        len(line) - len(line.lstrip())
+        for line in lines
+    ]
+
+    return (
+        # Fail if all lines after the first are indented.
+        all(indent >= 1 for indent in indents[1:])
+    )


### PR DESCRIPTION
## Description of proposed changes

Motivated by "Dedent help text" (28e6e8cf). A test has been added to catch these mistakes programmatically. Fixes for existing issues have been added.

So far this codebase has used textwrap.dedent, but inspect.cleandoc accomplishes the same without needing an extra backslash at the start of the multiline string.

## Related issue(s)

Closes #1720

## Checklist

- [x] Test with `pytest -k test_multiline_help_dedented`
- [x] Automated checks pass
- [x] ~[Check][1] if you need to add a changelog message~ very minor styling differences in docs, not worth noting
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
