### PR TITLE
Update changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Development
+
+* Refactored JSON schema validation functions for external use. [#2034] @victorlin
+
+[#2034]: https://github.com/nextstrain/augur/pull/2034
 
 ## 34.1.1 (23 July 2026)
 


### PR DESCRIPTION
Follow-up to #2034. I want to release this today to unblock https://github.com/nextstrain/measles/pull/141. It's the only change since the last release, and it'd be good to have a changelog entry for 34.1.2 instead of nothing.