### PR TITLE
Run docs CI on Augur code changes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
     paths: &paths
+      - augur/**
       - docs/**
       - setup.py
       - .github/workflows/docs.yaml


### PR DESCRIPTION
## Description of proposed changes

As noted in the commit message of "[export] fix incorrect type def" (9d178e5), the invalid type definition introduced in "[minor] refactor config transfer functions for export" (5981840) did not surface the failure until another PR touched docs-related files.

This will result in unnecessary runs for code changes that don't touch docstrings, but that's fine and was already the case before splitting docs CI into its own workflow.

## Related issue(s)

Follow-up to 9d178e5

## Checklist

- [x] Automated checks pass
- [x] ~[Check][1] if you need to add a changelog message~
- [x] ~[Check][2] if you need to add tests~
- [x] ~[Check][3] if you need to update docs~

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
