### PR TITLE
Add minimum code for pairwise distance edge lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Features
+
+* distance: Add `--output-edge-list` argument to save pairwise distances between sequences to an edge list TSV file for better compatibility with MicrobeTrace. [#2025][] @huddlej
+
+[#2025]: https://github.com/nextstrain/augur/pull/2025
 
 ## 34.0.0 (7 July 2026)
 

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -187,6 +187,7 @@ import pandas as pd
 import sys
 
 from .argparse_ import ExtendOverwriteDefault
+from .errors import AugurError
 from .frequency_estimators import timestamp_to_float
 from .io.file import open_file
 from .reconstruct_sequences import load_alignments
@@ -678,8 +679,7 @@ def register_parser(parent_subparsers):
 def run(args):
     # Check for supported comparisons for edge list output.
     if args.output_edge_list and args.compare_to != ["pairwise"]:
-        print("ERROR: Edge list output only works for a single pairwise comparison.", file=sys.stderr)
-        sys.exit(1)
+        raise AugurError("Edge list output only works for a single pairwise comparison.")
 
     # Load tree and annotate parents.
     tree = Bio.Phylo.read(args.tree, "newick")

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -180,6 +180,7 @@ import Bio
 import Bio.Phylo
 from collections import defaultdict
 import copy
+import csv
 from itertools import chain
 import json
 import pandas as pd
@@ -796,9 +797,10 @@ def run(args):
     write_augur_json({"params": params, "nodes": final_distances_by_node}, args.output)
 
     if args.output_edge_list and pairwise_distances_by_node is not None:
-        with open(args.output_edge_list, "w", encoding="utf-8") as oh:
-            print("sequence_1\tsequence_2\tdistance", file=oh)
+        with open_file(args.output_edge_list, "wt", encoding="utf-8", newline="") as oh:
+            tsv_writer = csv.writer(oh, delimiter = '\t', lineterminator='\n')
+            tsv_writer.writerow(["sequence_1", "sequence_2", "distance"])
 
             for sequence_1, nodes in pairwise_distances_by_node.items():
                 for sequence_2, distance in nodes.items():
-                    print(f"{sequence_1}\t{sequence_2}\t{distance}", file=oh)
+                    tsv_writer.writerow([sequence_1, sequence_2, distance])

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -675,6 +675,11 @@ def register_parser(parent_subparsers):
 
 
 def run(args):
+    # Check for supported comparisons for edge list output.
+    if args.output_edge_list and args.compare_to != ["pairwise"]:
+        print("ERROR: Edge list output only works for a single pairwise comparison.", file=sys.stderr)
+        sys.exit(1)
+
     # Load tree and annotate parents.
     tree = Bio.Phylo.read(args.tree, "newick")
     tree = annotate_parents_for_tree(tree)

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -724,7 +724,6 @@ def run(args):
 
     final_distances_by_node = {}
     distance_map_names = []
-    pairwise_distances_by_node = None
     for compare_to, attribute, distance_map_file in zip(args.compare_to, args.attribute_name, args.map):
         # Load the given distance map.
         distance_map = read_distance_map(distance_map_file)
@@ -758,7 +757,6 @@ def run(args):
                 earliest_date,
                 latest_date
             )
-            pairwise_distances_by_node = distances_by_node.copy()
         else:
             # If the command line argument choices are defined properly above,
             # this block should never execute.
@@ -796,11 +794,11 @@ def run(args):
     # Export distances to JSON.
     write_augur_json({"params": params, "nodes": final_distances_by_node}, args.output)
 
-    if args.output_edge_list and pairwise_distances_by_node is not None:
+    if args.output_edge_list:
         with open_file(args.output_edge_list, "wt", encoding="utf-8", newline="") as oh:
             tsv_writer = csv.writer(oh, delimiter = '\t', lineterminator='\n')
             tsv_writer.writerow(["sequence_1", "sequence_2", "distance"])
 
-            for sequence_1, nodes in pairwise_distances_by_node.items():
+            for sequence_1, nodes in distances_by_node.items():
                 for sequence_2, distance in nodes.items():
                     tsv_writer.writerow([sequence_1, sequence_2, distance])

--- a/augur/distance.py
+++ b/augur/distance.py
@@ -670,6 +670,7 @@ def register_parser(parent_subparsers):
     parser.add_argument("--earliest-date", help="earliest date at which samples are considered to be from previous seasons (e.g., 2019-01-01). This date is only used in pairwise comparisons. If omitted, all samples prior to the latest date will be considered.")
     parser.add_argument("--latest-date", help="latest date at which samples are considered to be from previous seasons (e.g., 2019-01-01); samples from any date after this are considered part of the current season")
     parser.add_argument("--output", help="JSON file with calculated distances stored by node name and attribute name", required=True)
+    parser.add_argument("--output-edge-list", help="TSV file of pairwise distances in 'edge list' format with columns for `sequence_1`, `sequence_2`, and `distance`. This argument only works when calculating pairwise distances for a single alignment.")
     return parser
 
 
@@ -717,6 +718,7 @@ def run(args):
 
     final_distances_by_node = {}
     distance_map_names = []
+    pairwise_distances_by_node = None
     for compare_to, attribute, distance_map_file in zip(args.compare_to, args.attribute_name, args.map):
         # Load the given distance map.
         distance_map = read_distance_map(distance_map_file)
@@ -750,6 +752,7 @@ def run(args):
                 earliest_date,
                 latest_date
             )
