### PR TITLE
Add schema def for unaligned sequences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Development
+
+* Added a subsample config schema definition for workflows that use unaligned sequences. [#2037] @victorlin
+
+[#2037]: https://github.com/nextstrain/augur/pull/2037
 
 ## 34.1.2 (5 August 2026)
 

--- a/augur/data/schema-subsample-config.json
+++ b/augur/data/schema-subsample-config.json
@@ -343,6 +343,25 @@
             "required": [
                 "focal_sample"
             ]
+        },
+        "schemaForUnalignedSequences": {
+            "title": "Configuration schema for unaligned sequences",
+            "allOf": [
+                {
+                    "$ref": "#"
+                },
+                {
+                    "properties": {
+                        "samples": {
+                            "patternProperties": {
+                                "^.+$": {
+                                    "$ref": "#/$defs/filterSampleProperties"
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
         }
     },
     "properties": {

--- a/devel/regenerate-subsample-schema
+++ b/devel/regenerate-subsample-schema
@@ -249,6 +249,21 @@ def create_schema():
             "additionalProperties": False,
             "properties": proximal_sample_options,
             **_required_properties(proximal_sample_options),
+        },
+        "schemaForUnalignedSequences": {
+            "title": "Configuration schema for unaligned sequences",
+            "allOf": [
+                {"$ref": "#"},
+                {
+                    "properties": {
+                        "samples": {
+                            "patternProperties": {
+                                "^.+$": {"$ref": "#/$defs/filterSampleProperties"}
+                            }
+                        }
+                    }
+                }
+            ]
         }
     }
 


### PR DESCRIPTION
## Description of proposed changes

Some workflows use unaligned sequences as input to augur subsample. In this case, proximal samples will not work properly. This schema def makes it easier for workflows to guard against configs with proximal samples.

## Related issue(s)

https://github.com/nextstrain/rsv/pull/103#discussion_r3739165616

## Checklist

- [x] Manually tested in https://github.com/nextstrain/rsv/pull/103
- [ ] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [ ] [Check][2] if you need to add tests
- [ ] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
