### PR TITLE
subsample: Don't validate schema in helper functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,11 @@
 
 ### Development
 
+* subsample: Refactored helper functions to only validate config during run time. [#2039] @victorlin
 * Added a subsample config schema for workflows that use unaligned sequences. [#2038] @victorlin
 
 [#2038]: https://github.com/nextstrain/augur/pull/2038
+[#2039]: https://github.com/nextstrain/augur/pull/2039
 
 ## 34.1.2 (5 August 2026)
 

--- a/augur/subsample.py
+++ b/augur/subsample.py
@@ -191,10 +191,14 @@ def run(args: argparse.Namespace) -> None:
       worth it if a proper input reuse approach such as database/parquet file
       support is adopted: <https://github.com/nextstrain/augur/issues/1574>
     """
-
-    # Load schema, parse and validate config.
     schema_validator = load_json_schema("schema-subsample-config.json")
-    config = _parse_config(args.config, args.config_section, schema_validator)
+    config = _parse_config(args.config, args.config_section)
+
+    try:
+        validate_json(config, schema_validator, args.config)
+    except ValidateError as e:
+        raise AugurError(e)
+
     sample_types = _get_sample_types(config)
 
     if _includes_proximal_sample(config) and not args.sequences:
@@ -324,9 +328,8 @@ def get_referenced_files(
     set
         Resolved filepaths
     """
-    # Load schema, parse and validate config.
     schema_validator = load_json_schema("schema-subsample-config.json")
-    config = _parse_config(config_file, config_section, schema_validator)
+    config = _parse_config(config_file, config_section)
 
     # Resolve filepaths.
     search_path_objs = _get_search_paths(config_file, search_paths)
@@ -357,11 +360,10 @@ def requires_aligned_sequences(
     bool
         Does augur subsample require aligned sequences?
     """
-    schema_validator = load_json_schema("schema-subsample-config.json")
-    config = _parse_config(config_file, config_section, schema_validator)
+    config = _parse_config(config_file, config_section)
     return _includes_proximal_sample(config)
 
-def _parse_config(filename: str, config_section: Optional[List[str]], schema) -> Dict[str, Any]:
+def _parse_config(filename: str, config_section: Optional[List[str]] = None) -> Dict[str, Any]:
     # Create a custom YAML loader to treat timestamps as strings.
     class CustomLoader(yaml.SafeLoader):
         pass
@@ -386,12 +388,6 @@ def _parse_config(filename: str, config_section: Optional[List[str]], schema) ->
             traversed_section = traversed_section[key]
 
         config = traversed_section
-
-    # Validate against schema.
-    try:
-        validate_json(config, schema, filename)
-    except ValidateError as e:
-        raise AugurError(e)
 
     return config
 


### PR DESCRIPTION
## Description of proposed changes

This change is primarily intended for pathogen workflows that use the helper functions prior to running augur subsample, commonly during Snakemake's initialization step. Schema is still validated at run time.

We are shifting to a pattern where pathogen workflows define and validate their own schema at workflow start, so the validation in these helper functions is unnecessary duplicate work.

## Related issue(s)

Example with measles:

```
Saved 'config' to 'results/run_config.yaml'.
Validating schema of 'results/run_config.yaml'...                             ← validation already happens here
Saved 'config.subsample.genome/global' to 'results/genome/global/subsample_config.yaml'.
Saved 'config.subsample.N450/global' to 'results/N450/global/subsample_config.yaml'.
Saved 'config.subsample.genome/north-america' to 'results/genome/north-america/subsample_config.yaml'.
host: b1f8e2df1311
Building DAG of jobs...
Validating schema of 'results/genome/global/subsample_config.yaml'...         ← duplicate validation
Validating schema of 'results/N450/global/subsample_config.yaml'...           ← duplicate validation
Validating schema of 'results/genome/north-america/subsample_config.yaml'...  ← duplicate validation
```

## Checklist

- [x] ~Automated checks pass~ failures unrelated
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
