### PR TITLE
Gracefully handle weighted sampling with no sequences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* filter: Fix unhandled `ValueError` with `--group-by-weights` when no sequences pass earlier filters. [#2032] @victorlin
+
+[#2032]: https://github.com/nextstrain/augur/issues/2032
 
 ## 34.1.0 (20 July 2026)
 

--- a/augur/filter/subsample.py
+++ b/augur/filter/subsample.py
@@ -321,6 +321,12 @@ def get_weighted_group_sizes(
     ) -> Dict[Group, int]:
     """Return target group sizes based on weights defined in ``weights_file``.
     """
+    if not records_per_group:
+        if output_sizes_file:
+            with open_file(output_sizes_file, "w", newline="") as f:
+                f.write("")
+        return {}
+
     groups = records_per_group.keys()
 
     weights = read_weights_file(weights_file)

--- a/tests/filter/test_subsample.py
+++ b/tests/filter/test_subsample.py
@@ -156,3 +156,19 @@ class TestFilterGroupBy:
             'SEQ_4': ('B', '2020', '2020-01'),
             'SEQ_5': ('B', '2020', '2020-01')
         }
+
+
+class TestWeightedGroupSizes:
+    def test_get_weighted_group_sizes_empty_records(self, tmp_path):
+        weights_file = tmp_path / "weights.tsv"
+        weights_file.write_text("country\tweight\nA\t1\n")
+
+        result = augur.filter.subsample.get_weighted_group_sizes(
+            records_per_group={},
+            group_by=['country', 'year'],
+            weights_file=str(weights_file),
+            target_total_size=10,
+            output_sizes_file=None,
+            random_seed=None,
+        )
+        assert result == {}


### PR DESCRIPTION
## Description of proposed changes

When running with `--group-by-weights` and no sequence records pass earlier filters, `get_weighted_group_sizes` was called with an empty `records_per_group` dict. This caused pandas `df.apply` on an empty DataFrame to return a DataFrame instead of a Series, triggering an unhandled error when setting `_augur_filter_input_size`.

Exit early in `get_weighted_group_sizes` when `records_per_group` is empty so that the command completes and handles empty filter results through `--empty-output-reporting`.

## Related issue(s)

Closes #2032 

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update