+            pairwise_distances_by_node = distances_by_node.copy()
         else:
             # If the command line argument choices are defined properly above,
             # this block should never execute.
@@ -786,3 +789,11 @@ def run(args):
 
     # Export distances to JSON.
     write_augur_json({"params": params, "nodes": final_distances_by_node}, args.output)
+
+    if args.output_edge_list and pairwise_distances_by_node is not None:
+        with open(args.output_edge_list, "w", encoding="utf-8") as oh:
+            print("sequence_1\tsequence_2\tdistance", file=oh)
+
+            for sequence_1, nodes in pairwise_distances_by_node.items():
+                for sequence_2, distance in nodes.items():
+                    print(f"{sequence_1}\t{sequence_2}\t{distance}", file=oh)

--- a/tests/functional/distance.t
+++ b/tests/functional/distance.t
@@ -1,0 +1,74 @@
+Integration tests for augur distance.
+
+  $ source "$TESTDIR"/_setup.sh
+
+Build a tree to use for distance calculations.
+
+  $ ${AUGUR} tree \
+  >   --alignment "$TESTDIR/distance/aligned.fasta" \
+  >   --output "tree_raw.nwk" &> /dev/null
+
+Refine tree to get internal node names.
+
+  $ ${AUGUR} refine \
+  >   --tree "tree_raw.nwk" \
+  >   --output-tree "tree.nwk" &> /dev/null
+
+Calculate pairwise distances and write them to an edge list.
+
+  $ ${AUGUR} distance \
+  >   --tree "tree.nwk" \
+  >   --alignment "$TESTDIR/distance/aligned.fasta" \
+  >   --gene-names nuc \
+  >   --attribute-name snvs \
+  >   --compare-to pairwise \
+  >   --map "$TESTDIR/distance/distance_map_hamming.json" \
+  >   --output distances.json \
+  >   --output-edge-list /dev/stdout
+  sequence_1	sequence_2	distance
+  with_gaps	with_gaps	0
+  with_gaps	some_other_seq	1
+  with_gaps	no_gaps	0
+  with_gaps	_R_crick_strand	0
+  some_other_seq	with_gaps	1
+  some_other_seq	some_other_seq	0
+  some_other_seq	no_gaps	1
+  some_other_seq	_R_crick_strand	1
+  no_gaps	with_gaps	0
+  no_gaps	some_other_seq	1
+  no_gaps	no_gaps	0
+  no_gaps	_R_crick_strand	0
+  _R_crick_strand	with_gaps	0
+  _R_crick_strand	some_other_seq	1
+  _R_crick_strand	no_gaps	0
+  _R_crick_strand	_R_crick_strand	0
+
+Try to calculate distance from the root with edge list output.
+This should fail because we only support edge lists for pairwise comparisons.
+
+  $ ${AUGUR} distance \
+  >   --tree "tree.nwk" \
+  >   --alignment "$TESTDIR/distance/aligned.fasta" \
+  >   --gene-names nuc \
+  >   --attribute-name snvs \
+  >   --compare-to root \
+  >   --map "$TESTDIR/distance/distance_map_hamming.json" \
+  >   --output distances.json \
+  >   --output-edge-list distances_edge_list.tsv
+  ERROR: Edge list output only works for a single pairwise comparison.
+  [1]
+
+Try to calculate distances with both root and pairwise comparisons and using edge list output.
+This should fail because we only support edge list output for a single pairwise comparison.
+
+  $ ${AUGUR} distance \
+  >   --tree "tree.nwk" \
+  >   --alignment "$TESTDIR/distance/aligned.fasta" \
+  >   --gene-names nuc \
+  >   --attribute-name snvs snvs_pairwise \
+  >   --compare-to root pairwise \
+  >   --map "$TESTDIR/distance/distance_map_hamming.json" \
+  >   --output distances.json \
+  >   --output-edge-list distances_edge_list.tsv
+  ERROR: Edge list output only works for a single pairwise comparison.
+  [1]

