### PR TITLE
frequencies: replace `np.in1d` with `np.isin`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,16 @@
 
 ## __NEXT__
 
+### Bug fixes
+
+* frequencies: Fix `AttributeError` when using numpy >= 2.4.0 with `--method diffusion`. [#2048] @joverlee521
+
 ### Development
 
 * Switched to `ruamel.yaml` for processing YAML files. [#2046][] @victorlin
 
 [#2046]: https://github.com/nextstrain/augur/pull/2046
+[#2048]: https://github.com/nextstrain/augur/pull/2048
 
 ## 34.1.3 (13 August 2026)
 
@@ -182,7 +187,7 @@
 
 * export v2: Improved the error message that is displayed when a deprecated coloring key is used. [#1882][] (@corneliusroemer)
 * export v2: `--no-minify-json` now properly overrides any truthy value in `AUGUR_MINIFY_JSON`. [#1943][] (@victorlin)
-* export v2: Skip unhashable node attr values with warning message to avoid previously unhandled `TypeError`. [#1948][] (@joverlee521) 
+* export v2: Skip unhashable node attr values with warning message to avoid previously unhandled `TypeError`. [#1948][] (@joverlee521)
 
 [#1304]: https://github.com/nextstrain/augur/issues/1304
 [#1768]: https://github.com/nextstrain/augur/issues/1768

--- a/augur/frequency_estimators.py
+++ b/augur/frequency_estimators.py
@@ -543,7 +543,7 @@ class tree_frequencies(object):
 
             for c in node.clades:
                 if len(c.leafs)>self.min_clades:
-                    obs_to_estimate[c.clade] = np.in1d(node.leafs, c.leafs)
+                    obs_to_estimate[c.clade] = np.isin(node.leafs, c.leafs)
                 else:
                     # Only include internal nodes or tips that pass the node
                     # filter as small clades.
@@ -553,7 +553,7 @@ class tree_frequencies(object):
                 if len(small_clades):
                     remainder = {}
                     for c in small_clades:
-                        remainder[c.clade] = np.in1d(node.leafs, c.leafs)
+                        remainder[c.clade] = np.isin(node.leafs, c.leafs)
                     if len(small_clades)==1:
                         obs_to_estimate.update(remainder)
                     else:

--- a/tests/functional/frequencies/cram/diffusion-minimal-clade-size-to-estimate.t
+++ b/tests/functional/frequencies/cram/diffusion-minimal-clade-size-to-estimate.t
@@ -1,0 +1,116 @@
+Setup
+
+  $ source "$TESTDIR"/_setup.sh
+
+Calculate diffusion-based tip frequencies from a refined tree with
+`--minimal-clade-size-to-estimate`
+
+  $ ${AUGUR} frequencies \
+  >  --method diffusion \
+  >  --tree "$TESTDIR/../data/tree.nwk" \
+  >  --metadata "$TESTDIR/../data/metadata.tsv" \
+  >  --pivot-interval 3 \
+  >  --minimal-clade-size-to-estimate 5 \
+  >  --output tip-frequencies.json > /dev/null
+
+  $ cat tip-frequencies.json
+  {
+    "BRA/2016/FC_6706": {
+      "global": [
+        0.094317,
+        0.09532,
+        0.104707,
+        0.107313
+      ]
+    },
+    "COL/FLR_00008/2015": {
+      "global": [
+        0.108525,
+        0.107021,
+        0.092939,
+        0.089031
+      ]
+    },
+    "Colombia/2016/ZC204Se": {
+      "global": [
+        0.108525,
+        0.107021,
+        0.092939,
+        0.089031
+      ]
+    },
+    "DOM/2016/BB_0183": {
+      "global": [
+        0.094317,
+        0.09532,
+        0.104707,
+        0.107313
+      ]
+    },
+    "EcEs062_16": {
+      "global": [
+        0.094317,
+        0.09532,
+        0.104707,
+        0.107313
+      ]
+    },
+    "HND/2016/HU_ME59": {
+      "global": [
+        0.094317,
+        0.09532,
+        0.104707,
+        0.107313
+      ]
+    },
+    "PAN/CDC_259359_V1_V3/2015": {
+      "global": [
+        0.108525,
+        0.107021,
+        0.092939,
+        0.089031
+      ]
+    },
+    "PRVABC59": {
+      "global": [
+        0.094317,
+        0.09532,
+        0.104707,
+        0.107313
+      ]
+    },
+    "VEN/UF_1/2016": {
+      "global": [
+        0.108525,
+        0.107021,
+        0.092939,
+        0.089031
+      ]
+    },
+    "ZKC2/2016": {
+      "global": [
+        0.094317,
+        0.09532,
+        0.104707,
+        0.107313
+      ]
+    },
+    "counts": {
+      "global": [
+        0,
+        5,
+        5,
+        0
+      ]
+    },
+    "generated_by": {
+      "program": "augur",
+      "version": ".*" (re)
+    },
+    "pivots": [
+      2015.7521,
+      2016.0041,
+      2016.2527,
+      2016.5014
+    ]
+  } (no-eol)


### PR DESCRIPTION
## Description of proposed changes

Adds functional test for `augur frequencies` that would hit the error with numpy >= 2.4.0 and then fixes by replacing `np.in1d` with `np.isin`. 

## Related issue(s)

Resolves https://github.com/nextstrain/augur/issues/2047

## Checklist

- [x] Automated checks pass
- [x] [Check][1] if you need to add a changelog message
- [x] [Check][2] if you need to add tests
- [x] [Check][3] if you need to update docs

[1]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#updating-the-changelog
[2]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#testing
[3]: https://github.com/nextstrain/augur/blob/-/docs/contribute/DEV_DOCS.md#when-to-update

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
