### PR TITLE
Add 'sharing.screenshot' to config schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* [export] Add `sharing.screenshot` to the auspice-config schema which was unintentionally omitted in the previous release. [#1999][] @jameshadfield
+
+[#1999]: https://github.com/nextstrain/augur/pull/1999
 
 ## 33.2.0 (13 May 2026)
 

--- a/augur/data/schema-auspice-config-v2.json
+++ b/augur/data/schema-auspice-config-v2.json
@@ -307,6 +307,10 @@
             "entropy": {
               "type": "boolean",
               "description": "Enable/disable downloading entropy panel data (where the dataset supports it)"
+            },
+            "screenshot": {
+              "type": "boolean",
+              "description": "Enable/disable downloading a SVG screenshot"
             }
           }
         },

--- a/augur/export_v2.py
+++ b/augur/export_v2.py
@@ -546,7 +546,7 @@ def transfer_directly_from_config(data_json, config, key):
         auspice JSON to be updated
     config : dict
         config JSON with an expected
-    key : string
+    key : str
         key to lookup data (in config) and set data (in data_json.meta)
 
     Examples


### PR DESCRIPTION
I forgot to add this property in #1993

