### PR TITLE
Update Cram tests

### DIFF
--- a/tests/functional/ancestral/cram/default-nucleotide-reconstruction.t
+++ b/tests/functional/ancestral/cram/default-nucleotide-reconstruction.t
@@ -9,15 +9,15 @@ The default is to infer ambiguous bases, so there should not be N bases in the i
   >  --tree $TESTDIR/../data/tree.nwk \
   >  --alignment $TESTDIR/../data/aligned.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations.json" \
+  >  --output-sequences "ancestral_sequences.fasta" &> /dev/null
 
-  $ grep "^N" "$CRAMTMP/$TESTFILE/ancestral_sequences.fasta"
+  $ grep "^N" "ancestral_sequences.fasta"
   [1]
 
 Check that the reference length was correctly exported as the nuc annotation
 
-  $ grep -A 6 'annotations' "$CRAMTMP/$TESTFILE/ancestral_mutations.json"
+  $ grep -A 6 'annotations' "ancestral_mutations.json"
     "annotations": {
       "nuc": {
         "end": 10769,

--- a/tests/functional/ancestral/cram/infer-ambiguous-nucleotides.t
+++ b/tests/functional/ancestral/cram/infer-ambiguous-nucleotides.t
@@ -10,10 +10,10 @@ There should not be N bases in the inferred output sequences.
   >  --alignment $TESTDIR/../data/aligned.fasta \
   >  --infer-ambiguous \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations.json" \
+  >  --output-sequences "ancestral_sequences.fasta" &> /dev/null
 
-  $ grep "^N" "$CRAMTMP/$TESTFILE/ancestral_sequences.fasta"
+  $ grep "^N" "ancestral_sequences.fasta"
   [1]
 
 test ambiguous bases remain in seqs and muts if we use `--keep-ambiguous`
@@ -32,16 +32,16 @@ and  also remain in the resulting sequence.
   $ ${AUGUR} ancestral --seed 0 \
   >  --keep-ambiguous \
   >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3Y.fasta \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_1.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_1.json" \
+  >  --output-sequences "ancestral_sequences_1.fasta" &> /dev/null
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" | jq -c '.nodes.sample_C.muts'
+  $ cat "ancestral_mutations_1.json" | jq -c '.nodes.sample_C.muts'
   ["C3Y"]
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" | jq -c '.nodes.sample_C.sequence'
+  $ cat "ancestral_mutations_1.json" | jq -c '.nodes.sample_C.sequence'
   "AAYAA"
 
-  $ grep 'sample_C' -A 1 "$CRAMTMP/$TESTFILE/ancestral_sequences_1.fasta"
+  $ grep 'sample_C' -A 1 "ancestral_sequences_1.fasta"
   >sample_C
   AAYAA
 
@@ -51,16 +51,16 @@ Same test as above but using `--infer-ambiguous` (the default) infers Y as eithe
   $ ${AUGUR} ancestral --seed 0 \
   >  --infer-ambiguous \
   >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3Y.fasta \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_2.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_2.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_2.json" \
+  >  --output-sequences "ancestral_sequences_2.fasta" &> /dev/null
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_2.json" | jq -c '.nodes.sample_C.muts'
+  $ cat "ancestral_mutations_2.json" | jq -c '.nodes.sample_C.muts'
   []
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_2.json" | jq -c '.nodes.sample_C.sequence'
+  $ cat "ancestral_mutations_2.json" | jq -c '.nodes.sample_C.sequence'
   "AACAA"
 
-  $ grep 'sample_C' -A 1 "$CRAMTMP/$TESTFILE/ancestral_sequences_2.fasta"
+  $ grep 'sample_C' -A 1 "ancestral_sequences_2.fasta"
   >sample_C
   AACAA
 
@@ -83,17 +83,17 @@ and reported in both sequences and mutations. Note that the parent state
   $ ${AUGUR} ancestral --seed 0 \
   >  --keep-ambiguous \
   >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3X.fasta \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_3.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_3.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_3.json" \
+  >  --output-sequences "ancestral_sequences_3.fasta" &> /dev/null
 
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_3.json" | jq -c '.nodes.sample_C.muts'
+  $ cat "ancestral_mutations_3.json" | jq -c '.nodes.sample_C.muts'
   ["G3N"]
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_3.json" | jq -c '.nodes.sample_C.sequence'
+  $ cat "ancestral_mutations_3.json" | jq -c '.nodes.sample_C.sequence'
   "AANAA"
 
-  $ grep 'sample_C' -A 1 "$CRAMTMP/$TESTFILE/ancestral_sequences_3.fasta"
+  $ grep 'sample_C' -A 1 "ancestral_sequences_3.fasta"
   >sample_C
   AANAA
 
@@ -104,17 +104,17 @@ Note 2: TreeTime chooses the root state as G as well, so there's no mutation on 
   $ ${AUGUR} ancestral --seed 0 \
   >  --infer-ambiguous \
   >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3X.fasta \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_4.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_4.json" \
+  >  --output-sequences "ancestral_sequences_4.fasta" &> /dev/null
 
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json" | jq -c '.nodes.sample_C.muts'
+  $ cat "ancestral_mutations_4.json" | jq -c '.nodes.sample_C.muts'
   []
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json" | jq -c '.nodes.sample_C.sequence'
+  $ cat "ancestral_mutations_4.json" | jq -c '.nodes.sample_C.sequence'
   "AAGAA"
 
-  $ grep 'sample_C' -A 1 "$CRAMTMP/$TESTFILE/ancestral_sequences_4.fasta"
+  $ grep 'sample_C' -A 1 "ancestral_sequences_4.fasta"
   >sample_C
   AAGAA
 
@@ -135,11 +135,11 @@ should report 'N' (the standard ambiguous nucleotide) when we're not inferring a
   $ ${AUGUR} ancestral --seed 0 \
   >  --keep-ambiguous \
   >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_pos3X_internal.fasta \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_5.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_5.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_5.json" \
+  >  --output-sequences "ancestral_sequences_5.fasta" &> /dev/null
 
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_5.json" | jq -c '.nodes.node_AB.sequence'
+  $ cat "ancestral_mutations_5.json" | jq -c '.nodes.node_AB.sequence'
   "AANAA"
 
 
@@ -166,15 +166,15 @@ The reference 'X' at pos 3 should be equivalent to 'N')
   >  --keep-ambiguous \
   >  --root-sequence ref_pos3X.fasta \
   >  --tree $TESTDIR/../data/simple-genome/tree.nwk --alignment aln_col3N.fasta \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_6.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences_6.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_6.json" \
+  >  --output-sequences "ancestral_sequences_6.fasta" &> /dev/null
 
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_6.json" | jq -c '[.nodes[].sequence] | unique'
+  $ cat "ancestral_mutations_6.json" | jq -c '[.nodes[].sequence] | unique'
   ["AANAA"]
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_6.json" | jq -c '[.nodes[].muts[]]'
+  $ cat "ancestral_mutations_6.json" | jq -c '[.nodes[].muts[]]'
   []
 
-  $ cat "$CRAMTMP/$TESTFILE/ancestral_mutations_6.json" | jq -c '.reference.nuc'
+  $ cat "ancestral_mutations_6.json" | jq -c '.reference.nuc'
   "AANAA"

--- a/tests/functional/ancestral/cram/infer-amino-acid-sequences-multiple-genes-no-nuc.t
+++ b/tests/functional/ancestral/cram/infer-amino-acid-sequences-multiple-genes-no-nuc.t
@@ -12,28 +12,28 @@ Infer multiple genes with a provided GenBank annotation file
   >  --genes ENV PRO \
   >  --translations $TESTDIR/../data/aa_sequences_%GENE.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" \
-  >  --output-translations "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_%GENE_1.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_1.json" \
+  >  --output-translations "ancestral_aa_sequences_%GENE_1.fasta" &> /dev/null
 
 Check that the annotations block only includes ENV & PRO, not nuc
 
-  $ grep -E "\"(ENV|PRO|nuc)\": {" "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json"
+  $ grep -E "\"(ENV|PRO|nuc)\": {" "ancestral_mutations_1.json"
       "ENV": {
       "PRO": {
 
 Check that amino acid sequences exist for the root node of the tree.
 
-  $ grep -A 2 "aa_sequences" "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json"
+  $ grep -A 2 "aa_sequences" "ancestral_mutations_1.json"
         "aa_sequences": {
           "ENV": .* (re)
           "PRO": .* (re)
 
 Check that internal nodes have ancestral amino acid sequences.
 
-  $ grep "NODE" "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV_1.fasta" | wc -l
+  $ grep "NODE" "ancestral_aa_sequences_ENV_1.fasta" | wc -l
   \s*8 (re)
 
-  $ grep "NODE" "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_PRO_1.fasta" | wc -l
+  $ grep "NODE" "ancestral_aa_sequences_PRO_1.fasta" | wc -l
   \s*8 (re)
 
 
@@ -46,7 +46,7 @@ Catches this bug <https://github.com/nextstrain/augur/pull/1958#discussion_r3034
   >  --genes $TESTDIR/../data/genes.txt \
   >  --translations $TESTDIR/../data/aa_sequences_ENV.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_error.json" \
-  >  --output-translations "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_error.fasta" > /dev/null
+  >  --output-node-data "ancestral_mutations_error.json" \
+  >  --output-translations "ancestral_aa_sequences_error.fasta" > /dev/null
   ERROR: --translations must contain %GENE for multiple-gene amino acid reconstructions
   [2]

--- a/tests/functional/ancestral/cram/infer-amino-acid-sequences-single-gene-no-nuc.t
+++ b/tests/functional/ancestral/cram/infer-amino-acid-sequences-single-gene-no-nuc.t
@@ -12,24 +12,24 @@ Firstly a single gene (ENV), using a hardcoded fasta path, and an annotation fil
   >  --genes ENV \
   >  --translations $TESTDIR/../data/aa_sequences_ENV.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" \
-  >  --output-translations "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV_1.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_1.json" \
+  >  --output-translations "ancestral_aa_sequences_ENV_1.fasta" &> /dev/null
 
 Check that the annotations block only includes ENV, not nuc or PRO
 
-  $ grep -E "\"(ENV|PRO|nuc)\": {" "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json"
+  $ grep -E "\"(ENV|PRO|nuc)\": {" "ancestral_mutations_1.json"
       "ENV": {
 
 Check that amino acid sequences exist for the root node of the tree.
 
-  $ grep -A 2 "aa_sequences" "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json"
+  $ grep -A 2 "aa_sequences" "ancestral_mutations_1.json"
         "aa_sequences": {
           "ENV": .* (re)
         }
 
 Check that internal nodes have ancestral amino acid sequences.
 
-  $ grep "NODE" "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV_1.fasta" | wc -l
+  $ grep "NODE" "ancestral_aa_sequences_ENV_1.fasta" | wc -l
   \s*8 (re)
 
 
@@ -41,14 +41,14 @@ And the exact same, but using a %GENE pattern in the filepath
   >  --genes ENV \
   >  --translations $TESTDIR/../data/aa_sequences_%GENE.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_2.json" \
-  >  --output-translations "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_%GENE_2.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_2.json" \
+  >  --output-translations "ancestral_aa_sequences_%GENE_2.fasta" &> /dev/null
 
 Check that the outputs are identical
 
-  $ diff "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" "$CRAMTMP/$TESTFILE/ancestral_mutations_2.json" 
+  $ diff "ancestral_mutations_1.json" "ancestral_mutations_2.json"
 
-  $ diff "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV_1.fasta" "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV_2.fasta"
+  $ diff "ancestral_aa_sequences_ENV_1.fasta" "ancestral_aa_sequences_ENV_2.fasta"
 
 
 For single genes the annotations file is optional. The result should be the same except the (nuc) coordinates of the CDS will differ without the annotation file
@@ -58,16 +58,16 @@ For single genes the annotations file is optional. The result should be the same
   >  --genes ENV \
   >  --translations $TESTDIR/../data/aa_sequences_ENV.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_3.json" \
-  >  --output-translations "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV_3.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations_3.json" \
+  >  --output-translations "ancestral_aa_sequences_ENV_3.fasta" &> /dev/null
 
 
-  $ diff "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV_1.fasta" "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV_3.fasta"
+  $ diff "ancestral_aa_sequences_ENV_1.fasta" "ancestral_aa_sequences_ENV_3.fasta"
 
 Nucleotide coordinates of the ENV gene are different - without the annotation file we start them at nuc_pos=1 (1-based, GFF-style)
-So for this example the offset is 960 (start is 961 - 960 = 1, end is 2472 - 960 = 1512) 
+So for this example the offset is 960 (start is 961 - 960 = 1, end is 2472 - 960 = 1512)
 
-  $ diff "$CRAMTMP/$TESTFILE/ancestral_mutations_1.json" "$CRAMTMP/$TESTFILE/ancestral_mutations_3.json" 
+  $ diff "ancestral_mutations_1.json" "ancestral_mutations_3.json"
   4,6c4,5
   \<       "end": 2472, (re)
   \<       "seqid": .* (re)
@@ -88,18 +88,18 @@ Test single gene reconstruction with an explicitly provided AA root-sequence
   >  --translations $TESTDIR/../data/aa_sequences_ENV.fasta \
   >  --aa-root-sequence $TESTDIR/../data/ENV_outgroup.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json" &> /dev/null
+  >  --output-node-data "ancestral_mutations_4.json" &> /dev/null
 
 The reference has been modified to include a leading AAA:
 
-  $ grep -A 2 "reference" "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json"
+  $ grep -A 2 "reference" "ancestral_mutations_4.json"
     "reference": {
       "ENV": "AAA.+ (re)
     }
 
 Check that this results in 3 mutations between the provided root-sequence & the inferred root node
 
-  $ grep -A 11 "NODE_0000006" "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json"
+  $ grep -A 11 "NODE_0000006" "ancestral_mutations_4.json"
       "NODE_0000006": {
         "aa_muts": {
           "ENV": [
@@ -123,10 +123,10 @@ Retest the above, using a %GENE placeholder in --aa-root-sequence
   >  --translations $TESTDIR/../data/aa_sequences_ENV.fasta \
   >  --aa-root-sequence $TESTDIR/../data/%GENE_outgroup.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_5.json" &> /dev/null
+  >  --output-node-data "ancestral_mutations_5.json" &> /dev/null
 
 
-  $ diff "$CRAMTMP/$TESTFILE/ancestral_mutations_4.json" "$CRAMTMP/$TESTFILE/ancestral_mutations_5.json"
+  $ diff "ancestral_mutations_4.json" "ancestral_mutations_5.json"
 
 
 Test that accidentally providing the wrong AA root-sequence (e.g. a nuc one) results in an error
@@ -138,6 +138,6 @@ Test that accidentally providing the wrong AA root-sequence (e.g. a nuc one) res
   >  --translations $TESTDIR/../data/aa_sequences_ENV.fasta \
   >  --aa-root-sequence $TESTDIR/../data/simple-genome/reference.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations_5.json" > /dev/null
+  >  --output-node-data "ancestral_mutations_5.json" > /dev/null
   ERROR: The provided root-sequence AA fasta for ENV has length 50 which doesn't match the length of the CDS 504 (amino acids)
   [2]

--- a/tests/functional/ancestral/cram/infer-amino-acid-sequences-with-root-sequence.t
+++ b/tests/functional/ancestral/cram/infer-amino-acid-sequences-with-root-sequence.t
@@ -16,12 +16,12 @@ ancestor).
   >  --genes ENV PRO \
   >  --translations $TESTDIR/../data/aa_sequences_%GENE.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations.json" &> /dev/null
+  >  --output-node-data "ancestral_mutations.json" &> /dev/null
 
 Check that the reference length was correctly exported as the nuc annotation
 
   $ python3 "$TESTDIR/../../../../scripts/diff_jsons.py" \
   >   --exclude-regex-paths "['seqid']" -- \
   >   "$TESTDIR/../data/ancestral_mutations_with_root_sequence.json" \
-  >   "$CRAMTMP/$TESTFILE/ancestral_mutations.json"
+  >   "ancestral_mutations.json"
   {}

--- a/tests/functional/ancestral/cram/infer-amino-acid-sequences.t
+++ b/tests/functional/ancestral/cram/infer-amino-acid-sequences.t
@@ -11,25 +11,25 @@ Infer ancestral nucleotide and amino acid sequences.
   >  --genes ENV PRO \
   >  --translations $TESTDIR/../data/aa_sequences_%GENE.fasta \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences.fasta" \
-  >  --output-translations "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_%GENE.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations.json" \
+  >  --output-sequences "ancestral_sequences.fasta" \
+  >  --output-translations "ancestral_aa_sequences_%GENE.fasta" &> /dev/null
 
 Check that the reference length was correctly exported as the nuc annotation
 
-  $ grep -E "\"(ENV|PRO|nuc)\": {" "$CRAMTMP/$TESTFILE/ancestral_mutations.json"
+  $ grep -E "\"(ENV|PRO|nuc)\": {" "ancestral_mutations.json"
       "ENV": {
       "PRO": {
       "nuc": {
 
 Check that amino acid sequences exist for the root node of the tree.
 
-  $ grep -A 2 "aa_sequences" "$CRAMTMP/$TESTFILE/ancestral_mutations.json"
+  $ grep -A 2 "aa_sequences" "ancestral_mutations.json"
         "aa_sequences": {
           "ENV": .* (re)
           "PRO": .* (re)
 
 Check that internal nodes have ancestral amino acid sequences.
 
-  $ grep "NODE" "$CRAMTMP/$TESTFILE/ancestral_aa_sequences_ENV.fasta" | wc -l
+  $ grep "NODE" "ancestral_aa_sequences_ENV.fasta" | wc -l
   \s*8 (re)

--- a/tests/functional/ancestral/cram/keep-ambiguous-nucleotides.t
+++ b/tests/functional/ancestral/cram/keep-ambiguous-nucleotides.t
@@ -10,8 +10,8 @@ There should be N bases in the inferred output sequences.
   >  --alignment $TESTDIR/../data/aligned.fasta \
   >  --keep-ambiguous \
   >  --seed 314159 \
-  >  --output-node-data "$CRAMTMP/$TESTFILE/ancestral_mutations.json" \
-  >  --output-sequences "$CRAMTMP/$TESTFILE/ancestral_sequences.fasta" &> /dev/null
+  >  --output-node-data "ancestral_mutations.json" \
+  >  --output-sequences "ancestral_sequences.fasta" &> /dev/null
 
-  $ grep "^N" "$CRAMTMP/$TESTFILE/ancestral_sequences.fasta" | head -n 1
+  $ grep "^N" "ancestral_sequences.fasta" | head -n 1
   NNNNNNNNNNNNGACAGTTCGAGTTTGAAGCGAAAGCTAGCAACAGTATCAACAGGTTTT

--- a/tests/functional/curate/cram/titlecase.t
+++ b/tests/functional/curate/cram/titlecase.t
@@ -1,8 +1,6 @@
 Setup
 
-  $ pushd "$TESTDIR" > /dev/null
-  $ export AUGUR="${AUGUR:-../../../../bin/augur}"
-
+  $ source "$TESTDIR"/_setup.sh
 
 Test output with articles and a mixture of lower and uppercase letters.
 
@@ -96,4 +94,3 @@ Test silencing on failures such as when encountering a non-string value
   >   | ${AUGUR} curate titlecase --titlecase-fields "bare_int" \
   >   --failure-reporting "silent"
   {"bare_int": 2021}
-

--- a/tests/functional/measurements_concat.t
+++ b/tests/functional/measurements_concat.t
@@ -1,37 +1,36 @@
 Integration tests for augur measurements export.
 
   $ source "$TESTDIR"/_setup.sh
-  $ pushd "$TESTDIR" > /dev/null
 
 Measurements concat for two measurements JSONs, each with a single collection.
 
   $ ${AUGUR} measurements concat \
-  >   --jsons measurements_concat/single_collection_measurements_1.json measurements_concat/single_collection_measurements_2.json \
+  >   --jsons "$TESTDIR/measurements_concat/single_collection_measurements_1.json" "$TESTDIR/measurements_concat/single_collection_measurements_2.json" \
   >   --default-collection collection_1 \
-  >   --output-json "$TMP/two_collections_measurements.json" &>/dev/null
+  >   --output-json "two_collections_measurements.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_concat/two_collections_measurements.json "$TMP/two_collections_measurements.json"
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_concat/two_collections_measurements.json" "two_collections_measurements.json"
   {}
 
 Measurements concat for two measurements JSONs, where one has multiple collections.
 
   $ ${AUGUR} measurements concat \
-  >   --jsons measurements_concat/two_collections_measurements.json measurements_concat/single_collection_measurements_3.json \
+  >   --jsons "$TESTDIR/measurements_concat/two_collections_measurements.json" "$TESTDIR/measurements_concat/single_collection_measurements_3.json" \
   >   --default-collection collection_1 \
-  >   --output-json "$TMP/multiple_collections_measurements.json" &>/dev/null
+  >   --output-json "multiple_collections_measurements.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_concat/multiple_collections_measurements.json "$TMP/multiple_collections_measurements.json"
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_concat/multiple_collections_measurements.json" "multiple_collections_measurements.json"
   {}
 
 Measurements concat for measurements JSONs that have collections that share the same key.
 This is expected to fail.
 
   $ ${AUGUR} measurements concat \
-  >   --jsons measurements_concat/single_collection_measurements_1.json measurements_concat/single_collection_measurements_1.json \
+  >   --jsons "$TESTDIR/measurements_concat/single_collection_measurements_1.json" "$TESTDIR/measurements_concat/single_collection_measurements_1.json" \
   >   --default-collection collection_1 \
-  >   --output-json "$TMP/multiple_collections_measurements.json" 1>/dev/null
-  Validating schema of 'measurements_concat/single_collection_measurements_1.json'...
-  Validating schema of 'measurements_concat/single_collection_measurements_1.json'...
+  >   --output-json "multiple_collections_measurements.json" 1>/dev/null
+  Validating schema of '.*measurements_concat/single_collection_measurements_1.json'... (re)
+  Validating schema of '.*measurements_concat/single_collection_measurements_1.json'... (re)
   Validating schema of '.*multiple_collections_measurements.json'... (re)
   ERROR: Collections at indexes [0, 1] share the same collection key 'collection_1'.
   ERROR: Validation of output JSON failed. See detailed errors above.
@@ -41,11 +40,11 @@ Measurements concat with an invalid default collection.
 This is expected to fail.
 
   $ ${AUGUR} measurements concat \
-  >   --jsons measurements_concat/single_collection_measurements_1.json measurements_concat/single_collection_measurements_2.json \
+  >   --jsons "$TESTDIR/measurements_concat/single_collection_measurements_1.json" "$TESTDIR/measurements_concat/single_collection_measurements_2.json" \
   >   --default-collection collection_3 \
-  >   --output-json "$TMP/multiple_collections_measurements.json" 1>/dev/null
-  Validating schema of 'measurements_concat/single_collection_measurements_1.json'...
-  Validating schema of 'measurements_concat/single_collection_measurements_2.json'...
+  >   --output-json "multiple_collections_measurements.json" 1>/dev/null
+  Validating schema of '.*measurements_concat/single_collection_measurements_1.json'... (re)
+  Validating schema of '.*measurements_concat/single_collection_measurements_2.json'... (re)
   Validating schema of '.*multiple_collections_measurements.json'... (re)
   ERROR: The default collection key 'collection_3' does not match any of the collections' keys.
   ERROR: Validation of output JSON failed. See detailed errors above.

--- a/tests/functional/measurements_export.t
+++ b/tests/functional/measurements_export.t
@@ -1,28 +1,27 @@
 Integration tests for augur measurements export.
 
   $ source "$TESTDIR"/_setup.sh
-  $ pushd "$TESTDIR" > /dev/null
 
 Minimal measurements export with existing strain and value columns.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection.tsv \
+  >   --collection "$TESTDIR/measurements_export/collection.tsv" \
   >   --grouping-column field_1 \
-  >   --output-json "$TMP/minimal_measurements.json" &>/dev/null
+  >   --output-json "minimal_measurements.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/minimal_measurements.json "$TMP/minimal_measurements.json"
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_export/minimal_measurements.json" "minimal_measurements.json"
   {}
 
 Minimal measurements export with user provided strain and value columns.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection_without_strain_value_columns.tsv \
+  >   --collection "$TESTDIR/measurements_export/collection_without_strain_value_columns.tsv" \
   >   --strain-column strain_field \
   >   --value-column value_field \
   >   --grouping-column field_1 \
-  >   --output-json "$TMP/minimal_measurements.json" &>/dev/null
+  >   --output-json "minimal_measurements.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/minimal_measurements.json "$TMP/minimal_measurements.json" \
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_export/minimal_measurements.json" "minimal_measurements.json" \
   >   --exclude-paths "root['collections'][0]['key']"
   {}
 
@@ -30,11 +29,11 @@ Try measurements export with user provided strain and value columns that would o
 This is expected to fail.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection.tsv \
+  >   --collection "$TESTDIR/measurements_export/collection.tsv" \
   >   --strain-column field_1 \
   >   --value-column field_2 \
   >   --grouping-column field_1 \
-  >   --output-json "$TMP/minimal_measurements.json"
+  >   --output-json "minimal_measurements.json"
   ERROR: Cannot use provided 'field_1' column as the strain column because a 'strain' column already exists in collection TSV.
   ERROR: Cannot use provided 'field_2' column as the value column because a 'value' column already exists in collection TSV.
   [1]
@@ -43,37 +42,37 @@ Try measurements export with user provided strain and value columns that are the
 This is expected to fail.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection_without_strain_value_columns.tsv \
+  >   --collection "$TESTDIR/measurements_export/collection_without_strain_value_columns.tsv" \
   >   --strain-column field_1 \
   >   --value-column field_1 \
   >   --grouping-column field_1 \
-  >   --output-json "$TMP/minimal_measurements.json"
+  >   --output-json "minimal_measurements.json"
   ERROR: The strain column and value column cannot be the same column.
   [1]
 
 Minimal measurements export with user provided strain, value, and subset of columns.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection_without_strain_value_columns.tsv \
+  >   --collection "$TESTDIR/measurements_export/collection_without_strain_value_columns.tsv" \
   >   --strain-column strain_field \
   >   --value-column value_field \
   >   --grouping-column field_1 \
   >   --include-columns field_1 field_3 \
-  >   --output-json "$TMP/minimal_measurements_subset.json" &>/dev/null
+  >   --output-json "minimal_measurements_subset.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/minimal_measurements_subset.json "$TMP/minimal_measurements_subset.json"
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_export/minimal_measurements_subset.json" "minimal_measurements_subset.json"
   {}
 
 Try measurements export with grouping column missing from include columns list
 This is expected to fail.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection_without_strain_value_columns.tsv \
+  >   --collection "$TESTDIR/measurements_export/collection_without_strain_value_columns.tsv" \
   >   --strain-column strain_field \
   >   --value-column value_field \
   >   --grouping-column field_1 \
   >   --include-columns field_3 \
-  >   --output-json "$TMP/minimal_measurements_subset.json" 1>/dev/null
+  >   --output-json "minimal_measurements_subset.json" 1>/dev/null
   ERROR: Provided grouping column 'field_1' was not in the list of columns to include: ['field_3'].
   [1]
 
@@ -81,16 +80,16 @@ Try measurements export with invalid grouping columns.
 This is expected to fail.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection.tsv \
+  >   --collection "$TESTDIR/measurements_export/collection.tsv" \
   >   --grouping-column bad_field \
-  >   --output-json "$TMP/minimal_measurements.json"
+  >   --output-json "minimal_measurements.json"
   ERROR: Provided grouping column 'bad_field' does not exist in collection TSV.
   [1]
 
 Measurements export for a single collection using only command line configs.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection.tsv \
+  >   --collection "$TESTDIR/measurements_export/collection.tsv" \
   >   --grouping-column field_1 field_2 \
   >   --key args-collection \
   >   --title collection-display-title \
@@ -101,26 +100,26 @@ Measurements export for a single collection using only command line configs.
   >   --measurements-display mean \
   >   --show-overall-mean \
   >   --show-threshold \
-  >   --output-json "$TMP/single_collection_with_args_measurements.json" &>/dev/null
+  >   --output-json "single_collection_with_args_measurements.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/single_collection_with_args_measurements.json "$TMP/single_collection_with_args_measurements.json"
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_export/single_collection_with_args_measurements.json" "single_collection_with_args_measurements.json"
   {}
 
 Measurements export for a single collection using a collection config.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection.tsv \
-  >   --collection-config measurements_export/collection_config.json \
-  >   --output-json "$TMP/single_collection_with_config_measurements.json" &>/dev/null
+  >   --collection "$TESTDIR/measurements_export/collection.tsv" \
+  >   --collection-config $TESTDIR/measurements_export/collection_config.json \
+  >   --output-json "single_collection_with_config_measurements.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/single_collection_with_config_measurements.json "$TMP/single_collection_with_config_measurements.json"
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_export/single_collection_with_config_measurements.json" "single_collection_with_config_measurements.json"
   {}
 
 Measurements export for a single collection using a collection config and command-line overrides.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection.tsv \
-  >   --collection-config measurements_export/collection_config.json \
+  >   --collection "$TESTDIR/measurements_export/collection.tsv" \
+  >   --collection-config "$TESTDIR/measurements_export/collection_config.json" \
   >   --grouping-column field_3 \
   >   --key override-collection \
   >   --title override-collection-display-title \
@@ -131,16 +130,16 @@ Measurements export for a single collection using a collection config and comman
   >   --measurements-display raw \
   >   --hide-overall-mean \
   >   --hide-threshold \
-  >   --output-json "$TMP/single_collection_with_overrides_measurements.json" &>/dev/null
+  >   --output-json "single_collection_with_overrides_measurements.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/single_collection_with_overrides_measurements.json "$TMP/single_collection_with_overrides_measurements.json"
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_export/single_collection_with_overrides_measurements.json" "single_collection_with_overrides_measurements.json"
   {}
 
 Measurements export for a single collection using a collection config and command-line overrides with multiple thresholds.
 
   $ ${AUGUR} measurements export \
-  >   --collection measurements_export/collection.tsv \
-  >   --collection-config measurements_export/collection_config.json \
+  >   --collection "$TESTDIR/measurements_export/collection.tsv" \
+  >   --collection-config "$TESTDIR/measurements_export/collection_config.json" \
   >   --grouping-column field_3 \
   >   --key override-collection \
   >   --title override-collection-display-title \
@@ -151,7 +150,7 @@ Measurements export for a single collection using a collection config and comman
   >   --measurements-display raw \
   >   --hide-overall-mean \
   >   --hide-threshold \
-  >   --output-json "$TMP/single_collection_with_multiple_thresholds.json" &>/dev/null
+  >   --output-json "single_collection_with_multiple_thresholds.json" &>/dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" measurements_export/single_collection_with_multiple_thresholds.json "$TMP/single_collection_with_multiple_thresholds.json"
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/measurements_export/single_collection_with_multiple_thresholds.json" "single_collection_with_multiple_thresholds.json"
   {}

--- a/tests/functional/parse.t
+++ b/tests/functional/parse.t
@@ -1,54 +1,51 @@
 Integration tests for augur parse.
 
   $ source "$TESTDIR"/_setup.sh
-  $ pushd "$TESTDIR" > /dev/null
 
 Try to parse Zika sequences without specifying fields.
 This should fail.
 
   $ ${AUGUR} parse \
-  >   --sequences parse/zika.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" 2>&1 | tail -1
+  >   --sequences "$TESTDIR/parse/zika.fasta" \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" 2>&1 | tail -1
   augur parse: error: the following arguments are required: --fields
   [2]
 
 Parse Zika sequences into sequences and metadata.
 
   $ ${AUGUR} parse \
-  >   --sequences parse/zika.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences "$TESTDIR/parse/zika.fasta" \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --fields strain virus accession date region country division city db segment authors url title journal paper_url \
   >   --prettify-fields region country division city \
   >   --fix-dates monthfirst
 
-  $ diff -u "parse/sequences.fasta" "$TMP/sequences.fasta"
-  $ diff -u "parse/metadata.tsv" "$TMP/metadata.tsv"
-  $ rm -f "$TMP/sequences.fasta" "$TMP/metadata.tsv"
+  $ diff -u "$TESTDIR/parse/sequences.fasta" "sequences.fasta"
+  $ diff -u "$TESTDIR/parse/metadata.tsv" "metadata.tsv"
 
 Parse Zika sequences into sequences and metadata using a different metadata field as record id (e.g. accession)
 
   $ ${AUGUR} parse \
-  >   --sequences parse/zika.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences "$TESTDIR/parse/zika.fasta" \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --output-id-field accession \
   >   --fields strain virus accession date region country division city db segment authors url title journal paper_url \
   >   --prettify-fields region country division city \
   >   --fix-dates monthfirst
 
-  $ diff -u "parse/sequences_other.fasta" "$TMP/sequences.fasta"
-  $ diff -u "parse/metadata_other.tsv" "$TMP/metadata.tsv"
-  $ rm -f "$TMP/sequences.fasta" "$TMP/metadata.tsv"
+  $ diff -u "$TESTDIR/parse/sequences_other.fasta" "sequences.fasta"
+  $ diff -u "$TESTDIR/parse/metadata_other.tsv" "metadata.tsv"
 
 Try to parse Zika sequences with a misspelled field.
 This should fail.
 
   $ ${AUGUR} parse \
-  >   --sequences parse/zika.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences "$TESTDIR/parse/zika.fasta" \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --output-id-field notexist \
   >   --fields strain virus accession date region country division city db segment authors url title journal paper_url \
   >   --prettify-fields region country division city \
@@ -59,68 +56,64 @@ This should fail.
 Parse Zika sequences into sequences and metadata, preferred default ids is 'name', then 'strain', then first field.
 
   $ ${AUGUR} parse \
-  >   --sequences parse/zika.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences "$TESTDIR/parse/zika.fasta" \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --fields strain virus name date region country division city db segment authors url title journal paper_url \
   >   --output-id-field 'name' \
   >   --prettify-fields region country division city \
   >   --fix-dates monthfirst
 
-  $ diff -u "parse/sequences_other.fasta" "$TMP/sequences.fasta"
-  $ rm -f "$TMP/sequences.fasta" "$TMP/metadata.tsv"
+  $ diff -u "$TESTDIR/parse/sequences_other.fasta" "sequences.fasta"
 
 Parse Zika sequences into sequences and metadata when there is no 'name' field.
 This should use the 2nd entry in DEFAULT_ID_COLUMNS ('name', 'strain') instead.
 
   $ ${AUGUR} parse \
-  >   --sequences parse/zika.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences "$TESTDIR/parse/zika.fasta" \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --fields col1 virus strain date region country division city db segment authors url title journal paper_url \
   >   --prettify-fields region country division city \
   >   --fix-dates monthfirst
 
-  $ diff -u "parse/sequences_other.fasta" "$TMP/sequences.fasta"
-  $ rm -f "$TMP/sequences.fasta" "$TMP/metadata.tsv"
+  $ diff -u "$TESTDIR/parse/sequences_other.fasta" "sequences.fasta"
 
 Parse Zika sequences into sequences and metadata when no output-id-field is provided and none of the fields match DEFAULT_ID_COLUMNS (e.g. ('strain', 'name')).
 This should use the first field as the id field and the metadata should not have an extra strain or name column.
 
   $ ${AUGUR} parse \
-  >   --sequences parse/zika.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences "$TESTDIR/parse/zika.fasta" \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --fields col1 virus col3 date region country division city db segment authors url title journal paper_url \
   >   --prettify-fields region country division city \
   >   --fix-dates monthfirst
 
-  $ diff -u "parse/sequences.fasta" "$TMP/sequences.fasta"
-  $ diff "parse/metadata.tsv" "$TMP/metadata.tsv" | tr '>' '+' | tr '<' '-'
+  $ diff -u "$TESTDIR/parse/sequences.fasta" "sequences.fasta"
+  $ diff "$TESTDIR/parse/metadata.tsv" "metadata.tsv" | tr '>' '+' | tr '<' '-'
   1c1
   - strain\tvirus\taccession\tdate\tregion\tcountry\tdivision\tcity\tdb\tsegment\tauthors\turl\ttitle\tjournal\tpaper_url (esc)
   ---
   + col1\tvirus\tcol3\tdate\tregion\tcountry\tdivision\tcity\tdb\tsegment\tauthors\turl\ttitle\tjournal\tpaper_url (esc)
   [1]
-  $ rm -f "$TMP/sequences.fasta" "$TMP/metadata.tsv"
 
 Parse compressed Zika sequences into sequences and metadata.
 
   $ ${AUGUR} parse \
-  >   --sequences parse/zika.fasta.gz \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences "$TESTDIR/parse/zika.fasta.gz" \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --fields strain virus accession date region country division city db segment authors url title journal paper_url \
   >   --prettify-fields region country division city \
   >   --fix-dates monthfirst
 
-  $ diff -u "parse/sequences.fasta" "$TMP/sequences.fasta"
-  $ diff -u "parse/metadata.tsv" "$TMP/metadata.tsv"
-  $ rm -f "$TMP/sequences.fasta" "$TMP/metadata.tsv"
+  $ diff -u "$TESTDIR/parse/sequences.fasta" "sequences.fasta"
+  $ diff -u "$TESTDIR/parse/metadata.tsv" "metadata.tsv"
 
 Error on the first duplicate.
 
-  $ cat >$TMP/data.fasta <<~~
+  $ cat >data.fasta <<~~
   > >SEQ1
   > AAA
   > >SEQ1
@@ -131,28 +124,25 @@ Error on the first duplicate.
   > AAA
   > ~~
   $ ${AUGUR} parse \
-  >   --sequences $TMP/data.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences data.fasta \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --fields strain
   ERROR: Duplicate found for 'SEQ1'.
   [2]
 
 Run without --fix-dates. The date is left unchanged.
 
-  $ cat >$TMP/data.fasta <<~~
+  $ cat >data.fasta <<~~
   > >SEQ1|05/01/2020
   > AAA
   > ~~
   $ ${AUGUR} parse \
-  >   --sequences $TMP/data.fasta \
-  >   --output-sequences "$TMP/sequences.fasta" \
-  >   --output-metadata "$TMP/metadata.tsv" \
+  >   --sequences data.fasta \
+  >   --output-sequences "sequences.fasta" \
+  >   --output-metadata "metadata.tsv" \
   >   --fields strain date
 
-  $ cat "$TMP/metadata.tsv"
+  $ cat "metadata.tsv"
   strain	date
   SEQ1	05/01/2020
-  $ rm -f "$TMP/metadata.tsv"
-
-  $ popd > /dev/null

--- a/tests/functional/titers/cram/titers-sub-with-tree-and-custom-prefix.t
+++ b/tests/functional/titers/cram/titers-sub-with-tree-and-custom-prefix.t
@@ -10,10 +10,10 @@ Test titer substitution model with alignment and tree inputs and a custom prefix
   >   --alignment $TESTDIR/../data/aa_seq_HA1.fasta \
   >   --gene-names HA1 \
   >   --attribute-prefix custom_prefix_ \
-  >   --output $TMP/titers-sub.json > /dev/null
+  >   --output titers-sub.json > /dev/null
   Read titers from */data/titers.tsv, found: (glob)
    --- 62 strains
    --- 15 data sources
    --- 272 total measurements
-  $ grep custom_prefix_cTiterSub $TMP/titers-sub.json | wc -l
+  $ grep custom_prefix_cTiterSub titers-sub.json | wc -l
   \s*120 (re)

--- a/tests/functional/titers/cram/titers-sub-with-tree.t
+++ b/tests/functional/titers/cram/titers-sub-with-tree.t
@@ -9,12 +9,12 @@ Test titer substitution model with alignment and tree inputs.
   >   --titers $TESTDIR/../data/titers.tsv \
   >   --alignment $TESTDIR/../data/aa_seq_HA1.fasta \
   >   --gene-names HA1 \
-  >   --output $TMP/titers-sub.json > /dev/null
+  >   --output titers-sub.json > /dev/null
   Read titers from */data/titers.tsv, found: (glob)
    --- 62 strains
    --- 15 data sources
    --- 272 total measurements
-  $ grep cTiterSub $TMP/titers-sub.json | wc -l
+  $ grep cTiterSub titers-sub.json | wc -l
   \s*120 (re)
 
 Verify that the titer drops assigned per branch correspond to the expected values for this dataset.
@@ -22,5 +22,5 @@ In this example, we know that the HA1 amino acid sequence for A/Fujian/445/2003 
 The titer model assigns a higher weight of 1.22 to the opposite substitution N193S.
 When we search for that sequence's per-branch titer drop, we should get the smaller value below.
 
-  $ jq -r '.nodes["A/Fujian/445/2003"].dTiterSub' $TMP/titers-sub.json
+  $ jq -r '.nodes["A/Fujian/445/2003"].dTiterSub' titers-sub.json
   0.6* (glob)

--- a/tests/functional/titers/cram/titers-tree-with-custom-prefix.t
+++ b/tests/functional/titers/cram/titers-tree-with-custom-prefix.t
@@ -8,10 +8,10 @@ Test titer tree model with a custom prefix for the node data attributes in the o
   >   --tree $TESTDIR/../data/tree.nwk \
   >   --titers $TESTDIR/../data/titers.tsv \
   >   --attribute-prefix custom_prefix_ \
-  >   --output $TMP/titers-tree.json > /dev/null
+  >   --output titers-tree.json > /dev/null
   Read titers from */data/titers.tsv, found: (glob)
    --- 62 strains
    --- 15 data sources
    --- 272 total measurements
-  $ grep custom_prefix_cTiter $TMP/titers-tree.json | wc -l
+  $ grep custom_prefix_cTiter titers-tree.json | wc -l
   \s*120 (re)

--- a/tests/functional/titers/cram/titers-tree.t
+++ b/tests/functional/titers/cram/titers-tree.t
@@ -7,10 +7,10 @@ Test titer tree model.
   $ ${AUGUR} titers tree \
   >   --tree $TESTDIR/../data/tree.nwk \
   >   --titers $TESTDIR/../data/titers.tsv \
-  >   --output $TMP/titers-tree.json > /dev/null
+  >   --output titers-tree.json > /dev/null
   Read titers from */data/titers.tsv, found: (glob)
    --- 62 strains
    --- 15 data sources
    --- 272 total measurements
-  $ grep cTiter $TMP/titers-tree.json | wc -l
+  $ grep cTiter titers-tree.json | wc -l
   \s*120 (re)

--- a/tests/functional/traits.t
+++ b/tests/functional/traits.t
@@ -1,76 +1,65 @@
 Integration tests for augur traits.
 
   $ source "$TESTDIR"/_setup.sh
-  $ pushd "$TESTDIR" > /dev/null
 
 Infer the ancestral region for a given tree and metadata.
 
   $ ${AUGUR} traits \
-  >  --metadata "traits/metadata.tsv" \
-  >  --tree "traits/tree.nwk" \
+  >  --metadata "$TESTDIR/traits/metadata.tsv" \
+  >  --tree "$TESTDIR/traits/tree.nwk" \
   >  --columns region \
-  >  --output-node-data "$TMP/traits.json" > /dev/null
+  >  --output-node-data "traits.json" > /dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "traits/traits_region.json" "$TMP/traits.json" --significant-digits 5
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/traits/traits_region.json" "traits.json" --significant-digits 5
   {}
-  $ rm -f "$TMP/traits.json"
 
 Infer the ancestral region for a tree and metadata where one or more records have a missing value ("?") in the region field.
 Tips with missing values should get their values inferred, too.
 In this case, a sample from Panama (North America) has its region inferred as "South America".
 
   $ ${AUGUR} traits \
-  >  --metadata "traits/metadata_with_missing_region.tsv" \
-  >  --tree "traits/tree.nwk" \
+  >  --metadata "$TESTDIR/traits/metadata_with_missing_region.tsv" \
+  >  --tree "$TESTDIR/traits/tree.nwk" \
   >  --columns region \
-  >  --output-node-data "$TMP/traits.json" > /dev/null
+  >  --output-node-data "traits.json" > /dev/null
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "traits/traits_with_missing_region.json" "$TMP/traits.json" --significant-digits 2
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/traits/traits_with_missing_region.json" "traits.json" --significant-digits 2
   {}
-  $ rm -f "$TMP/traits.json"
 
 Infer the ancestral "virus" value from the same metadata.
 Since there is only a single virus in the data, Augur warns the user through stderr.
 
   $ ${AUGUR} traits \
-  >  --metadata "traits/metadata.tsv" \
-  >  --tree "traits/tree.nwk" \
+  >  --metadata "$TESTDIR/traits/metadata.tsv" \
+  >  --tree "$TESTDIR/traits/tree.nwk" \
   >  --columns virus \
-  >  --output-node-data "$TMP/traits.json" > /dev/null
+  >  --output-node-data "traits.json" > /dev/null
   WARNING: only one state found for discrete state reconstruction: ['zika']
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "traits/traits_virus.json" "$TMP/traits.json" --significant-digits 5
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/traits/traits_virus.json" "traits.json" --significant-digits 5
   {}
-  $ rm -f "$TMP/traits.json"
 
 Repeat inference of a trait with a single value, but request confidence intervals.
 This should similarly warn the user through stderr, but it should produce an error.
 
   $ ${AUGUR} traits \
-  >  --metadata "traits/metadata.tsv" \
-  >  --tree "traits/tree.nwk" \
+  >  --metadata "$TESTDIR/traits/metadata.tsv" \
+  >  --tree "$TESTDIR/traits/tree.nwk" \
   >  --columns virus \
   >  --confidence \
-  >  --output-node-data "$TMP/traits.json" > /dev/null
+  >  --output-node-data "traits.json" > /dev/null
   WARNING: only one state found for discrete state reconstruction: ['zika']
 
-  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "traits/traits_virus.json" "$TMP/traits.json" --significant-digits 5
+  $ python3 "$TESTDIR/../../scripts/diff_jsons.py" "$TESTDIR/traits/traits_virus.json" "traits.json" --significant-digits 5
   {}
-  $ rm -f "$TMP/traits.json"
 
 Infer the ancestral "virus" value from the metadata after replacing the "zika" values with missing data values ("?").
 Augur should warn that there were no discrete states found for reconstruction, since "?" is not a valid state on its own.
 
-  $ sed 's/zika/?/' traits/metadata.tsv > "$TMP/metadata_with_missing_virus.tsv"
+  $ sed 's/zika/?/' "$TESTDIR/traits/metadata.tsv" > "metadata_with_missing_virus.tsv"
   $ ${AUGUR} traits \
-  >  --metadata "$TMP/metadata_with_missing_virus.tsv" \
-  >  --tree "traits/tree.nwk" \
+  >  --metadata "metadata_with_missing_virus.tsv" \
+  >  --tree "$TESTDIR/traits/tree.nwk" \
   >  --columns virus \
-  >  --output-node-data "$TMP/traits.json" > /dev/null
+  >  --output-node-data "traits.json" > /dev/null
   WARNING: no states found for discrete state reconstruction.
-
-  $ rm -f "$TMP/traits.json"
-
-Switch back to the original directory where testing started.
-
-  $ popd > /dev/null


### PR DESCRIPTION
## Description of proposed changes

Use default temp directory in Cram tests for ancestral, measurements, parse, titers, and traits.

I did this mostly because the use of the custom temp directory would cause tests to fail in the pytest-prysk test runs, but this is also part of effort to reorganize functional test files described in <https://github.com/nextstrain/augur/issues/1176>.

## Checklist

- [x] Automated checks pass
- [ ] ~[Check][1] if you need to add a changelog message~
- [ ] ~[Check][2] if you need to add tests~
- [ ] ~[Check][3] if you need to update docs~

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
