### PR TITLE
Expose augur.config.resolve_filepath()

### DIFF
--- a/augur/config.py
+++ b/augur/config.py
@@ -1,0 +1,78 @@
+"""
+Helpers for YAML-based configuration files.
+"""
+from pathlib import Path
+from textwrap import dedent
+from augur.errors import AugurError
+from augur.io.print import indented_list
+
+def resolve_filepath(
+    path: Path,
+    search_paths: list[Path],
+) -> Path:
+    """
+    Resolve a filepath by searching through multiple directories.
+
+    Parameters
+    ----------
+    path
+        The filepath to resolve. May be either an absolute path or a path
+        relative to one of the directories in ``search_paths``.
+    search_paths
+        Directories to search, in order, when ``path`` is relative. Ignored when
+        ``path`` is absolute.
+
+    Examples
+    --------
+
+    If the path is already absolute, verify it exists and return it.
+
+    >>> import tempfile
+    >>> tmpdir1 = Path(tempfile.mkdtemp()).resolve()
+    >>> tmpdir2 = Path(tempfile.mkdtemp()).resolve()
+    >>> absolute_path = tmpdir1 / "file.txt"
+    >>> with open(absolute_path, "w") as f: _ = f.write("test")
+    >>> resolve_filepath(absolute_path, []) == absolute_path
+    True
+
+    Otherwise, try resolving it relative to each directory in search_paths, in order.
+    Return the first path that exists.
+
+    >>> with open(tmpdir2 / "file.txt", "w") as f: _ = f.write("test")
+    >>> result = resolve_filepath(Path("file.txt"), [tmpdir1, tmpdir2])
+    >>> result == tmpdir1 / "file.txt"
+    True
+
+    If an absolute path doesn't exist, raise an error.
+
+    >>> resolve_filepath(Path("/nonexistent/file.txt"), [tmpdir1, tmpdir2])
+    Traceback (most recent call last):
+      ...
+    augur.errors.AugurError: File '/nonexistent/file.txt' does not exist.
+
+    If the relative path doesn't exist anywhere, raise an error.
+
+    >>> resolve_filepath(Path("nonexistent.txt"), [tmpdir1, tmpdir2]) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+      ...
+    augur.errors.AugurError: File 'nonexistent.txt' not resolvable from any of the following paths:
+    <BLANKLINE>
+      ...
+    """
+    # Absolute path
+    if path.is_absolute():
+        if not path.exists():
+            raise AugurError(f"File {str(path)!r} does not exist.")
+        return path
+
+    # Relative path
+    for search_path in search_paths:
+        resolved_path = (search_path / path).resolve()
+        if resolved_path.exists():
+            return resolved_path
+
+    # File not found
+    raise AugurError(dedent(f"""\
+        File {str(path)!r} not resolvable from any of the following paths:
+
+          {indented_list([str(p) for p in search_paths], '        ' + '  ')}"""))

--- a/augur/subsample.py
+++ b/augur/subsample.py
@@ -20,9 +20,10 @@ from textwrap import dedent
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from augur import filter as augur_filter
 from augur.argparse_ import ExtendOverwriteDefault, SKIP_AUTO_DEFAULT_IN_HELP
+from augur.config import resolve_filepath
 from augur.errors import AugurError
 from augur.io.metadata import DEFAULT_DELIMITERS, DEFAULT_ID_COLUMNS
-from augur.io.print import print_err, indented_list
+from augur.io.print import print_err
 from augur.utils import augur
 from augur.validate import load_json_schema, validate_json, ValidateError
 from augur.io.print import print_debug
