### PR TITLE
docs/nitpick_ignore: suppress numpy GenericAlias warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,11 @@ nitpick_ignore = [
      ("py:class", "numpy.int8"),
      ("py:class", "numpy.int32"),
      ("py:class", "numpy.bool_"),
+     # numpy.typing.NDArray is expanded to GenericAlias which is not in the
+     # intersphinx inventory. Ignore to suppress warning for now, but we should
+     # look into how to avoid the alias expansion for
+     # <https://github.com/nextstrain/augur/issues/2017>
+     ("py:class", "numpy._typing._array_like.GenericAlias"),
 ]
 
 # -- Cross-project references ------------------------------------------------


### PR DESCRIPTION

## Description of proposed changes

Suppress the warning for now, but we should look into why numpy.typing.NDArray gets expanded to the GenericAlias class for <https://github.com/nextstrain/augur/issues/2017>.

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
