### PR TITLE
Avoid sphinx-argparse ≥0.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ setuptools.setup(
             "recommonmark >=0.5.0",
             "Sphinx >=2.0.1",
             "sphinx-autobuild >=2021.3.14",
-            "sphinx-argparse >=0.2.5, !=0.5.0, !=0.6.0",
+            # TODO: Remove upper pin if bug is fixed: https://github.com/sphinx-doc/sphinx-argparse/issues/97
+            "sphinx-argparse >=0.2.5, !=0.5.0, <0.6.0",
             "sphinx-markdown-tables >= 0.0.9",
             "sphinx-rtd-theme >=0.4.3",
             "sphinx-autodoc-typehints >=1.21.4",


### PR DESCRIPTION
## Description of proposed changes

The warnings from "Avoid sphinx-argparse 0.6.0" (a462d21a) are still present in version 0.6.1. Setting an upper pin until the linked bug is fixed.

## Related issue(s)

https://github.com/nextstrain/augur/issues/2023#issuecomment-5403541600

## Checklist

- [x] ~Automated checks pass~ to be checked by next scheduled docs CI run
- [x] ~[Check][1] if you need to add a changelog message~
- [x] ~[Check][2] if you need to add tests~
- [x] ~[Check][3] if you need to update docs~

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
