### PR TITLE
Use ruamel.yaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## __NEXT__
 
+### Development
+
+* Switched to `ruamel.yaml` for processing YAML files. [#2046][] @victorlin
+
+[#2046]: https://github.com/nextstrain/augur/pull/2046
 
 ## 34.1.3 (13 August 2026)
 

--- a/augur/subsample.py
+++ b/augur/subsample.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 import sys
 import tempfile
-import yaml
+from ruamel.yaml import YAML, YAMLError, constructor
 from collections import defaultdict, deque
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, Future, wait
 from pathlib import Path
@@ -364,17 +364,20 @@ def requires_aligned_sequences(
     return _includes_proximal_sample(config)
 
 def _parse_config(filename: str, config_section: Optional[List[str]] = None) -> Dict[str, Any]:
-    # Create a custom YAML loader to treat timestamps as strings.
-    class CustomLoader(yaml.SafeLoader):
+    # Create a custom YAML constructor to treat timestamps as strings.
+    class CustomConstructor(constructor.SafeConstructor):
         pass
     def string_constructor(loader, node):
         return loader.construct_scalar(node)
-    CustomLoader.add_constructor('tag:yaml.org,2002:timestamp', string_constructor)
+    CustomConstructor.add_constructor('tag:yaml.org,2002:timestamp', string_constructor)
+
+    yaml = YAML(typ="safe")
+    yaml.Constructor = CustomConstructor
 
     with open(filename) as f:
         try:
-            config = yaml.load(f, Loader=CustomLoader)
-        except yaml.YAMLError as e:
+            config = yaml.load(f)
+        except YAMLError as e:
             raise AugurError(f"The configuration file {filename!r} is not valid YAML.\n" + str(e)) from e
 
     # Handle --config-section.

--- a/augur/validate.py
+++ b/augur/validate.py
@@ -8,7 +8,7 @@ import json
 import jsonschema
 import jsonschema.exceptions
 import re
-import yaml
+from ruamel.yaml import YAML, YAMLError
 from itertools import groupby
 from pathlib import Path
 from referencing import Registry
@@ -66,10 +66,10 @@ def load_json_schema(path, refs=None):
     try:
         with as_file(path) as file, open_file(file, "r") as fh:
             if is_yaml:
-                schema = yaml.safe_load(fh)
+                schema = YAML(typ="safe").load(fh)
             else:
                 schema = json.load(fh)
-    except (json.JSONDecodeError, yaml.YAMLError) as err:
+    except (json.JSONDecodeError, YAMLError) as err:
         raise ValidateError(f"Schema {path} is not a valid {'YAML' if is_yaml else 'JSON'} file. Error: {err}")
     # check loaded schema is itself valid -- see http://python-jsonschema.readthedocs.io/en/latest/errors/
     Validator = jsonschema.validators.validator_for(schema)

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
         "phylo-treetime >=0.11.2, <0.13",
         "pyfastx >=1.0.0, <3.0",
         "python_calamine >=0.2.0",
-        "pyyaml",
+        "ruamel.yaml ==0.*",
         "referencing >=0.29.1, <1.0",
         "scipy ==1.*",
         "xopen >=2.1.0, <3"
@@ -97,7 +97,6 @@ setuptools.setup(
             "sphinx-autodoc-typehints >=1.21.4",
             "sphinx-tabs >=3.5.0",
             "types-jsonschema >=4.18.0, ==4.*",
-            "types-PyYAML",
             "types-setuptools",
             "wheel >=0.32.3",
             "ipdb >=0.10.1"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 import random
-import yaml
+from ruamel.yaml import YAML
 
 from augur.validate import (
     validate_collection_config_fields,
@@ -209,7 +209,7 @@ def test_load_yaml_schema(tmp_path, ext):
         }
     }
     with open(schema_file, "w") as f:
-        yaml.dump(raw_schema, f)
+        YAML(typ="safe").dump(raw_schema, f)
 
     validator = load_json_schema(schema_file)
     valid_data = {"name": "test"}


### PR DESCRIPTION
## Description of proposed changes

The main motivation is to have errors on duplicate keys, which PyYAML silently allows due to a [longstanding bug](https://github.com/yaml/pyyaml/issues/165).

The other notable [difference](https://yaml.dev/doc/ruamel.yaml/pyyaml/) is a switch from YAML 1.1 to YAML 1.2 (latest).

## Related issue(s)

Follow-up to https://github.com/nextstrain/augur/pull/2040#discussion_r3898922670

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
