### PR TITLE
Use zstd from stdlib/backport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* Bump minimum xopen version to 2.1.0. This removes the indirect dependency on `zstandard` as there is built-in zstd support in Python 3.10 and an equivalent backport for older versions. [#2009][] @victorlin
+
+[#2007]: https://github.com/nextstrain/augur/pull/2009
 
 ## 33.4.1 (2 June 2026)
 

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,8 @@ setuptools.setup(
             "types-PyYAML",
             "types-setuptools",
             "wheel >=0.32.3",
-            "ipdb >=0.10.1"
+            "ipdb >=0.10.1",
+            "zstandard",
         ]
     },
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
     extras_require = {
         'dev': [
             "cram >=0.7",
+            "backports.zstd; python_version < '3.14'",
             "deepdiff >=4.3.2, <8.0.0",
             "flake8 >=7.0.0, <8",
             "freezegun >=0.3.15",
@@ -98,8 +99,7 @@ setuptools.setup(
             "types-PyYAML",
             "types-setuptools",
             "wheel >=0.32.3",
-            "ipdb >=0.10.1",
-            "zstandard",
+            "ipdb >=0.10.1"
         ]
     },
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setuptools.setup(
         "pyyaml",
         "referencing >=0.29.1, <1.0",
         "scipy ==1.*",
-        "xopen[zstd] >=2.0.0, <3"
+        "xopen >=2.1.0, <3"
     ],
     extras_require = {
         'dev': [

--- a/tests/io/test_file.py
+++ b/tests/io/test_file.py
@@ -1,5 +1,11 @@
 import pytest
+import sys
 import augur.io.file
+
+if sys.version_info >= (3, 14):
+    from compression import zstd
+else:
+    from backports import zstd
 
 
 class TestFile:
@@ -57,7 +63,6 @@ class TestFile:
 
     def test_open_file_read_zstd(self, tmpdir):
         """Read a text file compressed with zstd."""
-        import zstandard as zstd
         path = str(tmpdir / 'test.txt.zst')
         with zstd.open(path, 'wt') as f_write:
             f_write.write('foo\nbar\n')
@@ -66,7 +71,6 @@ class TestFile:
 
     def test_open_file_write_zstd(self, tmpdir):
         """Write a text file compressed with zstd."""
-        import zstandard as zstd
         path = str(tmpdir / 'test.txt.zst')
         with augur.io.file.open_file(path, 'w') as f_write:
             f_write.write('foo\nbar\n')
@@ -85,7 +89,6 @@ class TestFile:
 
     def test_open_file_nested_read_zstd(self, tmpdir):
         """Open a zstd-compressed text file as a path then buffer for reading."""
-        import zstandard as zstd
         path = str(tmpdir / 'test.txt.zst')
         with zstd.open(path, 'wt') as f_write:
             f_write.write('foo\nbar\n')


### PR DESCRIPTION
The first commit addresses test failures that came with release of [xopen 2.1.0](https://pypi.org/project/xopen/2.1.0/) (specifically https://github.com/pycompression/xopen/commit/755210b207e94000e6639fb8ea8f1523d767274e).

The other two commits follow through with related improvements, but are not strictly necessary.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