@@ -518,10 +519,10 @@ def _resolve_filepaths(
         # Resolve filepath
         if _is_filepath(prop_schema):
             if isinstance(value, list):
-                config[key] = [str(_resolve_filepath(Path(v), search_paths)) for v in value]
+                config[key] = [str(resolve_filepath(Path(v), search_paths)) for v in value]
                 filepaths.extend(config[key])
             elif isinstance(value, str):
-                config[key] = str(_resolve_filepath(Path(value), search_paths))
+                config[key] = str(resolve_filepath(Path(value), search_paths))
                 filepaths.append(config[key])
 
         # Recurse into config section
@@ -600,66 +601,6 @@ def _match_one_of(
     if not best_schema:
         raise AugurError("Couldn't match oneOf schema for config dict")
     return best_schema
-
-def _resolve_filepath(
-    path: Path,
-    search_paths: List[Path],
-) -> Path:
-    """
-    Resolve a filepath by searching through multiple directories.
-
-    If the path is already absolute, verify it exists and return it.
-
-    >>> import tempfile
-    >>> from pathlib import Path
-    >>> tmpdir1 = Path(tempfile.mkdtemp()).resolve()
-    >>> tmpdir2 = Path(tempfile.mkdtemp()).resolve()
-    >>> absolute_path = tmpdir1 / "file.txt"
-    >>> with open(absolute_path, "w") as f: _ = f.write("test")
-    >>> _resolve_filepath(absolute_path, []) == absolute_path
-    True
-
-    Otherwise, try resolving it relative to each directory in search_paths, in order.
-    Return the first path that exists.
-
-    >>> with open(tmpdir2 / "file.txt", "w") as f: _ = f.write("test")
-    >>> result = _resolve_filepath(Path("file.txt"), [tmpdir1, tmpdir2])
-    >>> result == tmpdir1 / "file.txt"
-    True
-
-    If an absolute path doesn't exist, raise an error.
-
-    >>> _resolve_filepath(Path("/nonexistent/file.txt"), [tmpdir1, tmpdir2])
-    Traceback (most recent call last):
-      ...
-    augur.errors.AugurError: File '/nonexistent/file.txt' does not exist.
-
-    If the relative path doesn't exist anywhere, raise an error.
-
-    >>> _resolve_filepath(Path("nonexistent.txt"), [tmpdir1, tmpdir2]) # doctest: +ELLIPSIS
-    Traceback (most recent call last):
-      ...
-    augur.errors.AugurError: File 'nonexistent.txt' not resolvable from any of the following paths:
-    <BLANKLINE>
-      ...
-    """
-    # Absolute path
-    if path.is_absolute():
-        if not path.exists():
-            raise AugurError(f"File {str(path)!r} does not exist.")
-        return path
-
-    # Relative path
-    for search_path in search_paths:
-        resolved_path = (search_path / path).resolve()
-        if resolved_path.exists():
-            return resolved_path
-
-    # File not found
-    raise AugurError(dedent(f"""\
-        File {str(path)!r} not resolvable from any of the following paths:
-
-          {indented_list([str(p) for p in search_paths], '        ' + '  ')}"""))
 
 
 def _merge_options(sample_options: Dict[str, Any], defaults: Optional[Dict[str, Any]]) -> Dict[str, Any]:

--- a/docs/api/developer/augur.config.rst
+++ b/docs/api/developer/augur.config.rst
@@ -1,0 +1,7 @@
+augur.config module
+===================
+
+.. automodule:: augur.config
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/developer/augur.rst
+++ b/docs/api/developer/augur.rst
@@ -31,6 +31,7 @@ Submodules
    augur.ancestral
    augur.argparse_
    augur.clades
+   augur.config
    augur.debug
    augur.distance
    augur.errors


### PR DESCRIPTION
## Description of proposed changes

The function is already used by the [ebola repo](https://github.com/nextstrain/ebola/blob/4e379804843ff5583764c27e30da37cc88d965bf/shared/vendored/snakemake/config.smk#L12). Moving to a proper namespace before using in other pathogen repos.

Preview of new docs page for `augur.config`: https://nextstrain--2026.org.readthedocs.build/projects/augur/en/2026/api/developer/augur.config.html

## Related issue(s)

Follow-up to https://github.com/nextstrain/ebola/pull/64#discussion_r3470470649

## Checklist

- [x] Automated checks pass
- [x] ~[Check][1] if you need to add a changelog message~ dev change
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
