### PR TITLE
filter: Handle ambiguity in date ranges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* filter: Fix handling of date ranges with `--group-by` and `--exclude-ambiguous-dates-by`. [#2007][] @victorlin
+
+[#2007]: https://github.com/nextstrain/augur/issues/2007
 
 ## 33.4.0 (2 June 2026)
 

--- a/augur/dates/__init__.py
+++ b/augur/dates/__init__.py
@@ -90,34 +90,30 @@ def numeric_date_type(date):
 
 def is_date_ambiguous(date, ambiguous_by):
     """
-    Returns whether a given date string in the format of YYYY-MM-DD is ambiguous by a given part of the date (e.g., day, month, year, or any parts).
+    Returns whether a given date string is ambiguous by a given part of the date
+    (e.g., day, month, year, or any parts).
 
     Parameters
     ----------
     date : str
-        Date string in the format of YYYY-MM-DD
+        Date string
     ambiguous_by : str
         Field of the date string to test for ambiguity ("day", "month", "year", "any")
     """
-    date_components = date.split('-', 2)
-
-    if len(date_components) == 3:
-        year, month, day = date_components
-    elif len(date_components) == 2:
-        year, month = date_components
-        day = "XX"
-    else:
-        year = date_components[0] if date_components[0] else 'X'
-        month = "XX"
-        day = "XX"
+    try:
+        year, month, day = get_year_month_day(date)
+    except InvalidDate:
+        return True
 
     # Determine ambiguity hierarchically such that, for example, an ambiguous
     # month implicates an ambiguous day even when day information is available.
-    return any((
-        "X" in year,
-        "X" in month and ambiguous_by in ("any", "month", "day"),
-        "X" in day and ambiguous_by in ("any", "day")
-    ))
+    if year is None:
+        return True
+    if month is None and ambiguous_by in ("any", "month", "day"):
+        return True
+    if day is None and ambiguous_by in ("any", "day"):
+        return True
+    return False
 
 
 def validate_dates(

--- a/tests/dates/test_dates.py
+++ b/tests/dates/test_dates.py
@@ -169,6 +169,12 @@ class TestDates:
         assert dates.is_date_ambiguous("2019-XX", "any")
         assert dates.is_date_ambiguous("2019-XX", "day")
 
+        # Test date ranges with ambiguous values.
+        assert dates.is_date_ambiguous("2019-01-01/2020-01-01", "year")
+        assert dates.is_date_ambiguous("2019-01-01/2019-02-01", "month")
+        assert dates.is_date_ambiguous("2019-01-01/2019-01-02", "day")
+        assert dates.is_date_ambiguous("2019-01-01/2019-01-02", "any")
+
         # Test complete date strings without ambiguous dates for the requested field.
         assert not dates.is_date_ambiguous("2019-09-03", "any")
         assert not dates.is_date_ambiguous("2019-03-XX", "month")
@@ -178,6 +184,11 @@ class TestDates:
         # Test incomplete date strings without ambiguous dates for the requested fields.
         assert not dates.is_date_ambiguous("2019", "year")
         assert not dates.is_date_ambiguous("2019-10", "month")
+
+        # Test date ranges without ambiguous dates for the requested fields.
+        assert not dates.is_date_ambiguous("2019-01-01/2019-12-31", "year")
+        assert not dates.is_date_ambiguous("2019-01-01/2019-01-31", "month")
+        assert not dates.is_date_ambiguous("2019-01-01/2019-01-01", "day")
 
     def test_get_numerical_dates_dict_error(self):
         """Using get_numerical_dates with metadata represented as a dict should raise an error."""


### PR DESCRIPTION
## Description of proposed changes

"Support precise date ranges" (2387af80) added a new way to express ambiguity but forgot to take that into account in is_date_ambiguous(), affecting various use cases in augur filter.

## Related issue(s)

Closes #2007

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
