### PR TITLE
.github/docs: Only run linkcheck on scheduled runs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,3 +25,4 @@ jobs:
     with:
       docs-directory: docs/
       pip-install-target: .[dev]
+      run-linkcheck: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,13 +4,8 @@ on:
   push:
     branches:
       - master
-    paths: &paths
-      - docs/**
-      - setup.py
-      - .github/workflows/docs.yaml
 
   pull_request:
-    paths: *paths
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Description of proposed changes

Reduce noise from false positive linkchecks by only running linkcheck for the scheduled workflow runs.

## Related issue(s)

Related to https://github.com/nextstrain/.github/pull/170
Prompted by https://github.com/nextstrain/augur/pull/2002

## Checklist

- [x] Automated checks pass
- [ ] ~[Check][1] if you need to add a changelog message~
- [ ] ~[Check][2] if you need to add tests~
- [ ] ~[Check][3] if you need to update docs~

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