--- a/tests/functional/distance.t
+++ b/tests/functional/distance.t
@@ -56,7 +56,7 @@ This should fail because we only support edge lists for pairwise comparisons.
   >   --output distances.json \
   >   --output-edge-list distances_edge_list.tsv
   ERROR: Edge list output only works for a single pairwise comparison.
-  [1]
+  [2]
 
 Try to calculate distances with both root and pairwise comparisons and using edge list output.
 This should fail because we only support edge list output for a single pairwise comparison.
@@ -71,4 +71,4 @@ This should fail because we only support edge list output for a single pairwise 
   >   --output distances.json \
   >   --output-edge-list distances_edge_list.tsv
   ERROR: Edge list output only works for a single pairwise comparison.
-  [1]
+  [2]

--- a/tests/functional/distance/aligned.fasta
+++ b/tests/functional/distance/aligned.fasta
@@ -1,0 +1,8 @@
+>with_gaps
+---ATATA---
+>no_gaps
+GGGATATAGGG
+>some_other_seq
+--GATCTAGGG
+>_R_crick_strand some description
+-GGATATAGG-

--- a/tests/functional/distance/distance_map_hamming.json
+++ b/tests/functional/distance/distance_map_hamming.json
@@ -1,0 +1,7 @@
+{
+    "name": "nucleotide Hamming distance",
+    "default": 1,
+    "ignored_characters": ["-", "N"],
+    "output_type": "integer",
+    "map": {}
+}


### PR DESCRIPTION
## Description of proposed changes

Implements [a requested feature to support "edge list" format for pairwise distances between sequences](https://github.com/nextstrain/augur/issues/1931) by adding a new output argument, `--output-edge-list`, to `augur distance`. This argument allows users to save pairwise distances to a TSV file in ["molten" format](https://github.com/tseemann/snp-dists/#snp-dists--m-molten-output-format) which looks like this:

```
sequence_1	sequence_2	distance
Thailand/1610acTw	Thailand/1610acTw	0
Thailand/1610acTw	SG_018	43
Thailand/1610acTw	SG_056	40
Thailand/1610acTw	SG_027	42
Thailand/1610acTw	SG_074	39
Thailand/1610acTw	1_0087_PF	82
Thailand/1610acTw	ZKC2/2016	103
Thailand/1610acTw	SMGC_1	103
Thailand/1610acTw	1_0181_PF	81
```

The example output above comes from running the following command on the Zika tutorial outputs from [this development branch](https://github.com/nextstrain/zika-tutorial/pull/20):

```
augur distance \
    --tree results/tree.nwk \
    --alignment results/aligned.fasta \
    --gene-names nuc \
    --attribute-name snvs \
    --compare-to pairwise \
    --map config/distance_map_nucleotides.json \
    --output snvs.json \
    --output-edge-list snvs.tsv
```

When I load this edge list into MicrobeTrace, I get the following network by default.

<img width="389" height="445" alt="image" src="https://github.com/user-attachments/assets/39930fc7-66b7-44bc-9d6b-673d11ccf47b" />

My plan was to limit this functionality to a single alignment input and single `--compare-to` value of `pairwise`. In all other use cases, I would expect the command to error loudly. Alternately, we could be more flexible and allow this argument to work with multiple `--compare-to` values including multiple "pairwise" maps. To support multiple pairwise maps, we would need to allow multiple output TSV files.

## Related issue(s)

https://github.com/nextstrain/augur/issues/1931

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
