### PR TITLE
filter: speed up subsampling and metadata output on large datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * filter: Improved the speed and memory usage of subsampling with `--group-by` and `--subsample-max-sequences` by caching each record's group during the first pass instead of reading the metadata a second time. [#2018][] @trvrb
+* filter: Improved the speed of computing groups for `--group-by` subsampling by replacing a row-wise pandas apply with a vectorized operation. [#2018][] @trvrb
 
 [#2018]: https://github.com/nextstrain/augur/pull/2018
 [#2025]: https://github.com/nextstrain/augur/pull/2025

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@
 
 * distance: Add `--output-edge-list` argument to save pairwise distances between sequences to an edge list TSV file for better compatibility with MicrobeTrace. [#2025][] @huddlej
 
+### Bug fixes
+
+* filter: Improved the speed and memory usage of subsampling with `--group-by` and `--subsample-max-sequences` by caching each record's group during the first pass instead of reading the metadata a second time. [#2018][] @trvrb
+
+[#2018]: https://github.com/nextstrain/augur/pull/2018
 [#2025]: https://github.com/nextstrain/augur/pull/2025
 
 ## 34.0.0 (7 July 2026)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 * filter: Improved the speed and memory usage of subsampling with `--group-by` and `--subsample-max-sequences` by caching each record's group during the first pass instead of reading the metadata a second time. [#2018][] @trvrb
 * filter: Improved the speed of computing groups for `--group-by` subsampling by replacing a row-wise pandas apply with a vectorized operation. [#2018][] @trvrb
+* filter: Improved the speed of writing `--output-metadata` by streaming rows instead of building a dictionary per row. [#2018][] @trvrb
 
 [#2018]: https://github.com/nextstrain/augur/pull/2018
 [#2025]: https://github.com/nextstrain/augur/pull/2025

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -142,12 +142,15 @@ def run(args):
     # and use a second pass to add records to the queue.
     group_by = args.group_by
     sequences_per_group = args.sequences_per_group
-    records_per_group = None
+    strains_by_group = None
 
     if group_by and args.subsample_max_sequences:
-        # In this case, we need two passes through the metadata with the first
-        # pass used to count the number of records per group.
-        records_per_group = defaultdict(int)
+        # In this case, we need to count the number of records per group before
+        # we know how many sequences to keep per group. We cache each group's
+        # strains during the first pass (group keys are shared across chunks) so
+        # we can populate the priority queues without reading the metadata a
+        # second time.
+        strains_by_group = defaultdict(list)
     elif not group_by and args.subsample_max_sequences:
         group_by = ("_dummy",)
         sequences_per_group = args.subsample_max_sequences
@@ -270,12 +273,20 @@ def run(args):
                 group_by,
             )
 
-            if args.subsample_max_sequences and records_per_group is not None:
-                # Count the number of records per group. We will use this
-                # information to calculate the number of sequences per group
-                # for the given maximum number of requested sequences.
-                for group in group_by_strain.values():
-                    records_per_group[group] += 1
+            if args.subsample_max_sequences and strains_by_group is not None:
+                # Cache each record's group assignment (in the same order it
+                # would be added to a priority queue) so we can avoid a second
+                # pass through the metadata.
+                for strain in sorted(group_by_strain.keys()):
+                    group = group_by_strain[strain]
+                    strains_by_group[group].append(strain)
+
+                    # Assign each strain's priority now, in the order of a single
+                    # pass through the metadata. When priorities are random
+                    # (no --priority file), they are generated on first access,
+                    # so this preserves the values regardless of the order in
+                    # which groups are later drained into the priority queues.
+                    priorities[strain]
             else:
                 # Track the highest priority records, when we already
                 # know the number of sequences allowed per group.
@@ -301,10 +312,11 @@ def run(args):
     # requested maximum number of sequences and the number of sequences per
     # group. Then, we need to make a second pass through the metadata to find
     # the requested number of records.
-    if args.subsample_max_sequences and records_per_group is not None:
+    if args.subsample_max_sequences and strains_by_group is not None:
         if queues_by_group is None:
             # We know all of the possible groups now from the first pass through
             # the metadata, so we can create queues for all groups at once.
+            records_per_group = {group: len(strains) for group, strains in strains_by_group.items()}
             if args.group_by_weights:
                 print_err(f"Sampling with weights defined by {args.group_by_weights}.")
                 group_sizes = get_weighted_group_sizes(
@@ -341,37 +353,13 @@ def run(args):
                     group_sizes = {group: sequences_per_group for group in records_per_group.keys()}
             queues_by_group = create_queues_by_group(group_sizes)
 
-        print_debug(f"Reading metadata from {args.metadata!r}…")
-        # Make a second pass through the metadata, only considering records that
-        # have passed filters.
-        metadata_reader = read_metadata(
-            args.metadata,
-            delimiters=args.metadata_delimiters,
-            columns=useful_metadata_columns,
-            id_columns=args.metadata_id_columns,
-            chunk_size=args.metadata_chunk_size,
-            dtype="string",
-        )
-        for metadata in metadata_reader:
-            # Recalculate groups for subsampling as we loop through the
-            # metadata a second time. TODO: We could store these in memory
-            # during the first pass, but we want to minimize overall memory
-            # usage at the moment.
-            seq_keep = set(metadata.index.values) & valid_strains
-
-            # Prevent force-included strains from being considered in this
-            # second pass, as in the first pass.
-            seq_keep = seq_keep - all_sequences_to_include
-
-            group_by_strain = get_groups_for_subsampling(
-                seq_keep,
-                metadata,
-                group_by,
-            )
-
-            for strain in sorted(group_by_strain.keys()):
-                group = group_by_strain[strain]
-                queues_by_group[group].add(
+        # Populate the priority queues using the strains cached per group during
+        # the first pass, in the same order they were encountered, so we avoid
+        # reading the metadata a second time.
+        for group, strains in strains_by_group.items():
+            queue = queues_by_group[group]
+            for strain in strains:
+                queue.add(
                     strain,
                     priorities[strain],
                 )

--- a/augur/filter/_run.py
+++ b/augur/filter/_run.py
@@ -419,8 +419,7 @@ def run(args):
 
     if args.output_metadata:
         print_debug(f"Reading metadata from {args.metadata!r} and writing to {args.output_metadata!r}…")
-        write_output_metadata(args.metadata, args.metadata_delimiters,
-                              args.metadata_id_columns, args.output_metadata,
+        write_output_metadata(metadata_object, args.output_metadata,
                               valid_strains)
 
     # Calculate the number of strains that don't exist in either metadata or

--- a/augur/filter/io.py
+++ b/augur/filter/io.py
@@ -96,23 +96,20 @@ def read_priority_scores(fname):
         raise AugurError(f"missing or malformed priority scores file {fname}")
 
 
-def write_output_metadata(input_metadata_path: str, delimiters: Sequence[str],
-                          id_columns: Sequence[str], output_metadata_path: str,
+def write_output_metadata(input_metadata: Metadata, output_metadata_path: str,
                           ids_to_write: Set[str]):
     """
-    Write output metadata file given input metadata information and a set of IDs
-    to write.
+    Write output metadata file given the input metadata and a set of IDs to
+    write.
     """
-    input_metadata = Metadata(input_metadata_path, delimiters, id_columns)
-
     with xopen(output_metadata_path, "w", newline="") as output_metadata_handle:
-        output_metadata = csv.DictWriter(output_metadata_handle, fieldnames=input_metadata.columns,
-                                         delimiter="\t", lineterminator=os.linesep)
-        output_metadata.writeheader()
+        output_metadata = csv.writer(output_metadata_handle,
+                                     delimiter="\t", lineterminator=os.linesep)
+        output_metadata.writerow(input_metadata.columns)
 
         # Write outputs based on rows in the original metadata.
         for row in input_metadata.rows():
-            row_id = row[input_metadata.id_column]
+            row_id = row[input_metadata.columns.index(input_metadata.id_column)]
             if row_id in ids_to_write:
                 output_metadata.writerow(row)
 

--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -170,8 +170,10 @@ def get_groups_for_subsampling(strains, metadata, group_by=None):
         for group in unknown_groups:
             metadata[group] = 'unknown'
 
-    # Finally, determine groups.
-    group_by_strain = dict(zip(metadata.index, metadata[group_by].apply(tuple, axis=1)))
+    # Finally, determine groups. Use itertuples() rather than a row-wise
+    # apply(tuple, axis=1), which is significantly faster on large inputs while
+    # producing the same group tuples.
+    group_by_strain = dict(zip(metadata.index, metadata[group_by].itertuples(index=False, name=None)))
     return group_by_strain
 
 

--- a/augur/io/metadata.py
+++ b/augur/io/metadata.py
@@ -697,27 +697,28 @@ class Metadata:
         raise AugurError(f"{self.path}: None of the possible id columns ({', '.join(map(repr, columns))}) were found in the metadata's columns ({', '.join(map(repr, self.columns))}).")
 
     def rows(self, strict: bool = True):
-        """Yield rows in a dictionary format. Empty lines are ignored.
+        """Yield rows as lists of values, in column order. Empty lines are ignored.
 
         Parameters
         ----------
         strict
             If True, raise an error when a row contains more or less than the number of expected columns.
         """
+        num_columns = len(self.columns)
         with self.open() as f:
-            reader = csv.DictReader(f, delimiter=self.delimiter, fieldnames=self.columns, restkey=None, restval=None)
+            reader = csv.reader(f, delimiter=self.delimiter)
 
             # Skip the header row.
             next(reader)
 
-            # NOTE: Empty lines are ignored by csv.DictReader.
-            # <https://github.com/python/cpython/blob/647b6cc7f16c03535cede7e1748a58ab884135b2/Lib/csv.py#L181-L185>
             for row in reader:
+                # Ignore empty lines.
+                if not row:
+                    continue
                 if strict:
-                    if None in row.keys():
+                    if len(row) > num_columns:
                         raise AugurError(f"{self.path}: Line {reader.line_num} contains at least one extra column. The inferred delimiter is {self.delimiter!r}.")
-                    if None in row.values():
-                        # This is distinct from a blank value (empty string).
+                    if len(row) < num_columns:
                         raise AugurError(f"{self.path}: Line {reader.line_num} is missing at least one column. The inferred delimiter is {self.delimiter!r}.")
                 yield row
 

--- a/devel/benchmark-filter
+++ b/devel/benchmark-filter
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Benchmark representative `augur filter` invocations against a metadata file.
+#
+# Useful for measuring the performance impact of changes to the filter command.
+# Times a few representative invocations (a query, a query writing metadata, and
+# a group-by subsample) and reports wall-clock time for each.
+#
+# Usage:
+#
+#     devel/benchmark-filter <metadata-file> [output-dir]
+#
+# <metadata-file> may be compressed (e.g. .tsv.zst, .tsv.xz). Outputs are
+# written to a temporary directory (or [output-dir] if given) and removed
+# afterwards unless an output directory is provided.
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: devel/benchmark-filter <metadata-file> [output-dir]" >&2
+    exit 1
+fi
+
+metadata="$1"
+augur="${AUGUR:-./bin/augur}"
+
+if [[ $# -ge 2 ]]; then
+    outdir="$2"
+    keep=1
+    mkdir -p "$outdir"
+else
+    outdir="$(mktemp -d)"
+    keep=0
+fi
+
+cleanup() {
+    if [[ "$keep" -eq 0 ]]; then
+        rm -rf "$outdir"
+    fi
+}
+trap cleanup EXIT
+
+run() {
+    local label="$1"; shift
+    echo "=== ${label} ==="
+    # Print the command, then time it. Errors/summary go to stderr as usual.
+    echo "+ ${augur} filter --metadata ${metadata} $*"
+    /usr/bin/time -p "${augur}" filter --metadata "$metadata" "$@"
+    echo
+}
+
+run "query, output-strains" \
+    --query "country == 'USA'" \
+    --output-strains "$outdir/strains.txt"
+
+run "query, output-metadata" \
+    --query "country == 'USA'" \
+    --output-metadata "$outdir/metadata.tsv"
+
+run "group-by + subsample-max-sequences, output-strains" \
+    --group-by region year month \
+    --subsample-max-sequences 50000 \
+    --subsample-seed 0 \
+    --output-strains "$outdir/subsampled.txt"

--- a/tests/io/test_metadata.py
+++ b/tests/io/test_metadata.py
@@ -564,10 +564,10 @@ class TestMetadataClass:
         """Check Metadata.rows() output format."""
         m = Metadata(metadata_file, delimiters=['\t'], id_columns=['strain'])
         assert list(m.rows()) == [
-            {'country': 'USA', 'date': '2020-10-01', 'strain': 'SEQ_A'},
-            {'country': 'USA', 'date': '2020-10-02', 'strain': 'SEQ_T'},
-            {'country': 'USA', 'date': '2020-10-03', 'strain': 'SEQ_C'},
-            {'country': 'USA', 'date': '2020-10-04', 'strain': 'SEQ_G'},
+            ['SEQ_A', 'USA', '2020-10-01'],
+            ['SEQ_T', 'USA', '2020-10-02'],
+            ['SEQ_C', 'USA', '2020-10-03'],
+            ['SEQ_G', 'USA', '2020-10-04'],
         ]
 
     def test_blank_lines(self, tmpdir):
@@ -586,10 +586,10 @@ class TestMetadataClass:
 
         m = Metadata(path, delimiters=',', id_columns=['a'])
         assert list(m.rows()) == [
-            {'a': '1', 'b': '2', 'c': '3'},
-            {'a': '3', 'b': '2', 'c': '3'},
-            {'a': '' , 'b': '' , 'c': '' },
-            {'a': '5', 'b': '2', 'c': '3'}
+            ['1', '2', '3'],
+            ['3', '2', '3'],
+            ['' , '' , '' ],
+            ['5', '2', '3'],
         ]
 
     def test_rows_strict_extra(self, tmpdir):
@@ -606,9 +606,9 @@ class TestMetadataClass:
             list(m.rows(strict=True))
 
         assert list(m.rows(strict=False)) == [
-            {'a': '1', 'b': '2', 'c': '3'},
-            {'a': '2', 'b': '2', 'c': '3', None: ['4']},
-            {'a': '3', 'b': '2', 'c': '3', None: ['']},
+            ['1', '2', '3'],
+            ['2', '2', '3', '4'],
+            ['3', '2', '3', ''],
         ]
 
     def test_rows_strict_missing(self, tmpdir):
@@ -625,9 +625,9 @@ class TestMetadataClass:
             list(m.rows(strict=True))
 
         assert list(m.rows(strict=False)) == [
-            {'a': '1', 'b': '2', 'c': '3'},
-            {'a': '2', 'b': '2', 'c': ''},
-            {'a': '3', 'b': '2', 'c': None},
+            ['1', '2', '3'],
+            ['2', '2', ''],
+            ['3', '2'],
         ]
 
     def test_rows_embedded_newline(self, tmpdir):
@@ -642,7 +642,7 @@ class TestMetadataClass:
         m = Metadata(path, delimiters=',', id_columns=['a'])
 
         assert list(m.rows()) == [
-            {'a': '1', 'b': '2', 'c': '3'},
-            {'a': '4', 'b': '5\r\n6', 'c': '7'},
-            {'a': '8', 'b': '9', 'c': '10'},
+            ['1', '2', '3'],
+            ['4', '5\r\n6', '7'],
+            ['8', '9', '10'],
         ]


### PR DESCRIPTION
_Via Claude_

## Summary

`augur filter` is remains a slow point in running `ncov` builds in particular. This PR makes three independent, **behavior-preserving** changes to two common calls. On the 9.4M-row open SARS-CoV-2 metadata:

- **Subsampling** (`--group-by … --subsample-max-sequences`): **135s → 66s (≈2.1×)**, and peak memory **~4.2 GB → ~3.6 GB**.
- **Query + `--output-metadata`**: **171s → 142s (≈1.2×)**.

Output is byte-identical to `master` in every case.

## What changed (3 commits)

1. **`filter: avoid second metadata pass when subsampling`** — With `--group-by` + `--subsample-max-sequences`, each record's group was computed during the first metadata pass only to count records per group, then the *entire metadata file was read and parsed a second time* to populate the priority queues. We now cache each record's group during the first pass — bucketed per group so group keys are shared (interned) across chunks rather than stored per record — and drain those caches into the queues. Random priorities are assigned during the first pass in metadata order so results are identical without the second read. Resolves a long-standing `TODO`. *(This is the bulk of the subsampling win and also lowers peak RSS.)*

2. **`filter: vectorize group computation for subsampling`** — `get_groups_for_subsampling()` built group tuples with a row-wise `DataFrame.apply(tuple, axis=1)`; replaced with `DataFrame.itertuples()`, which yields identical tuples far faster.

3. **`filter: stream --output-metadata instead of per-row dicts`** — `--output-metadata` re-read the full input with a `csv.DictReader` and re-serialized each kept row via `csv.DictWriter`, building one dict spanning every column for every row. We now stream with `csv.reader`/`csv.writer`, selecting rows by the id column's index. Input delimiter sniffing, TSV output, and the strict column-count checks are preserved, and we reuse the `Metadata` object already built earlier in the run.

## Benchmarks

**Methodology.** Single machine (macOS, Python 3.12, pandas 2.3.3), run against the open SARS-CoV-2 `metadata.tsv.zst` (9.4M rows, ~40 columns) via `./bin/augur`. Each commit was checked out and timed on both workloads; numbers below are the **minimum of two sequential passes** (run-to-run noise ≈1–3s), with output verified **byte-identical to `master` on every commit**. A `devel/benchmark-filter` helper is included to reproduce these runs.

Commands:

```
# subsample
augur filter --metadata metadata.tsv.zst \
  --group-by region year month --subsample-max-sequences 50000 \
  --subsample-seed 0 --output-strains strains.txt

# query + output-metadata
augur filter --metadata metadata.tsv.zst \
  --query "country == 'USA'" --output-metadata metadata.tsv
```

**Subsampling**

| Commit | Wall-clock | Δ vs previous | Cumulative |
|---|---|---|---|
| `master` (baseline) | 135.4s | — | 1.00× |
| avoid second metadata pass | 78.4s | −57.0s (−42%) | 1.73× |
| vectorize group computation | 65.0s | −13.4s (−17%) | 2.08× |
| stream `--output-metadata` | 65.7s | neutral (path unaffected) | 2.06× |

**Query + `--output-metadata`**

| Commit | Wall-clock | Δ vs previous | Cumulative |
|---|---|---|---|
| `master` (baseline) | 170.8s | — | 1.00× |
| avoid second metadata pass | 170.9s | neutral (path unaffected) | 1.00× |
| vectorize group computation | 170.4s | neutral (path unaffected) | 1.00× |
| stream `--output-metadata` | 142.2s | −28.2s (−16%) | 1.20× |

Each commit only moves the workload it targets, with the other column acting as a control: the subsampling gains come from commits 1–2, the `--output-metadata` gain from commit 3.

## An approach we tried and dropped

We also tried skipping the per-strain `{strain, filter, kwargs}` record that `apply_filters()` builds for every excluded/force-included strain (only building it when `--output-log` is set). It's a clean reduction in transient allocations, but in these benchmarks it was **wall-clock-neutral** (≈1–3s against ~170s runs dominated by decompression, parsing, and output), so we left it out to keep the diff focused on changes with measurable wins.

## Correctness

These are pure performance changes. Verified on both the 9.4M dataset and a 100k subset that `--output-strains`, `--output-metadata`, `--output-log`, and `--group-by … --subsample-max-sequences --subsample-seed` produce identical results to `master` (with `PYTHONHASHSEED=0` to make set-ordered outputs directly comparable). One subtlety worth noting for reviewers: random priorities (`defaultdict(rng.random)`) are assigned *on first access*, so commit 1 deliberately assigns them in metadata order during the first pass to keep subsampling output identical.

## Test plan

- [ ] `./run_tests.sh` (unit + doctests + cram)
- [ ] `mypy` and `npx pyright` clean
- [ ] Changelog entries added under `__NEXT__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
